### PR TITLE
Add tool_choice support for AWS Bedrock

### DIFF
--- a/ai-agent-bedrock/src/main/scala/wvlet/ai/agent/chat/bedrock/BedrockChat.scala
+++ b/ai-agent-bedrock/src/main/scala/wvlet/ai/agent/chat/bedrock/BedrockChat.scala
@@ -163,10 +163,10 @@ class BedrockChat(agent: LLMAgent, bedrockClient: BedrockClient) extends ChatMod
         .specificTool
         .foreach { specificTool =>
           val specificToolChoice = SpecificToolChoice.builder().name(specificTool.name).build()
-          val bedrockToolChoice = BedrockToolChoice.builder().tool(specificToolChoice).build()
+          val bedrockToolChoice  = BedrockToolChoice.builder().tool(specificToolChoice).build()
           toolConfigBuilder.toolChoice(bedrockToolChoice)
         }
-      
+
       // Or handle general tool choice if specific tool is not set
       if effectiveConfig.specificTool.isEmpty then
         effectiveConfig
@@ -181,13 +181,14 @@ class BedrockChat(agent: LLMAgent, bedrockClient: BedrockClient) extends ChatMod
                   null
                 case wvlet.ai.agent.ToolChoice.Required =>
                   BedrockToolChoice.builder().any(AnyToolChoice.builder().build()).build()
-  
+
             // Only set the tool choice if it's not null
             if bedrockToolChoice != null then
               toolConfigBuilder.toolChoice(bedrockToolChoice)
           }
 
       builder.toolConfig(toolConfigBuilder.build())
+    end if
 
     // Set messages
     val messages: Seq[Message] = extractBedrockChatMessages(request.messages)

--- a/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockAgentToolChoiceTest.scala
+++ b/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockAgentToolChoiceTest.scala
@@ -6,8 +6,8 @@ import wvlet.ai.agent.core.DataType
 import wvlet.airspec.AirSpec
 
 /**
- * Tests for using LLMAgent with tool_choice configurations
- */
+  * Tests for using LLMAgent with tool_choice configurations
+  */
 class BedrockAgentToolChoiceTest extends AirSpec:
 
   private def createAgent(modelConfig: ModelConfig = ModelConfig()): LLMAgent = LLMAgent(
@@ -16,79 +16,67 @@ class BedrockAgentToolChoiceTest extends AirSpec:
     model = LLM.Bedrock.Claude3_7Sonnet_20250219V1_0,
     modelConfig = modelConfig
   )
-  
+
   private def createToolSpec(): ToolSpec = ToolSpec(
     name = "get_weather",
     description = "Get the current weather for a location",
     parameters = List(
-      ToolParameter(
-        "location",
-        "The city and state, e.g., San Francisco, CA",
-        DataType.StringType
-      )
+      ToolParameter("location", "The city and state, e.g., San Francisco, CA", DataType.StringType)
     ),
     returnType = DataType.StringType
   )
-  
+
   test("agent should support auto tool choice") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoiceAuto
-      
+    val agent = createAgent().withTools(List(createToolSpec())).withToolChoiceAuto
+
     agent.modelConfig.toolChoice shouldBe defined
     agent.modelConfig.toolChoice.get.toString shouldBe "Auto"
   }
-  
+
   test("agent should support none tool choice") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoiceNone
-      
+    val agent = createAgent().withTools(List(createToolSpec())).withToolChoiceNone
+
     agent.modelConfig.toolChoice shouldBe defined
     agent.modelConfig.toolChoice.get.toString shouldBe "None"
   }
-  
+
   test("agent should support specific tool choice") {
     val toolName = "get_weather"
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoice(toolName)
-      
+    val agent    = createAgent().withTools(List(createToolSpec())).withToolChoice(toolName)
+
     agent.modelConfig.toolChoice shouldBe defined
     agent.modelConfig.toolChoice.get.toString shouldBe s"Tool($toolName)"
   }
-  
+
   test("agent should support required tool choice") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoiceRequired
-      
+    val agent = createAgent().withTools(List(createToolSpec())).withToolChoiceRequired
+
     agent.modelConfig.toolChoice shouldBe defined
     agent.modelConfig.toolChoice.get.toString shouldBe "Required"
   }
