### PR TITLE
internal: Fix auto-merge config

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/create-github-app-token@v2
         id: app-token
         with:
-          app-id: ${{ vars.APP_INSTALLATION_ID }}
+          app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Dependabot metadata
@@ -32,7 +32,7 @@ jobs:
         uses: actions/create-github-app-token@v2
         id: app-token
         with:
-          app-id: ${{ vars.APP_INSTALLATION_ID }}
+          app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Enable auto-merge PR for minor updates


### PR DESCRIPTION
This pull request updates the `.github/workflows/auto-merge.yml` file to fix the configuration for generating GitHub App tokens by replacing the incorrect variable `APP_INSTALLATION_ID` with the correct `APP_ID`.

* [`.github/workflows/auto-merge.yml`](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L14-R14): Replaced `vars.APP_INSTALLATION_ID` with `vars.APP_ID` in two instances within the `jobs` section to ensure the proper app ID is used when creating GitHub App tokens. [[1]](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L14-R14) [[2]](diffhunk://#diff-9e68ee04621d1e0e7dd2bf6032197d7a7848afb1a5c4ad805f617b330165e243L35-R35)

**Related Issue/Task**

**Checklist**

- [ ] This pull request focuses on a single task.
- [ ] The change does not contain security credentials
