### PR TITLE
internal: Refactor DesignException handling to use unified DesignErrorCode enum

### DIFF
--- a/ai-core/src/main/scala/wvlet/ai/design/Binder.scala
+++ b/ai-core/src/main/scala/wvlet/ai/design/Binder.scala
@@ -13,7 +13,6 @@
  */
 package wvlet.ai.design
 
-import wvlet.ai.design.DesignException.CYCLIC_DEPENDENCY
 import wvlet.ai.design.LifeCycleHookType.*
 import wvlet.ai.log.LogSupport
 import wvlet.ai.util.SourceCode
@@ -27,7 +26,7 @@ object Binder:
 
   case class ClassBinding(from: Surface, to: Surface, sourceCode: SourceCode) extends Binding:
     if from == to then
-      throw new CYCLIC_DEPENDENCY(List(to), sourceCode)
+      throw DesignException.cyclicDependency(List(to), sourceCode)
 
   case class SingletonBinding(from: Surface, to: Surface, isEager: Boolean, sourceCode: SourceCode)
       extends Binding:
@@ -134,14 +133,14 @@ class Binder[A](val design: Design, val from: Surface, val sourceCode: SourceCod
     val to = Surface.of[B]
     if from == to then
       warn("Binding to the same type is not allowed: " + to.toString)
-      throw new DesignException.CYCLIC_DEPENDENCY(List(to), SourceCode())
+      throw DesignException.cyclicDependency(List(to), SourceCode())
     design.addBinding[B](SingletonBinding(from, to, false, sourceCode))
 
   inline def toEagerSingletonOf[B <: A]: DesignWithContext[B] =
     val to = Surface.of[B]
     if from == to then
       warn("Binding to the same type is not allowed: " + to.toString)
-      throw new DesignException.CYCLIC_DEPENDENCY(List(to), SourceCode())
+      throw DesignException.cyclicDependency(List(to), SourceCode())
     design.addBinding[B](SingletonBinding(from, to, true, sourceCode))
 
   inline def toProvider[D1](factory: D1 => A): DesignWithContext[A] = design.addBinding[A](

--- a/ai-core/src/main/scala/wvlet/ai/design/DesignException.scala
+++ b/ai-core/src/main/scala/wvlet/ai/design/DesignException.scala
@@ -30,7 +30,7 @@ enum DesignErrorCode:
 
 case class DesignException(code: DesignErrorCode, message: String, cause: Throwable = null)
     extends Exception(message, cause):
-  override def toString: String = s"[${code}] ${getMessage}"
+  override def getMessage: String = s"[${code}] ${message}"
 
 object DesignException:
   def cyclicDependency(deps: List[Surface], sourceCode: SourceCode): DesignException =

--- a/ai-core/src/main/scala/wvlet/ai/design/DesignException.scala
+++ b/ai-core/src/main/scala/wvlet/ai/design/DesignException.scala
@@ -16,39 +16,33 @@ package wvlet.ai.design
 import wvlet.ai.surface.Surface
 import wvlet.ai.util.SourceCode
 
-import scala.language.existentials
+enum DesignErrorCode:
+  case CYCLIC_DEPENDENCY  extends DesignErrorCode
+  case MISSING_DEPENDENCY extends DesignErrorCode
+  case SHUTDOWN_FAILURE   extends DesignErrorCode
 
-trait DesignException extends Exception:
-  self =>
+  def newException(message: String): DesignException = DesignException(this, message)
+  def newException(message: String, cause: Throwable): DesignException = DesignException(
+    this,
+    message,
+    cause
+  )
 
-  /**
-    * Returns the exception type
-    */
-  def getCode: String           = this.getClass.getSimpleName
-  override def toString: String = getMessage
+case class DesignException(code: DesignErrorCode, message: String, cause: Throwable = null)
+    extends Exception(message, cause):
+  override def toString: String = s"[${code}] ${getMessage}"
 
 object DesignException:
-  case class MISSING_SESSION(cl: Class[?]) extends DesignException:
-    override def getMessage: String =
-      s"[$getCode] Session is not found inside ${cl}. You may need to define ${cl} as a trait or implement DISupport to inject the current Session."
+  def cyclicDependency(deps: List[Surface], sourceCode: SourceCode): DesignException =
+    DesignException(
+      DesignErrorCode.CYCLIC_DEPENDENCY,
+      s"${deps.reverse.mkString(" -> ")} at ${sourceCode}"
+    )
 
-  case class CYCLIC_DEPENDENCY(deps: List[Surface], sourceCode: SourceCode) extends DesignException:
-    override def getMessage: String =
-      s"[$getCode] ${deps.reverse.mkString(" -> ")} at ${sourceCode}"
+  def missingDependency(stack: List[Surface], sourceCode: SourceCode): DesignException =
+    DesignException(
+      DesignErrorCode.MISSING_DEPENDENCY,
+      s"Binding for ${stack.head} at ${sourceCode} is not found: ${stack.mkString(" <- ")}"
+    )
 
-  case class MISSING_DEPENDENCY(stack: List[Surface], sourceCode: SourceCode)
-      extends DesignException:
-    override def getMessage: String =
-      s"[$getCode] Binding for ${stack.head} at ${sourceCode} is not found: ${stack.mkString(
-          " <- "
-        )}"
-
-  case class SHUTDOWN_FAILURE(cause: Throwable) extends DesignException:
-    override def getMessage: String =
-      s"[${getCode}] Failure at session shutdown: ${cause.getMessage}"
-
-  case class MULTIPLE_SHUTDOWN_FAILURES(causes: List[Throwable]) extends DesignException:
-    override def getMessage: String =
-      s"[${getCode}] Multiple failures occurred during session shutdown:\n${causes
-          .map(x => s"  - ${x.getMessage}")
-          .mkString("\n")}"
+end DesignException