-  
+
   test("agent should support removing tool choice") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoiceAuto
-      .noToolChoice
-      
+    val agent = createAgent().withTools(List(createToolSpec())).withToolChoiceAuto.noToolChoice
+
     agent.modelConfig.toolChoice shouldBe None
   }
-  
+
   test("overrideConfig in request should override agent's toolChoice") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoiceAuto
-    
+    val agent = createAgent().withTools(List(createToolSpec())).withToolChoiceAuto
+
     val request = ChatRequest(
       messages = List(ChatMessage.user("Hello")),
       overrideConfig = Some(ModelConfig().withToolChoiceRequired)
     )
-    
-    val overriden = request.overrideConfig.map(agent.modelConfig.overrideWith).getOrElse(agent.modelConfig)
+
+    val overriden = request
+      .overrideConfig
+      .map(agent.modelConfig.overrideWith)
+      .getOrElse(agent.modelConfig)
     overriden.toolChoice shouldBe defined
     overriden.toolChoice.get.toString shouldBe "Required"
   }
-  
+
 end BedrockAgentToolChoiceTest
+
+

--- a/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockAgentToolChoiceTest.scala
+++ b/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockAgentToolChoiceTest.scala
@@ -1,0 +1,94 @@
+package wvlet.ai.agent.chat.bedrock
+
+import wvlet.ai.agent.{LLM, LLMAgent, ModelConfig}
+import wvlet.ai.agent.chat.{ChatMessage, ChatRequest, ToolParameter, ToolSpec}
+import wvlet.ai.agent.core.DataType
+import wvlet.airspec.AirSpec
+
+/**
+ * Tests for using LLMAgent with tool_choice configurations
+ */
+class BedrockAgentToolChoiceTest extends AirSpec:
+
+  private def createAgent(modelConfig: ModelConfig = ModelConfig()): LLMAgent = LLMAgent(
+    name = "test-agent",
+    description = "Test Agent",
+    model = LLM.Bedrock.Claude3_7Sonnet_20250219V1_0,
+    modelConfig = modelConfig
+  )
+  
+  private def createToolSpec(): ToolSpec = ToolSpec(
+    name = "get_weather",
+    description = "Get the current weather for a location",
+    parameters = List(
+      ToolParameter(
+        "location",
+        "The city and state, e.g., San Francisco, CA",
+        DataType.StringType
+      )
+    ),
+    returnType = DataType.StringType
+  )
+  
+  test("agent should support auto tool choice") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoiceAuto
+      
+    agent.modelConfig.toolChoice shouldBe defined
+    agent.modelConfig.toolChoice.get.toString shouldBe "Auto"
+  }
+  
+  test("agent should support none tool choice") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoiceNone
+      
+    agent.modelConfig.toolChoice shouldBe defined
+    agent.modelConfig.toolChoice.get.toString shouldBe "None"
+  }
+  
+  test("agent should support specific tool choice") {
+    val toolName = "get_weather"
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoice(toolName)
+      
+    agent.modelConfig.toolChoice shouldBe defined
+    agent.modelConfig.toolChoice.get.toString shouldBe s"Tool($toolName)"
+  }
+  
+  test("agent should support required tool choice") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoiceRequired
+      
+    agent.modelConfig.toolChoice shouldBe defined
+    agent.modelConfig.toolChoice.get.toString shouldBe "Required"
+  }
+  
+  test("agent should support removing tool choice") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoiceAuto
+      .noToolChoice
+      
+    agent.modelConfig.toolChoice shouldBe None
+  }
+  
+  test("overrideConfig in request should override agent's toolChoice") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoiceAuto
+    
+    val request = ChatRequest(
+      messages = List(ChatMessage.user("Hello")),
+      overrideConfig = Some(ModelConfig().withToolChoiceRequired)
+    )
+    
+    val overriden = request.overrideConfig.map(agent.modelConfig.overrideWith).getOrElse(agent.modelConfig)
+    overriden.toolChoice shouldBe defined
+    overriden.toolChoice.get.toString shouldBe "Required"
+  }
+  
+end BedrockAgentToolChoiceTest

