### PR TITLE
feature: Introduce BedrockConfig for chat settings

### DIFF
--- a/ai-bedrock/src/main/scala/wvlet/ai/agent/chat/bedrock/BedrockChat.scala
+++ b/ai-bedrock/src/main/scala/wvlet/ai/agent/chat/bedrock/BedrockChat.scala
@@ -31,13 +31,6 @@ import java.util.concurrent.atomic.AtomicReference
 import scala.collection.immutable.ListMap
 import scala.jdk.CollectionConverters.*
 
-case class BedrockConfig(
-    region: Region = Region.US_EAST_1,
-    credentialProvider: AwsCredentialsProvider = DefaultCredentialsProvider.create(),
-    asyncClientConfig: BedrockRuntimeAsyncClientBuilder => BedrockRuntimeAsyncClientBuilder =
-      identity
-)
-
 class BedrockChat(agent: LLMAgent, bedrockClient: BedrockClient) extends ChatModel with LogSupport:
   import BedrockChat.*
   import wvlet.ai.core.ops.*
@@ -59,6 +52,7 @@ class BedrockChat(agent: LLMAgent, bedrockClient: BedrockClient) extends ChatMod
           .onContentBlockStop(converseResponseBuilder.onEvent)
           .onMetadata(converseResponseBuilder.onEvent)
           .onMessageStart(converseResponseBuilder.onEvent)
+          .onMessageStop(converseResponseBuilder.onEvent)
           .build()
       )
       .build()

--- a/ai-bedrock/src/main/scala/wvlet/ai/agent/chat/bedrock/BedrockConfig.scala
+++ b/ai-bedrock/src/main/scala/wvlet/ai/agent/chat/bedrock/BedrockConfig.scala
@@ -1,0 +1,21 @@
+package wvlet.ai.agent.chat.bedrock
+
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProvider, DefaultCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClientBuilder
+
+case class BedrockConfig(
+    region: Region = Region.US_EAST_1,
+    credentialProvider: AwsCredentialsProvider = DefaultCredentialsProvider.create(),
+    asyncClientConfig: BedrockRuntimeAsyncClientBuilder => BedrockRuntimeAsyncClientBuilder =
+      identity
+):
+  def withRegion(region: Region): BedrockConfig = this.copy(region = region)
+
+  def withCredentials(credentialProvider: AwsCredentialsProvider): BedrockConfig = this.copy(
+    credentialProvider = credentialProvider
+  )
+
+  def withAsyncClientConfig(
+      config: BedrockRuntimeAsyncClientBuilder => BedrockRuntimeAsyncClientBuilder
+  ): BedrockConfig = this.copy(asyncClientConfig = config)

--- a/ai-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockConfigTest.scala
+++ b/ai-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockConfigTest.scala
@@ -1,0 +1,71 @@
+package wvlet.ai.agent.chat.bedrock
+
+import software.amazon.awssdk.auth.credentials.{
+  AwsBasicCredentials,
+  DefaultCredentialsProvider,
+  StaticCredentialsProvider
+}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.bedrockruntime.{
+  BedrockRuntimeAsyncClient,
+  BedrockRuntimeAsyncClientBuilder
+}
+import wvlet.airspec.AirSpec
+
+class BedrockConfigTest extends AirSpec:
+
+  test("default values") {
+    val config = BedrockConfig()
+    config.region shouldBe Region.US_EAST_1
+    config.credentialProvider shouldBe DefaultCredentialsProvider.create()
+
+    // Verify the default asyncClientConfig is identity
+    val mockBuilder = BedrockRuntimeAsyncClient.builder()
+    config.asyncClientConfig(mockBuilder) shouldBeTheSameInstanceAs mockBuilder
+  }
+
+  test("withRegion") {
+    val config    = BedrockConfig()
+    val newConfig = config.withRegion(Region.US_WEST_2)
+    newConfig.region shouldBe Region.US_WEST_2
+    // Ensure other properties are unchanged
+    newConfig.credentialProvider shouldBe config.credentialProvider
+    newConfig.asyncClientConfig shouldBe config.asyncClientConfig
+  }
+
+  test("withCredentials") {
+    val config = BedrockConfig()
+    val creds = StaticCredentialsProvider.create(
+      AwsBasicCredentials.create("test-key", "test-secret")
+    )
+    val newConfig = config.withCredentials(creds)
+    newConfig.credentialProvider shouldBe creds
+    // Ensure other properties are unchanged
+    newConfig.region shouldBe config.region
+    newConfig.asyncClientConfig shouldBe config.asyncClientConfig
+  }
+
+  test("withAsyncClientConfig") {
+    val config = BedrockConfig()
+    val customizer =
+      (builder: BedrockRuntimeAsyncClientBuilder) =>
+        // Apply some custom configuration, e.g., endpoint override (just for testing the function call)
+        builder.endpointOverride(java.net.URI.create("http://localhost:8080"))
+    val newConfig = config.withAsyncClientConfig(customizer)
+
+    // Verify the new function is stored
+    newConfig.asyncClientConfig shouldBeTheSameInstanceAs customizer
+
+    // Apply the config function and check if it modifies the builder as expected
+    val mockBuilder       = BedrockRuntimeAsyncClient.builder()
+    val customizedBuilder = newConfig.asyncClientConfig(mockBuilder)
+    // We can't directly check the endpointOverride value easily without building,
+    // but we can verify the function was applied and returned the same builder instance.
+    customizedBuilder shouldBeTheSameInstanceAs mockBuilder
+
+    // Ensure other properties are unchanged
+    newConfig.region shouldBe config.region
+    newConfig.credentialProvider shouldBe config.credentialProvider
+  }
+
+end BedrockConfigTest


### PR DESCRIPTION
Adds a new `BedrockConfig` feature that enables configurable chat settings. This enhancement facilitates better control and customization for chat functionalities in the application.