### PR TITLE
Fix typo in DataType and improve type consistency

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
 - Use AirSpec testing framework and `shouldBe`, `shouldMatch` assertion syntax. Test names should be concise and descriptive, written in plain English.
-- Avoid using mock as much as possible as it increases the maintainance cost and complexity of the test.
+- Avoid using mock as much as possible as it increases the maintenance cost and complexity of the test.
 - case classes for configuration should have withXXX(...) methods for all fields and noXXX(...) methods for all optional fields.
 - For commit messages, add prefix from one of feature, fix, internal, doc to classify change types. Focus on `why` and `what` of the change, not `how`. 

--- a/ai-core/src/main/scala/wvlet/ai/agent/chat/ToolSpec.scala
+++ b/ai-core/src/main/scala/wvlet/ai/agent/chat/ToolSpec.scala
@@ -1,17 +1,18 @@
 package wvlet.ai.agent.chat
 
+import wvlet.ai.core.DataType
+
 case class ToolSpec(
     name: String,
     description: String,
     parameters: List[ToolParameter],
-    returnType: ToolReturnType
+    returnType: DataType
 )
 
-case class ToolReturnType(dataType: String, description: String)
 case class ToolParameter(
     name: String,
     description: String,
-    dataType: String,
+    dataType: DataType,
     required: Boolean,
     defaultValue: Option[Any] = None
 )

--- a/ai-core/src/main/scala/wvlet/ai/core/DataType.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/DataType.scala
@@ -7,7 +7,7 @@ object DataType:
   case object StringType                                                  extends DataType
   case object JsonType                                                    extends DataType
   case object IntegerType                                                 extends DataType
-  case object FloadType                                                   extends DataType
+  case object FloatType                                                   extends DataType
   case object ByteArrayType                                               extends DataType
   case object AnyType                                                     extends DataType
   case object ObjectType                                                  extends DataType
@@ -17,4 +17,3 @@ object DataType:
   case class GenericType(typeParams: List[DataType], fields: List[Field]) extends DataType
 
   case class Field(name: String, dataType: DataType, description: String = "", isRequired: Boolean)
-      extends DataType

--- a/ai-core/src/test/scala/wvlet/ai/core/DataTypeSpec.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/DataTypeSpec.scala
@@ -1,0 +1,75 @@
+package wvlet.ai.core
+
+import wvlet.airspec.AirSpec
+
+class DataTypeSpec extends AirSpec:
+
+  test("primitive types should be distinct") {
+    DataType.BooleanType shouldBe DataType.BooleanType
+    DataType.StringType shouldBe DataType.StringType
+    DataType.JsonType shouldBe DataType.JsonType
+    DataType.IntegerType shouldBe DataType.IntegerType
+    DataType.FloatType shouldBe DataType.FloatType
+    DataType.ByteArrayType shouldBe DataType.ByteArrayType
+    DataType.AnyType shouldBe DataType.AnyType
+    DataType.ObjectType shouldBe DataType.ObjectType
+
+    DataType.StringType shouldNotBe DataType.IntegerType
+  }
+
+  test("ArrayType should hold element type") {
+    val arrType = DataType.ArrayType(DataType.StringType)
+    arrType.elementType shouldBe DataType.StringType
+    arrType shouldBe DataType.ArrayType(DataType.StringType)
+    arrType shouldNotBe DataType.ArrayType(DataType.IntegerType)
+  }
+
+  test("RecordType should hold fields") {
+    val field1     = DataType.Field("id", DataType.IntegerType, isRequired = true)
+    val field2     = DataType.Field("name", DataType.StringType, isRequired = false)
+    val recordType = DataType.RecordType(List(field1, field2))
+
+    recordType.fields shouldBe List(field1, field2)
+    recordType shouldBe DataType.RecordType(List(field1, field2))
+    recordType shouldNotBe DataType.RecordType(List(field1))
+  }
+
+  test("OptionalType should hold data type") {
+    val optType = DataType.OptionalType(DataType.FloatType)
+    optType.dataType shouldBe DataType.FloatType
+    optType shouldBe DataType.OptionalType(DataType.FloatType)
+    optType shouldNotBe DataType.OptionalType(DataType.StringType)
+  }
+
+  test("GenericType should hold type parameters and fields") {
+    val typeParam   = DataType.StringType
+    val field1      = DataType.Field("key", typeParam, isRequired = true)
+    val field2      = DataType.Field("value", DataType.AnyType, isRequired = true)
+    val genericType = DataType.GenericType(List(typeParam), List(field1, field2))
+
+    genericType.typeParams shouldBe List(typeParam)
+    genericType.fields shouldBe List(field1, field2)
+    genericType shouldBe DataType.GenericType(List(typeParam), List(field1, field2))
+    genericType shouldNotBe DataType.GenericType(List(DataType.IntegerType), List(field1, field2))
+  }
+
+  test("Field should hold its properties") {
+    val field = DataType.Field(
+      name = "age",
+      dataType = DataType.IntegerType,
+      description = "User age",
+      isRequired = true
+    )
+    field.name shouldBe "age"
+    field.dataType shouldBe DataType.IntegerType
+    field.description shouldBe "User age"
+    field.isRequired shouldBe true
+
+    val field2 = DataType.Field("age", DataType.IntegerType, "User age", true)
+    field shouldBe field2
+
+    val field3 = DataType.Field("name", DataType.StringType, "", false)
+    field shouldNotBe field3
+  }
+
+end DataTypeSpec


### PR DESCRIPTION
### Description

This pull request addresses the following changes:
- Corrected a typo in `DataType.FloadType` by renaming it to `FloatType`.
- Updated `ToolSpec` and `ToolParameter` to use `DataType` instead of string-based types for improved consistency.
- Added comprehensive test cases in `DataTypeSpec` to validate various `DataType` constructs.

### Checklists

#### Testing
- [x] Includes unit tests