--- a/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockAgentToolChoiceTest.scala
+++ b/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockAgentToolChoiceTest.scala
@@ -1,6 +1,6 @@
 package wvlet.ai.agent.chat.bedrock
 
-import wvlet.ai.agent.{LLM, LLMAgent, ModelConfig}
+import wvlet.ai.agent.{LLM, LLMAgent, ModelConfig, SpecificTool}
 import wvlet.ai.agent.chat.{ChatMessage, ChatRequest, ToolParameter, ToolSpec}
 import wvlet.ai.agent.core.DataType
 import wvlet.airspec.AirSpec
@@ -44,8 +44,9 @@ class BedrockAgentToolChoiceTest extends AirSpec:
     val toolName = "get_weather"
     val agent    = createAgent().withTools(List(createToolSpec())).withToolChoice(toolName)
 
-    agent.modelConfig.toolChoice shouldBe defined
-    agent.modelConfig.toolChoice.get.toString shouldBe s"Tool($toolName)"
+    agent.modelConfig.toolChoice shouldBe None
+    agent.modelConfig.specificTool shouldBe defined
+    agent.modelConfig.specificTool.get.name shouldBe toolName
   }
 
   test("agent should support required tool choice") {
@@ -74,9 +75,7 @@ class BedrockAgentToolChoiceTest extends AirSpec:
       .map(agent.modelConfig.overrideWith)
       .getOrElse(agent.modelConfig)
     overriden.toolChoice shouldBe defined
-    overriden.toolChoice.get.toString shouldBe "Required"
+    overriden.toolChoice.get shouldBe wvlet.ai.agent.ToolChoice.Required
   }
 
 end BedrockAgentToolChoiceTest
-
-

--- a/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockToolChoiceTest.scala
+++ b/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockToolChoiceTest.scala
@@ -1,6 +1,6 @@
 package wvlet.ai.agent.chat.bedrock
 
-import software.amazon.awssdk.services.bedrockruntime.model.ToolChoice as BedrockToolChoice
+import software.amazon.awssdk.services.bedrockruntime.model.{ToolChoice => BedrockToolChoice}
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest
 import wvlet.ai.agent.{LLM, LLMAgent, ModelConfig, ToolChoice}
 import wvlet.ai.agent.chat.{ChatMessage, ChatRequest, ToolParameter, ToolSpec}
@@ -117,5 +117,3 @@ class BedrockToolChoiceTest extends AirSpec with LogSupport:
   }
 
 end BedrockToolChoiceTest
-
-

--- a/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockToolChoiceTest.scala
+++ b/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockToolChoiceTest.scala
@@ -1,6 +1,6 @@
 package wvlet.ai.agent.chat.bedrock
 
-import software.amazon.awssdk.services.bedrockruntime.model.{ToolChoice => BedrockToolChoice}
+import software.amazon.awssdk.services.bedrockruntime.model.ToolChoice as BedrockToolChoice
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest
 import wvlet.ai.agent.{LLM, LLMAgent, ModelConfig, ToolChoice}
 import wvlet.ai.agent.chat.{ChatMessage, ChatRequest, ToolParameter, ToolSpec}
@@ -11,8 +11,8 @@ import wvlet.log.LogSupport
 import scala.jdk.CollectionConverters.*
 
 /**
- * Tests for the tool choice functionality in Bedrock integration
- */
+  * Tests for the tool choice functionality in Bedrock integration
+  */
 class BedrockToolChoiceTest extends AirSpec with LogSupport:
 
   private def createAgent(modelConfig: ModelConfig = ModelConfig()): LLMAgent = LLMAgent(
@@ -28,102 +28,87 @@ class BedrockToolChoiceTest extends AirSpec with LogSupport:
   ) // Use default config for testing request building
 
   private val dummyRequest = ChatRequest(List(ChatMessage.user("Hello")))
-  
+
   private def createToolSpec(): ToolSpec = ToolSpec(
     name = "get_weather",
     description = "Get the current weather for a location",
     parameters = List(
-      ToolParameter(
-        "location",
-        "The city and state, e.g., San Francisco, CA",
-        DataType.StringType
-      )
+      ToolParameter("location", "The city and state, e.g., San Francisco, CA", DataType.StringType)
     ),
     returnType = DataType.StringType
   )
 
   test("should configure AUTO tool choice") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoiceAuto
