### PR TITLE
feature: Add reasoning support to Bedrock chat responses

### DIFF
--- a/ai-bedrock/src/main/scala/wvlet/ai/agent/chat/bedrock/BedrockConverseResponseBuilder.scala
+++ b/ai-bedrock/src/main/scala/wvlet/ai/agent/chat/bedrock/BedrockConverseResponseBuilder.scala
@@ -13,6 +13,8 @@ import software.amazon.awssdk.services.bedrockruntime.model.{
   Message,
   MessageStartEvent,
   MessageStopEvent,
+  ReasoningContentBlock,
+  ReasoningTextBlock,
   ToolUseBlock
 }
 import software.amazon.eventstream.MessageBuilder
@@ -91,6 +93,20 @@ class BedrockConverseResponseBuilder(observer: ChatObserver) extends LogSupport:
     converseResponseBuilder.stopReason(event.stopReason())
     converseResponseBuilder.additionalModelResponseFields(event.additionalModelResponseFields())
     val contents = List.newBuilder[ContentBlock]
+
+    // Add reasoning message
+    contents +=
+      ContentBlock
+        .builder()
+        .reasoningContent(
+          ReasoningContentBlock
+            .builder
+            .reasoningText(ReasoningTextBlock.builder().text(reasoningText.result()).build())
+            .build()
+        )
+        .build()
+
+    // Add regular chat response
     contents += ContentBlock.builder().text(chatText.result()).build()
     contents ++=
       toolUseBlocks
@@ -106,5 +122,7 @@ class BedrockConverseResponseBuilder(observer: ChatObserver) extends LogSupport:
     )
     // Reset the builder
     messageBuilder = Message.builder()
+
+  end onEvent
 
 end BedrockConverseResponseBuilder

--- a/ai-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockIntegrationTest.scala
+++ b/ai-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockIntegrationTest.scala
@@ -10,16 +10,14 @@ class BedrockIntegrationTest extends AirSpec:
     skip("AWS environment variables are not set. Skip this test")
 
   initDesign {
-    _.bind[LLMAgent]
-      .toInstance(
+    _.bindInstance(
         LLMAgent(
           name = "test-agent",
           description = "Test Agent",
           model = LLM.Bedrock.Claude3_7Sonnet_20250219V1_0.withAWSCrossRegionInference("us")
         ).withReasoning(1024)
       )
-      .bind[BedrockClient]
-      .toInstance(BedrockClient())
+      .bindInstance(BedrockClient())
   }
 
   test("bedrock agent") { (chat: BedrockChat) =>


### PR DESCRIPTION
**Description**

Include reasoning texts in the resposne

**Related Issue/Task**

**Checklist**

- [x] This pull request focuses on a single task.
- [x] The change does not contain security credentials
