### PR TITLE
Rename MessagePack.newBufferPacker to MessagePack.newPacker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,9 @@ sbt projectNative/compile # Scala Native only
 ```
 
 ### Code Formatting
+
+Ensure the code is formatted with `scalafmtAll` command for consistent code style. CI will check formatting on pull requests.
+
 ```bash
 # Format code
 sbt scalafmtAll

--- a/ai-core/src/main/scala/wvlet/ai/core/msgpack/json/NestedMessagePackBuilder.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/msgpack/json/NestedMessagePackBuilder.scala
@@ -27,7 +27,7 @@ object NestedMessagePackBuilder:
 
 class NestedMessagePackBuilder extends JSONContext[Seq[MsgPack]] with LogSupport:
   parent =>
-  protected val packer = MessagePack.newPacker
+  protected val packer = MessagePack.newPacker()
 
   def mergedResult: MsgPack =
     val buffers = result
@@ -90,7 +90,7 @@ class NestedMessagePackBuilder extends JSONContext[Seq[MsgPack]] with LogSupport
         val mapElementCount = getElementCount / 2
         Seq(
           // Embed map header count
-          MessagePack.newPacker.packMapHeader(mapElementCount).toByteArray,
+          MessagePack.newPacker().packMapHeader(mapElementCount).toByteArray,
           packer.toByteArray
         )
 
@@ -102,7 +102,7 @@ class NestedMessagePackBuilder extends JSONContext[Seq[MsgPack]] with LogSupport
 
       override def result: Seq[MsgPack] = Seq(
         // Embed array header count
-        MessagePack.newPacker.packArrayHeader(getElementCount).toByteArray,
+        MessagePack.newPacker().packArrayHeader(getElementCount).toByteArray,
         packer.toByteArray
       )
 

--- a/ai-core/src/main/scala/wvlet/ai/core/msgpack/json/NestedMessagePackBuilder.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/msgpack/json/NestedMessagePackBuilder.scala
@@ -27,7 +27,7 @@ object NestedMessagePackBuilder:
 
 class NestedMessagePackBuilder extends JSONContext[Seq[MsgPack]] with LogSupport:
   parent =>
-  protected val packer = MessagePack.newBufferPacker
+  protected val packer = MessagePack.newPacker
 
   def mergedResult: MsgPack =
     val buffers = result
@@ -90,7 +90,7 @@ class NestedMessagePackBuilder extends JSONContext[Seq[MsgPack]] with LogSupport
         val mapElementCount = getElementCount / 2
         Seq(
           // Embed map header count
-          MessagePack.newBufferPacker.packMapHeader(mapElementCount).toByteArray,
+          MessagePack.newPacker.packMapHeader(mapElementCount).toByteArray,
           packer.toByteArray
         )
 
@@ -102,7 +102,7 @@ class NestedMessagePackBuilder extends JSONContext[Seq[MsgPack]] with LogSupport
 
       override def result: Seq[MsgPack] = Seq(
         // Embed array header count
-        MessagePack.newBufferPacker.packArrayHeader(getElementCount).toByteArray,
+        MessagePack.newPacker.packArrayHeader(getElementCount).toByteArray,
         packer.toByteArray
       )
 

--- a/ai-core/src/main/scala/wvlet/ai/core/msgpack/json/StreamMessagePackBuilder.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/msgpack/json/StreamMessagePackBuilder.scala
@@ -45,7 +45,7 @@ object StreamMessagePackBuilder:
 
 class StreamMessagePackBuilder extends JSONContext[MsgPack] with LogSupport:
   import StreamMessagePackBuilder.*
-  protected val packer = MessagePack.newPacker
+  protected val packer = MessagePack.newPacker()
 
   protected var contextStack: List[ParseContext]         = Nil
   protected var finishedContextStack: List[ParseContext] = Nil

--- a/ai-core/src/main/scala/wvlet/ai/core/msgpack/json/StreamMessagePackBuilder.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/msgpack/json/StreamMessagePackBuilder.scala
@@ -45,7 +45,7 @@ object StreamMessagePackBuilder:
 
 class StreamMessagePackBuilder extends JSONContext[MsgPack] with LogSupport:
   import StreamMessagePackBuilder.*