-      
-    val chat = createChat(agent)
+    val agent = createAgent().withTools(List(createToolSpec())).withToolChoiceAuto
+
+    val chat            = createChat(agent)
     val converseRequest = chat.newConverseRequest(dummyRequest)
-    
+
     val toolConfig = converseRequest.toolConfig()
     toolConfig shouldNotBe null
     val toolChoice = toolConfig.toolChoice()
     toolChoice shouldNotBe null
     toolChoice.toString.toLowerCase shouldContain "auto"
   }
-  
+
   test("should configure NONE tool choice") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoiceNone
-      
-    val chat = createChat(agent)
+    val agent = createAgent().withTools(List(createToolSpec())).withToolChoiceNone
+
+    val chat            = createChat(agent)
     val converseRequest = chat.newConverseRequest(dummyRequest)
-    
+
     val toolConfig = converseRequest.toolConfig()
     toolConfig shouldNotBe null
     // For "none" tool choice, we use null in AWS SDK
     Option(toolConfig.toolChoice()) shouldBe None
   }
-  
+
   test("should configure REQUIRED tool choice") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoiceRequired
-      
-    val chat = createChat(agent)
+    val agent = createAgent().withTools(List(createToolSpec())).withToolChoiceRequired
+
+    val chat            = createChat(agent)
     val converseRequest = chat.newConverseRequest(dummyRequest)
-    
+
     val toolConfig = converseRequest.toolConfig()
     toolConfig shouldNotBe null
     val toolChoice = toolConfig.toolChoice()
     toolChoice shouldNotBe null
     toolChoice.toString.toLowerCase shouldContain "any"
   }
-  
+
   test("should configure specific tool choice") {
     val toolName = "get_weather"
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoice(toolName)
-      
-    val chat = createChat(agent)
+    val agent    = createAgent().withTools(List(createToolSpec())).withToolChoice(toolName)
+
+    val chat            = createChat(agent)
     val converseRequest = chat.newConverseRequest(dummyRequest)
-    
+
     val toolConfig = converseRequest.toolConfig()
     toolConfig shouldNotBe null
     val toolChoice = toolConfig.toolChoice()
     toolChoice shouldNotBe null
     toolChoice.toString().contains(toolName) shouldBe true
   }
-  
+
   test("should not set tool choice when not configured") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      
-    val chat = createChat(agent)
+    val agent = createAgent().withTools(List(createToolSpec()))
+
+    val chat            = createChat(agent)
     val converseRequest = chat.newConverseRequest(dummyRequest)
-    
+
     val toolConfig = converseRequest.toolConfig()
     toolConfig shouldNotBe null
     Option(toolConfig.toolChoice()) shouldBe None
   }
-  
+
   test("should override tool choice in request") {
-    val agent = createAgent()
-      .withTools(List(createToolSpec()))
-      .withToolChoiceAuto
-      
-    val chat = createChat(agent)
-    val overrideConfig = ModelConfig().withToolChoiceRequired
-    val request = ChatRequest(List(ChatMessage.user("Hello")), Some(overrideConfig))
+    val agent = createAgent().withTools(List(createToolSpec())).withToolChoiceAuto
+
+    val chat            = createChat(agent)
+    val overrideConfig  = ModelConfig().withToolChoiceRequired
+    val request         = ChatRequest(List(ChatMessage.user("Hello")), Some(overrideConfig))
     val converseRequest = chat.newConverseRequest(request)
-    
+
     val toolConfig = converseRequest.toolConfig()
     toolConfig shouldNotBe null
     val toolChoice = toolConfig.toolChoice()
@@ -132,3 +117,5 @@ class BedrockToolChoiceTest extends AirSpec with LogSupport:
   }
 
 end BedrockToolChoiceTest
+
+

