### PR TITLE
internal: Set scope of scala steward

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -21,6 +21,8 @@ jobs:
           github-app-id: ${{ vars.APP_ID }}
           github-app-installation-id: ${{ secrets.APP_INSTALLATION_ID }}
           github-app-key: ${{ secrets.APP_PRIVATE_KEY }}
+          github-app-auth-only: true
+          github-repository: 'scala-ai'
           author-name: 'scala-steward'
           author-email: 'leo+bot@xerial.org'
           other-args: '--do-not-fork --add-labels'

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -22,7 +22,6 @@ jobs:
           github-app-installation-id: ${{ secrets.APP_INSTALLATION_ID }}
           github-app-key: ${{ secrets.APP_PRIVATE_KEY }}
           github-app-auth-only: true
-          github-repository: 'scala-ai'
           author-name: 'scala-steward'
           author-email: 'leo+bot@xerial.org'
           other-args: '--do-not-fork --add-labels'


### PR DESCRIPTION
**Description**
This pull request makes a small adjustment to the `.github/workflows/scala-steward.yml` file, adding two new configuration options to the `jobs` section for improved functionality.

* [`.github/workflows/scala-steward.yml`](diffhunk://#diff-5f70f29f856428700109959debc5d1f950fa48d279caee7f9f0962a3caa63958R24-R25): Added `github-app-auth-only: true` to enable authentication-only mode and `github-repository: 'scala-ai'` to specify the repository for Scala Steward operations.

**Related Issue/Task**

**Checklist**

- [ ] This pull request focuses on a single task.
- [ ] The change does not contain security credentials