-  protected val packer = MessagePack.newBufferPacker
+  protected val packer = MessagePack.newPacker
 
   protected var contextStack: List[ParseContext]         = Nil
   protected var finishedContextStack: List[ParseContext] = Nil

--- a/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/MessagePack.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/MessagePack.scala
@@ -21,7 +21,7 @@ import wvlet.ai.core.msgpack.json.{NestedMessagePackBuilder, StreamMessagePackBu
 /**
   */
 object MessagePack:
-  def newPacker(): BufferPacker               = Compat.newBufferPacker
+  def newPacker(): BufferPacker                   = Compat.newBufferPacker
   def newUnpacker(msgpack: Array[Byte]): Unpacker = Compat.newUnpacker(msgpack)
   def newUnpacker(msgpack: Array[Byte], offset: Int, len: Int): Unpacker = Compat.newUnpacker(
     msgpack,

--- a/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/MessagePack.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/MessagePack.scala
@@ -21,7 +21,7 @@ import wvlet.ai.core.msgpack.json.{NestedMessagePackBuilder, StreamMessagePackBu
 /**
   */
 object MessagePack:
-  def newPacker: BufferPacker               = Compat.newBufferPacker
+  def newPacker(): BufferPacker               = Compat.newBufferPacker
   def newUnpacker(msgpack: Array[Byte]): Unpacker = Compat.newUnpacker(msgpack)
   def newUnpacker(msgpack: Array[Byte], offset: Int, len: Int): Unpacker = Compat.newUnpacker(
     msgpack,

--- a/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/MessagePack.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/MessagePack.scala
@@ -21,7 +21,7 @@ import wvlet.ai.core.msgpack.json.{NestedMessagePackBuilder, StreamMessagePackBu
 /**
   */
 object MessagePack:
-  def newBufferPacker: BufferPacker               = Compat.newBufferPacker
+  def newPacker: BufferPacker               = Compat.newBufferPacker
   def newUnpacker(msgpack: Array[Byte]): Unpacker = Compat.newUnpacker(msgpack)
   def newUnpacker(msgpack: Array[Byte], offset: Int, len: Int): Unpacker = Compat.newUnpacker(
     msgpack,

--- a/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/Value.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/Value.scala
@@ -42,7 +42,7 @@ trait Value:
   def writeTo(packer: Packer): Unit
 
   def toMsgpack: Array[Byte] =
-    val p = MessagePack.newBufferPacker
+    val p = MessagePack.newPacker
     writeTo(p)
     p.toByteArray
 

--- a/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/Value.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/msgpack/spi/Value.scala
@@ -42,7 +42,7 @@ trait Value:
   def writeTo(packer: Packer): Unit
 
   def toMsgpack: Array[Byte] =
-    val p = MessagePack.newPacker
+    val p = MessagePack.newPacker()
     writeTo(p)
     p.toByteArray
 

--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/ObjectWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/ObjectWeaver.scala
@@ -23,7 +23,7 @@ trait ObjectWeaver[A]:
     JSONWeaver.unweave(msgpack, config)
 
   def toMsgPack(v: A, config: WeaverConfig = WeaverConfig()): MsgPack =
-    val packer = MessagePack.newPacker
+    val packer = MessagePack.newPacker()
     pack(packer, v, config)
     packer.toByteArray
 

--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/ObjectWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/ObjectWeaver.scala
@@ -23,7 +23,7 @@ trait ObjectWeaver[A]:
     JSONWeaver.unweave(msgpack, config)
 
   def toMsgPack(v: A, config: WeaverConfig = WeaverConfig()): MsgPack =
-    val packer = MessagePack.newBufferPacker
+    val packer = MessagePack.newPacker
     pack(packer, v, config)
     packer.toByteArray
 

--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/JSONWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/JSONWeaver.scala
@@ -28,7 +28,7 @@ object JSONWeaver extends ObjectWeaver[String]:
     p.writePayload(msgpack)
 
   private def toMsgPack(jsonValue: JSONValue, config: WeaverConfig): Array[Byte] =
-    val packer = MessagePack.newPacker
+    val packer = MessagePack.newPacker()
     packJsonValue(packer, jsonValue, config)
     packer.toByteArray
 

--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/JSONWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/JSONWeaver.scala
@@ -28,7 +28,7 @@ object JSONWeaver extends ObjectWeaver[String]:
     p.writePayload(msgpack)
 
   private def toMsgPack(jsonValue: JSONValue, config: WeaverConfig): Array[Byte] =
-    val packer = MessagePack.newBufferPacker
+    val packer = MessagePack.newPacker
     packJsonValue(packer, jsonValue, config)
     packer.toByteArray
 

--- a/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaverTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaverTest.scala
@@ -28,7 +28,7 @@ class PrimitiveWeaverTest extends AirSpec:
     )
 
     for (floatValue, expectedInt) <- testCases do
-      val packer = MessagePack.newPacker
+      val packer = MessagePack.newPacker()
       packer.packDouble(floatValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[Int](packed)
@@ -40,7 +40,7 @@ class PrimitiveWeaverTest extends AirSpec:
     val invalidFloats = Seq(1.5, -2.7, Double.PositiveInfinity, Double.NegativeInfinity, Double.NaN)
 
     for floatValue <- invalidFloats do
-      val packer = MessagePack.newPacker
+      val packer = MessagePack.newPacker()
       packer.packDouble(floatValue)
       val packed = packer.toByteArray
 
@@ -61,7 +61,7 @@ class PrimitiveWeaverTest extends AirSpec:
     )
 
     for (stringValue, expectedInt) <- testCases do
-      val packer = MessagePack.newPacker
+      val packer = MessagePack.newPacker()
       packer.packString(stringValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[Int](packed)
@@ -73,7 +73,7 @@ class PrimitiveWeaverTest extends AirSpec:
     val invalidStrings = Seq("hello", "1.5", "", "2147483648", "-2147483649", "0x10")
 
     for stringValue <- invalidStrings do
-      val packer = MessagePack.newPacker
+      val packer = MessagePack.newPacker()
       packer.packString(stringValue)
       val packed = packer.toByteArray
 
@@ -84,13 +84,13 @@ class PrimitiveWeaverTest extends AirSpec:
 
   test("unpack Int from BOOLEAN types") {
     // Test boolean to int conversion (true = 1, false = 0)
-    val packer1 = MessagePack.newPacker
+    val packer1 = MessagePack.newPacker()
     packer1.packBoolean(true)
     val packed1   = packer1.toByteArray
     val unpacked1 = ObjectWeaver.unweave[Int](packed1)
     unpacked1 shouldBe 1
 
-    val packer2 = MessagePack.newPacker
+    val packer2 = MessagePack.newPacker()
     packer2.packBoolean(false)
     val packed2   = packer2.toByteArray
     val unpacked2 = ObjectWeaver.unweave[Int](packed2)
@@ -99,7 +99,7 @@ class PrimitiveWeaverTest extends AirSpec:
 
   test("unpack Int from NIL type") {
     // Test nil to int conversion (nil = 0)
-    val packer = MessagePack.newPacker
+    val packer = MessagePack.newPacker()
     packer.packNil
     val packed   = packer.toByteArray
     val unpacked = ObjectWeaver.unweave[Int](packed)
@@ -108,7 +108,7 @@ class PrimitiveWeaverTest extends AirSpec:
 
   test("unpack Int from unsupported types") {
     // Test types that cannot be converted to Int
-    val packer = MessagePack.newPacker
+    val packer = MessagePack.newPacker()
     packer.packArrayHeader(2)
     packer.packInt(1)
     packer.packInt(2)
@@ -129,7 +129,7 @@ class PrimitiveWeaverTest extends AirSpec:
     )
 
     for longValue <- testCases do
-      val packer = MessagePack.newPacker
+      val packer = MessagePack.newPacker()
       packer.packLong(longValue)
       val packed = packer.toByteArray
 

--- a/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaverTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaverTest.scala
@@ -28,7 +28,7 @@ class PrimitiveWeaverTest extends AirSpec:
     )
 
     for (floatValue, expectedInt) <- testCases do
-      val packer = MessagePack.newBufferPacker
+      val packer = MessagePack.newPacker
       packer.packDouble(floatValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[Int](packed)
@@ -40,7 +40,7 @@ class PrimitiveWeaverTest extends AirSpec:
     val invalidFloats = Seq(1.5, -2.7, Double.PositiveInfinity, Double.NegativeInfinity, Double.NaN)
 
     for floatValue <- invalidFloats do
-      val packer = MessagePack.newBufferPacker
+      val packer = MessagePack.newPacker
       packer.packDouble(floatValue)
       val packed = packer.toByteArray
 
@@ -61,7 +61,7 @@ class PrimitiveWeaverTest extends AirSpec:
     )
 
     for (stringValue, expectedInt) <- testCases do
-      val packer = MessagePack.newBufferPacker
+      val packer = MessagePack.newPacker
       packer.packString(stringValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[Int](packed)
@@ -73,7 +73,7 @@ class PrimitiveWeaverTest extends AirSpec:
     val invalidStrings = Seq("hello", "1.5", "", "2147483648", "-2147483649", "0x10")
 
     for stringValue <- invalidStrings do
-      val packer = MessagePack.newBufferPacker
+      val packer = MessagePack.newPacker
       packer.packString(stringValue)
       val packed = packer.toByteArray
 
@@ -84,13 +84,13 @@ class PrimitiveWeaverTest extends AirSpec:
 
   test("unpack Int from BOOLEAN types") {
     // Test boolean to int conversion (true = 1, false = 0)
-    val packer1 = MessagePack.newBufferPacker
+    val packer1 = MessagePack.newPacker
     packer1.packBoolean(true)
     val packed1   = packer1.toByteArray
     val unpacked1 = ObjectWeaver.unweave[Int](packed1)
     unpacked1 shouldBe 1
 
-    val packer2 = MessagePack.newBufferPacker
+    val packer2 = MessagePack.newPacker
     packer2.packBoolean(false)
     val packed2   = packer2.toByteArray
     val unpacked2 = ObjectWeaver.unweave[Int](packed2)
@@ -99,7 +99,7 @@ class PrimitiveWeaverTest extends AirSpec:
 
   test("unpack Int from NIL type") {
     // Test nil to int conversion (nil = 0)
-    val packer = MessagePack.newBufferPacker
+    val packer = MessagePack.newPacker
     packer.packNil
     val packed   = packer.toByteArray
     val unpacked = ObjectWeaver.unweave[Int](packed)
@@ -108,7 +108,7 @@ class PrimitiveWeaverTest extends AirSpec:
 
   test("unpack Int from unsupported types") {
     // Test types that cannot be converted to Int
-    val packer = MessagePack.newBufferPacker
+    val packer = MessagePack.newPacker
     packer.packArrayHeader(2)
     packer.packInt(1)
     packer.packInt(2)
@@ -129,7 +129,7 @@ class PrimitiveWeaverTest extends AirSpec:
     )
 
     for longValue <- testCases do
-      val packer = MessagePack.newBufferPacker
+      val packer = MessagePack.newPacker
       packer.packLong(longValue)
       val packed = packer.toByteArray
 

--- a/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/StringWeaverTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/StringWeaverTest.scala
@@ -33,7 +33,7 @@ class StringWeaverTest extends AirSpec:
     )
 
     for (intValue, expectedStr) <- testCases do
-      val packer = MessagePack.newBufferPacker
+      val packer = MessagePack.newPacker
       packer.packInt(intValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[String](packed)
@@ -47,7 +47,7 @@ class StringWeaverTest extends AirSpec:
     val testCases = Seq((0.0, "0"), (1.0, "1"), (-1.0, "-1"), (3.14, "3.14"))
 
     for (floatValue, expectedStr) <- testCases do
-      val packer = MessagePack.newBufferPacker
+      val packer = MessagePack.newPacker
       packer.packDouble(floatValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[String](packed)
@@ -61,7 +61,7 @@ class StringWeaverTest extends AirSpec:
     val testCases = Seq((true, "true"), (false, "false"))
 
     for (booleanValue, expectedStr) <- testCases do
-      val packer = MessagePack.newBufferPacker
+      val packer = MessagePack.newPacker
       packer.packBoolean(booleanValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[String](packed)
@@ -70,7 +70,7 @@ class StringWeaverTest extends AirSpec:
 
   test("unpack String from NIL type") {
     // Test nil to String conversion (nil = empty string)
-    val packer = MessagePack.newBufferPacker
+    val packer = MessagePack.newPacker
     packer.packNil
     val packed   = packer.toByteArray
     val unpacked = ObjectWeaver.unweave[String](packed)
@@ -79,7 +79,7 @@ class StringWeaverTest extends AirSpec:
 
   test("unpack String from unsupported types") {
     // Test types that cannot be converted to String
-    val packer = MessagePack.newBufferPacker
+    val packer = MessagePack.newPacker
     packer.packArrayHeader(2)
     packer.packInt(1)
     packer.packInt(2)

--- a/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/StringWeaverTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/StringWeaverTest.scala
@@ -33,7 +33,7 @@ class StringWeaverTest extends AirSpec:
     )
 
     for (intValue, expectedStr) <- testCases do
-      val packer = MessagePack.newPacker
+      val packer = MessagePack.newPacker()
       packer.packInt(intValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[String](packed)
@@ -47,7 +47,7 @@ class StringWeaverTest extends AirSpec:
     val testCases = Seq((0.0, "0"), (1.0, "1"), (-1.0, "-1"), (3.14, "3.14"))
 
     for (floatValue, expectedStr) <- testCases do
-      val packer = MessagePack.newPacker
+      val packer = MessagePack.newPacker()
       packer.packDouble(floatValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[String](packed)
@@ -61,7 +61,7 @@ class StringWeaverTest extends AirSpec:
     val testCases = Seq((true, "true"), (false, "false"))
 
     for (booleanValue, expectedStr) <- testCases do
-      val packer = MessagePack.newPacker
+      val packer = MessagePack.newPacker()
       packer.packBoolean(booleanValue)
       val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[String](packed)
@@ -70,7 +70,7 @@ class StringWeaverTest extends AirSpec:
 
   test("unpack String from NIL type") {
     // Test nil to String conversion (nil = empty string)
-    val packer = MessagePack.newPacker
+    val packer = MessagePack.newPacker()
     packer.packNil
     val packed   = packer.toByteArray
     val unpacked = ObjectWeaver.unweave[String](packed)
@@ -79,7 +79,7 @@ class StringWeaverTest extends AirSpec:
 
   test("unpack String from unsupported types") {
     // Test types that cannot be converted to String
-    val packer = MessagePack.newPacker
+    val packer = MessagePack.newPacker()
     packer.packArrayHeader(2)
     packer.packInt(1)
     packer.packInt(2)

--- a/docs/ai-core-walkthrough.md
+++ b/docs/ai-core-walkthrough.md
@@ -212,7 +212,7 @@ AI-Core provides efficient binary serialization using MessagePack format.
 import wvlet.ai.core.msgpack.spi.{MessagePack, Packer, Unpacker}
 
 // Serialize primitive data
-val packer = MessagePack.newBufferPacker()
+val packer = MessagePack.newPacker()
 packer.packString("Alice")
 packer.packInt(30)
 val bytes = packer.toByteArray


### PR DESCRIPTION
## Summary
- Rename `MessagePack.newBufferPacker` to `MessagePack.newPacker` to simplify the API
- Update all usages across the codebase including tests and documentation
- Remove redundant "Buffer" prefix since all packers use buffer-based implementation internally

## Test plan
- [x] Compile all modules successfully
- [x] Run PrimitiveWeaverTest - all tests pass
- [x] Run StringWeaverTest - all tests pass
- [x] Update documentation with new method name

🤖 Generated with [Claude Code](https://claude.ai/code)