--- a/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockToolChoiceTest.scala
+++ b/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockToolChoiceTest.scala
@@ -1,0 +1,134 @@
+package wvlet.ai.agent.chat.bedrock
+
+import software.amazon.awssdk.services.bedrockruntime.model.{ToolChoice => BedrockToolChoice}
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest
+import wvlet.ai.agent.{LLM, LLMAgent, ModelConfig, ToolChoice}
+import wvlet.ai.agent.chat.{ChatMessage, ChatRequest, ToolParameter, ToolSpec}
+import wvlet.ai.agent.core.DataType
+import wvlet.airspec.AirSpec
+import wvlet.log.LogSupport
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Tests for the tool choice functionality in Bedrock integration
+ */
+class BedrockToolChoiceTest extends AirSpec with LogSupport:
+
+  private def createAgent(modelConfig: ModelConfig = ModelConfig()): LLMAgent = LLMAgent(
+    name = "test-agent",
+    description = "Test Agent",
+    model = LLM.Bedrock.Claude3_7Sonnet_20250219V1_0,
+    modelConfig = modelConfig
+  )
+
+  private def createChat(agent: LLMAgent): BedrockChat = BedrockChat(
+    agent,
+    BedrockClient()
+  ) // Use default config for testing request building
+
+  private val dummyRequest = ChatRequest(List(ChatMessage.user("Hello")))
+  
+  private def createToolSpec(): ToolSpec = ToolSpec(
+    name = "get_weather",
+    description = "Get the current weather for a location",
+    parameters = List(
+      ToolParameter(
+        "location",
+        "The city and state, e.g., San Francisco, CA",
+        DataType.StringType
+      )
+    ),
+    returnType = DataType.StringType
+  )
+
+  test("should configure AUTO tool choice") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoiceAuto
+      
+    val chat = createChat(agent)
+    val converseRequest = chat.newConverseRequest(dummyRequest)
+    
+    val toolConfig = converseRequest.toolConfig()
+    toolConfig shouldNotBe null
+    val toolChoice = toolConfig.toolChoice()
+    toolChoice shouldNotBe null
+    toolChoice.toString.toLowerCase shouldContain "auto"
+  }
+  
+  test("should configure NONE tool choice") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoiceNone
+      
+    val chat = createChat(agent)
+    val converseRequest = chat.newConverseRequest(dummyRequest)
+    
+    val toolConfig = converseRequest.toolConfig()
+    toolConfig shouldNotBe null
+    // For "none" tool choice, we use null in AWS SDK
+    Option(toolConfig.toolChoice()) shouldBe None
+  }
+  
+  test("should configure REQUIRED tool choice") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoiceRequired
+      
+    val chat = createChat(agent)
+    val converseRequest = chat.newConverseRequest(dummyRequest)
+    
+    val toolConfig = converseRequest.toolConfig()
+    toolConfig shouldNotBe null
+    val toolChoice = toolConfig.toolChoice()
+    toolChoice shouldNotBe null
+    toolChoice.toString.toLowerCase shouldContain "any"
+  }
+  
+  test("should configure specific tool choice") {
+    val toolName = "get_weather"
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoice(toolName)
+      
+    val chat = createChat(agent)
+    val converseRequest = chat.newConverseRequest(dummyRequest)
+    
+    val toolConfig = converseRequest.toolConfig()
+    toolConfig shouldNotBe null
+    val toolChoice = toolConfig.toolChoice()
+    toolChoice shouldNotBe null
+    toolChoice.toString().contains(toolName) shouldBe true
+  }
+  
+  test("should not set tool choice when not configured") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      
+    val chat = createChat(agent)
+    val converseRequest = chat.newConverseRequest(dummyRequest)
+    
+    val toolConfig = converseRequest.toolConfig()
+    toolConfig shouldNotBe null
+    Option(toolConfig.toolChoice()) shouldBe None
+  }
+  
+  test("should override tool choice in request") {
+    val agent = createAgent()
+      .withTools(List(createToolSpec()))
+      .withToolChoiceAuto
+      
+    val chat = createChat(agent)
+    val overrideConfig = ModelConfig().withToolChoiceRequired
+    val request = ChatRequest(List(ChatMessage.user("Hello")), Some(overrideConfig))
+    val converseRequest = chat.newConverseRequest(request)
+    
+    val toolConfig = converseRequest.toolConfig()
+    toolConfig shouldNotBe null
+    val toolChoice = toolConfig.toolChoice()
+    toolChoice shouldNotBe null
+    toolChoice.toString.toLowerCase shouldContain "any"
+  }
+
+end BedrockToolChoiceTest

