### PR TITLE
Add comprehensive chat history test for Bedrock integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,11 @@ sbt integrationTest/test
 - Integration tests are in separate `ai-integration-test` module
 - Mock implementations available for testing without external dependencies
 
+### AirSpec Assertion Syntax
+- Use `shouldBe`, `should include()`, `shouldBe a[Type]` for basic assertions
+- For comparison operators, wrap in parentheses: `(value >= 1) shouldBe true`
+- Avoid ScalaTest-style matchers like `should be >= 1` - not supported in AirSpec
+
 ## Key Dependencies
 
 - **Scala Version**: 3.7.0

--- a/ai-integration-test/src/test/scala/wvlet/ai/agent/bedrock/BedrockIntegrationTest.scala
+++ b/ai-integration-test/src/test/scala/wvlet/ai/agent/bedrock/BedrockIntegrationTest.scala
@@ -49,4 +49,26 @@ class BedrockIntegrationTest extends AirSpec:
     debug(resp)
   }
 
+  test("bedrock agent with chat history") { (runner: BedrockRunner) =>
+    val session = runner.newChatSession
+    
+    // First message
+    val firstResponse = session.chat("My name is Alice. What's your name?")
+    debug(s"First response: ${firstResponse}")
+    
+    // Continue with history using continueChat
+    val secondResponse = session.continueChat(firstResponse, "Do you remember my name?")
+    debug(s"Second response: ${secondResponse}")
+    
+    // Test with explicit ChatRequest containing history
+    val history = Seq(
+      ChatMessage.user("I like blue color"),
+      ChatMessage.assistant("That's nice! Blue is a calming color."),
+      ChatMessage.user("What color did I say I like?")
+    )
+    val request = ChatRequest(messages = history)
+    val thirdResponse = session.chatStream(request)
+    debug(s"Third response with explicit history: ${thirdResponse}")
+  }
+
 end BedrockIntegrationTest

--- a/ai-integration-test/src/test/scala/wvlet/ai/agent/bedrock/BedrockIntegrationTest.scala
+++ b/ai-integration-test/src/test/scala/wvlet/ai/agent/bedrock/BedrockIntegrationTest.scala
@@ -1,6 +1,7 @@
 package wvlet.ai.agent.bedrock
 
 import wvlet.ai.agent.chat.*
+import wvlet.ai.agent.chat.ChatMessage.AIMessage
 import wvlet.ai.agent.chat.bedrock.BedrockRunner
 import wvlet.ai.agent.{LLM, LLMAgent}
 import wvlet.airspec.AirSpec
@@ -57,8 +58,8 @@ class BedrockIntegrationTest extends AirSpec:
     debug(s"First response: ${firstResponse}")
     
     // Verify basic response structure
-    firstResponse.messages should not be empty
-    firstResponse.messages.head shouldBe a[AIMessage]
+    firstResponse.messages.nonEmpty shouldBe true
+    firstResponse.messages.head.isInstanceOf[AIMessage] shouldBe true
     
     // Continue with history using continueChat - test memory retention
     val secondResponse = session.continueChat(firstResponse, "What is my name?")
@@ -66,7 +67,7 @@ class BedrockIntegrationTest extends AirSpec:
     
     // Verify the response contains the remembered name
     val secondMessage = secondResponse.messages.head.asInstanceOf[AIMessage]
-    secondMessage.text.toLowerCase should include("alice")
+    secondMessage.text.toLowerCase shouldContain "alice"
     
     // Test with explicit ChatRequest containing history
     val history = Seq(
@@ -80,11 +81,11 @@ class BedrockIntegrationTest extends AirSpec:
     
     // Verify the response references the conversation history
     val thirdMessage = thirdResponse.messages.head.asInstanceOf[AIMessage]
-    thirdMessage.text.toLowerCase should include("blue")
+    thirdMessage.text.toLowerCase shouldContain "blue"
     
     // Verify that chat history is properly maintained in responses
-    secondResponse.messages.size should be >= 1
-    thirdResponse.messages.size should be >= 1
+    (secondResponse.messages.size >= 1) shouldBe true
+    (thirdResponse.messages.size >= 1) shouldBe true
   }
 
 end BedrockIntegrationTest


### PR DESCRIPTION
## Summary
- Add integration test demonstrating chat history support in Bedrock
- Test three different approaches to maintaining conversation context
- Validate existing chat history functionality in BedrockChat implementation

## Test plan
- [x] Test `continueChat()` method for automatic history maintenance
- [x] Test explicit `ChatRequest` with message sequences
- [x] Test session-based conversations across multiple interactions
- [x] Run integration tests with AWS credentials to verify functionality

🤖 Generated with [Claude Code](https://claude.ai/code)