### PR TITLE
internal: Set owner for generating tokens for auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           app-id: ${{ vars.APP_INSTALLATION_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Dependabot metadata
         id: metadata
         if: ${{ github.actor == 'dependabot[bot]' }}
@@ -33,6 +34,7 @@ jobs:
         with:
           app-id: ${{ vars.APP_INSTALLATION_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Enable auto-merge PR for minor updates
         if: ${{ ! contains(github.event.issue.labels.*.name, 'semver-spec-major') }}
         run: gh pr merge --squash --auto "${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
This pull request updates the `.github/workflows/auto-merge.yml` file to include the repository owner as an input parameter for certain steps in the workflow. This change ensures that the workflow explicitly specifies the repository owner when interacting with GitHub Actions.

Workflow improvements:

* [`.github/workflows/auto-merge.yml`](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243R16): Added the `owner` parameter (`${{ github.repository_owner }}`) to steps requiring GitHub App authentication to ensure the repository owner is explicitly defined. [[1]](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243R16) [[2]](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243R37)**Description**

**Related Issue/Task**

**Checklist**

- [ ] This pull request focuses on a single task.
- [ ] The change does not contain security credentials