--- a/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockToolChoiceTest.scala
+++ b/ai-agent-bedrock/src/test/scala/wvlet/ai/agent/chat/bedrock/BedrockToolChoiceTest.scala
@@ -1,6 +1,6 @@
 package wvlet.ai.agent.chat.bedrock
 
-import software.amazon.awssdk.services.bedrockruntime.model.{ToolChoice => BedrockToolChoice}
+import software.amazon.awssdk.services.bedrockruntime.model.ToolChoice as BedrockToolChoice
 import software.amazon.awssdk.services.bedrockruntime.model.ConverseStreamRequest
 import wvlet.ai.agent.{LLM, LLMAgent, ModelConfig, ToolChoice}
 import wvlet.ai.agent.chat.{ChatMessage, ChatRequest, ToolParameter, ToolSpec}

--- a/ai-agent/src/main/scala/wvlet/ai/agent/LLMAgent.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/LLMAgent.scala
@@ -74,7 +74,7 @@ case class LLMAgent(
 
   /** Remove the reasoning configuration. */
   def noReasoning: LLMAgent = this.withModelConfig(_.noReasoning)
-  
+
   /** Let the model decide which tool to use, if any. */
   def withToolChoiceAuto: LLMAgent = this.withModelConfig(_.withToolChoiceAuto)
 

--- a/ai-agent/src/main/scala/wvlet/ai/agent/LLMAgent.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/LLMAgent.scala
@@ -74,5 +74,20 @@ case class LLMAgent(
 
   /** Remove the reasoning configuration. */
   def noReasoning: LLMAgent = this.withModelConfig(_.noReasoning)
+  
+  /** Let the model decide which tool to use, if any. */
+  def withToolChoiceAuto: LLMAgent = this.withModelConfig(_.withToolChoiceAuto)
+
+  /** Force the model not to use any tools. */
+  def withToolChoiceNone: LLMAgent = this.withModelConfig(_.withToolChoiceNone)
+
+  /** Force the model to call the specified tool. */
+  def withToolChoice(toolName: String): LLMAgent = this.withModelConfig(_.withToolChoice(toolName))
+
+  /** Force the model to call any tool. */
+  def withToolChoiceRequired: LLMAgent = this.withModelConfig(_.withToolChoiceRequired)
+
+  /** Remove any tool choice configuration. */
+  def noToolChoice: LLMAgent = this.withModelConfig(_.noToolChoice)
 
 end LLMAgent

--- a/ai-agent/src/main/scala/wvlet/ai/agent/ModelConfig.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/ModelConfig.scala
@@ -67,8 +67,8 @@ case class ModelConfig(
     toolChoice: Option[ToolChoice] = None,
 
     /**
-      * Forces the model to call a specific named tool.
-      * This is mutually exclusive with toolChoice - if both are set, specificTool takes precedence.
+      * Forces the model to call a specific named tool. This is mutually exclusive with toolChoice -
+      * if both are set, specificTool takes precedence.
       */
     specificTool: Option[SpecificTool] = None
 ):
@@ -142,8 +142,8 @@ case class ModelConfig(
     candidateCount = other.candidateCount.orElse(this.candidateCount),
     reasoningConfig = other
       .reasoningConfig
-      .orElse(this.reasoningConfig),                      // Add reasoningConfig override
-    toolChoice = other.toolChoice.orElse(this.toolChoice), // Add toolChoice override
+      .orElse(this.reasoningConfig),                            // Add reasoningConfig override
+    toolChoice = other.toolChoice.orElse(this.toolChoice),      // Add toolChoice override
     specificTool = other.specificTool.orElse(this.specificTool) // Add specificTool override
   )
 

--- a/ai-agent/src/main/scala/wvlet/ai/agent/ModelConfig.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/ModelConfig.scala
@@ -6,10 +6,13 @@ package wvlet.ai.agent
 enum ToolChoice:
   /** Let the model decide which tool to call and whether to call a tool */
   case Auto
+
   /** Don't call any tool, even if the tools are provided */
   case None
+
   /** Force the model to use a specific tool by name */
   case Tool(name: String)
+
   /** Force the model to use any tool (forces a tool call) */
   case Required
 
@@ -56,11 +59,11 @@ case class ModelConfig(
 
     /**
       * Controls how the model selects and uses tools.
-      * - None: No specific setting, let the model provider determine (default)
-      * - Some(Auto): Let the model decide which tool to call, if any
-      * - Some(None): Force the model not to call any tools
-      * - Some(Tool("tool_name")): Force the model to call a specific tool
-      * - Some(Required): Force the model to call some tool
+      *   - None: No specific setting, let the model provider determine (default)
+      *   - Some(Auto): Let the model decide which tool to call, if any
+      *   - Some(None): Force the model not to call any tools
+      *   - Some(Tool("tool_name")): Force the model to call a specific tool
+      *   - Some(Required): Force the model to call some tool
       */
     toolChoice: Option[ToolChoice] = None
 ):
@@ -103,7 +106,9 @@ case class ModelConfig(
   def withToolChoiceNone: ModelConfig = this.copy(toolChoice = Some(ToolChoice.None))
 
   /** Force the model to call the specified tool. */
-  def withToolChoice(toolName: String): ModelConfig = this.copy(toolChoice = Some(ToolChoice.Tool(toolName)))
+  def withToolChoice(toolName: String): ModelConfig = this.copy(toolChoice =
+    Some(ToolChoice.Tool(toolName))
+  )
 
   /** Force the model to call any tool. */
   def withToolChoiceRequired: ModelConfig = this.copy(toolChoice = Some(ToolChoice.Required))
@@ -131,7 +136,7 @@ case class ModelConfig(
     candidateCount = other.candidateCount.orElse(this.candidateCount),
     reasoningConfig = other
       .reasoningConfig
-      .orElse(this.reasoningConfig), // Add reasoningConfig override
+      .orElse(this.reasoningConfig),                      // Add reasoningConfig override
     toolChoice = other.toolChoice.orElse(this.toolChoice) // Add toolChoice override
   )
 

--- a/ai-agent/src/main/scala/wvlet/ai/agent/ModelConfig.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/ModelConfig.scala
@@ -1,5 +1,18 @@
 package wvlet.ai.agent
 
+/**
+  * Defines how models select which tools to use during inference.
+  */
+enum ToolChoice:
+  /** Let the model decide which tool to call and whether to call a tool */
+  case Auto
+  /** Don't call any tool, even if the tools are provided */
+  case None
+  /** Force the model to use a specific tool by name */
+  case Tool(name: String)
+  /** Force the model to use any tool (forces a tool call) */
+  case Required
+
 case class ModelConfig(
     /**
       * Controls the randomness of token selection. Lower values produce less random responses,
@@ -39,7 +52,17 @@ case class ModelConfig(
       * The reasoning configuration for the model. This is a placeholder and can be used to specify
       * additional reasoning parameters.
       */
-    reasoningConfig: Option[ReasoningConfig] = None
+    reasoningConfig: Option[ReasoningConfig] = None,
+
+    /**
+      * Controls how the model selects and uses tools.
+      * - None: No specific setting, let the model provider determine (default)
+      * - Some(Auto): Let the model decide which tool to call, if any
+      * - Some(None): Force the model not to call any tools
+      * - Some(Tool("tool_name")): Force the model to call a specific tool
+      * - Some(Required): Force the model to call some tool
+      */
+    toolChoice: Option[ToolChoice] = None
 ):
 
   /** Set the temperature parameter for randomness control. */
@@ -73,6 +96,21 @@ case class ModelConfig(
   /** Remove the reasoning configuration. */
   def noReasoning: ModelConfig = this.copy(reasoningConfig = None)
 
+  /** Let the model decide which tool to use, if any. */
+  def withToolChoiceAuto: ModelConfig = this.copy(toolChoice = Some(ToolChoice.Auto))
+
+  /** Force the model not to use any tools. */
+  def withToolChoiceNone: ModelConfig = this.copy(toolChoice = Some(ToolChoice.None))
+
+  /** Force the model to call the specified tool. */
+  def withToolChoice(toolName: String): ModelConfig = this.copy(toolChoice = Some(ToolChoice.Tool(toolName)))
+
+  /** Force the model to call any tool. */
+  def withToolChoiceRequired: ModelConfig = this.copy(toolChoice = Some(ToolChoice.Required))
+
+  /** Remove any tool choice configuration. */
+  def noToolChoice: ModelConfig = this.copy(toolChoice = None)
+
   /**
     * Creates a new ModelConfig by overriding the parameters of this config with the defined
     * parameters from the `other` config.
@@ -93,7 +131,8 @@ case class ModelConfig(
     candidateCount = other.candidateCount.orElse(this.candidateCount),
     reasoningConfig = other
       .reasoningConfig
-      .orElse(this.reasoningConfig) // Add reasoningConfig override
+      .orElse(this.reasoningConfig), // Add reasoningConfig override
+    toolChoice = other.toolChoice.orElse(this.toolChoice) // Add toolChoice override
   )
 
 end ModelConfig

--- a/ai-integration-test/src/test/scala/wvlet/ai/agent/bedrock/BedrockIntegrationTest.scala
+++ b/ai-integration-test/src/test/scala/wvlet/ai/agent/bedrock/BedrockIntegrationTest.scala
@@ -5,7 +5,7 @@ import wvlet.ai.agent.chat.bedrock.BedrockRunner
 import wvlet.ai.agent.{LLM, LLMAgent}
 import wvlet.airspec.AirSpec
 
-class BedrockIntegrationTest extends AirSpec:
+object BedrockIntegrationTest extends AirSpec:
   if !sys.env.isDefinedAt("AWS_SECRET_ACCESS_KEY") then
     skip("AWS environment variables are not set. Skip this test")
 

--- a/ai-integration-test/src/test/scala/wvlet/ai/agent/bedrock/BedrockIntegrationTest.scala
+++ b/ai-integration-test/src/test/scala/wvlet/ai/agent/bedrock/BedrockIntegrationTest.scala
@@ -5,7 +5,7 @@ import wvlet.ai.agent.chat.bedrock.BedrockRunner
 import wvlet.ai.agent.{LLM, LLMAgent}
 import wvlet.airspec.AirSpec
 
-object BedrockIntegrationTest extends AirSpec:
+class BedrockIntegrationTest extends AirSpec:
   if !sys.env.isDefinedAt("AWS_SECRET_ACCESS_KEY") then
     skip("AWS environment variables are not set. Skip this test")
 


### PR DESCRIPTION
## Description

This PR adds support for the `tool_choice` parameter in AWS Bedrock's Claude models. The feature allows developers to control how and when the model uses available tools during conversations.

Key additions:
- New `ToolChoice` enum with modes (Auto, None, Required)
- New `SpecificTool` case class for selecting specific tools by name
- Extended `ModelConfig` with tool choice support
- Added convenience methods to `LLMAgent` for setting tool choice
- Implemented AWS Bedrock-specific SDK handling
- Added comprehensive unit tests

## Usage

```scala
// Let the model decide when to use tools (default behavior)
val agent = LLMAgent(...)
  .withTools(tools)
  .withToolChoiceAuto

// Prevent the model from using tools, even if tools are available
val agent = LLMAgent(...)
  .withTools(tools) 
  .withToolChoiceNone

// Force the model to use a specific tool
val agent = LLMAgent(...)
  .withTools(tools)
  .withToolChoice("calculator")

// Force the model to use some tool (but let it pick which one)
val agent = LLMAgent(...)
  .withTools(tools)
  .withToolChoiceRequired
```

You can also override the tool choice setting for specific requests:

```scala
val request = ChatRequest(
  messages = messages,
  overrideConfig = Some(ModelConfig().withToolChoiceRequired)
)
```

## Implementation Notes

- Used a separate `SpecificTool` case class instead of a parameterized enum case for Airframe compatibility
- Both `toolChoice` and `specificTool` fields in `ModelConfig` are mutually exclusive
- When both are set, `specificTool` takes precedence

## Testing

- Added unit tests for both configuration and request behavior
- Verified proper AWS SDK integration
- All tests pass
EOL < /dev/null