--- a/ai-core/src/test/scala/wvlet/ai/design/DependencyTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/design/DependencyTest.scala
@@ -1,6 +1,5 @@
 package wvlet.ai.design
 
-import wvlet.ai.design.DesignException.MISSING_DEPENDENCY
 import wvlet.ai.design.Design
 import wvlet.airspec.AirSpec
 
@@ -19,9 +18,10 @@ class DependencyTest extends AirSpec:
   test("show missing dependencies") {
     val d = Design.newSilentDesign
     d.withSession { session =>
-      val m = intercept[MISSING_DEPENDENCY] {
+      val m = intercept[DesignException] {
         val a = session.build[DependencyTest1.A]
       }
+      m.code shouldBe DesignErrorCode.MISSING_DEPENDENCY
       val msg = m.getMessage
       msg.contains("D <- C") shouldBe true
     }

--- a/ai-core/src/test/scala/wvlet/ai/design/DisableNoDefaultInstanceCreationTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/design/DisableNoDefaultInstanceCreationTest.scala
@@ -13,8 +13,8 @@
  */
 package wvlet.ai.design
 
-import wvlet.ai.design.DesignException.MISSING_DEPENDENCY
 import wvlet.ai.design.Design
+import wvlet.ai.design.DesignErrorCode.MISSING_DEPENDENCY
 import wvlet.airspec.AirSpec
 
 object DisableNoDefaultInstanceCreationTest:
@@ -26,19 +26,21 @@ class DisableNoDefaultInstanceCreationTest extends AirSpec:
 
   test("disable implicit instance creation") {
     val d = Design.newSilentDesign.bindSingleton[Component].noDefaultInstanceInjection
-    intercept[MISSING_DEPENDENCY] {
+    val e = intercept[DesignException] {
       d.build[Component] { _ =>
       }
     }
+    e.code shouldBe MISSING_DEPENDENCY
   }
 
   test("disable implicit instance creation with production mode") {
     val d =
       Design.newSilentDesign.bindSingleton[Component].noDefaultInstanceInjection.withProductionMode
-    intercept[MISSING_DEPENDENCY] {
+    val e = intercept[DesignException] {
       d.withSession { _ =>
       }
     }
+    e.code shouldBe MISSING_DEPENDENCY
   }
 
   test("enable implicit instance creation") {

--- a/project/project/.bloop/scala-ai-build-build.json
+++ b/project/project/.bloop/scala-ai-build-build.json
@@ -218,7 +218,7 @@
         "platform": {
             "name": "jvm",
             "config": {
-                "home": "/Users/leo/Library/Java/JavaVirtualMachines/corretto-21.0.6/Contents/Home",
+                "home": "/Users/leo/Library/Java/JavaVirtualMachines/corretto-21.0.7/Contents/Home",
                 "options": [
                     "-Duser.dir=/Users/leo/work/scala-ai/project/project"
                 ]
@@ -227,7 +227,7 @@
                 
             ],
             "runtimeConfig": {
-                "home": "/Users/leo/Library/Java/JavaVirtualMachines/corretto-21.0.6/Contents/Home",
+                "home": "/Users/leo/Library/Java/JavaVirtualMachines/corretto-21.0.7/Contents/Home",
                 "options": [
                     "-Duser.dir=/Users/leo/work/scala-ai/project/project"
                 ]


### PR DESCRIPTION
**Description**

Refactored `DesignException` handling to integrate the use of a unified `DesignErrorCode` enum, improving consistency and maintainability.

**Related Issue/Task**

N/A

**Checklist**

- [ ] This pull request focuses on a single task.
- [ ] The change does not contain security credentials