### PR TITLE
Support more primitive types in ObjectWeaver

### DIFF
--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
@@ -30,6 +30,14 @@ object PrimitiveWeaver:
       case e: Exception =>
         context.setError(e)
 
+  private def safeUnpackNil(context: WeaverContext, u: Unpacker): Unit =
+    try
+      u.unpackNil
+      context.setNull
+    catch
+      case e: Exception =>
+        context.setError(e)
+
   given intWeaver: ObjectWeaver[Int] =
     new ObjectWeaver[Int]:
       override def pack(p: Packer, v: Int, config: WeaverConfig): Unit = p.packInt(v)
@@ -77,12 +85,7 @@ object PrimitiveWeaver:
               case e: Exception =>
                 context.setError(e)
           case ValueType.NIL =>
-            try
-              u.unpackNil
-              context.setNull
-            catch
-              case e: Exception =>
-                context.setError(e)
+            safeUnpackNil(context, u)
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Int"))
@@ -157,13 +160,7 @@ object PrimitiveWeaver:
               context.setLong
             )
           case ValueType.NIL =>
-            safeUnpack(
-              context, {
-                u.unpackNil;
-                0L
-              },
-              context.setLong
-            )
+            safeUnpackNil(context, u)
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Long"))
@@ -191,13 +188,7 @@ object PrimitiveWeaver:
               context.setDouble
             )
           case ValueType.NIL =>
-            safeUnpack(
-              context, {
-                u.unpackNil;
-                0.0
-              },
-              context.setDouble
-            )
+            safeUnpackNil(context, u)
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Double"))
@@ -247,12 +238,7 @@ object PrimitiveWeaver:
               case e: Exception =>
                 context.setError(e)
           case ValueType.NIL =>
-            try
-              u.unpackNil
-              context.setFloat(0.0f)
-            catch
-              case e: Exception =>
-                context.setError(e)
+            safeUnpackNil(context, u)
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Float"))
@@ -299,12 +285,7 @@ object PrimitiveWeaver:
               case e: Exception =>
                 context.setError(e)
           case ValueType.NIL =>
-            try
-              u.unpackNil
-              context.setBoolean(false)
-            catch
-              case e: Exception =>
-                context.setError(e)
+            safeUnpackNil(context, u)
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Boolean"))
@@ -360,12 +341,7 @@ object PrimitiveWeaver:
               case e: Exception =>
                 context.setError(e)
           case ValueType.NIL =>
-            try
-              u.unpackNil
-              context.setByte(0.toByte)
-            catch
-              case e: Exception =>
-                context.setError(e)
+            safeUnpackNil(context, u)
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Byte"))
@@ -421,12 +397,7 @@ object PrimitiveWeaver:
               case e: Exception =>
                 context.setError(e)
           case ValueType.NIL =>
-            try
-              u.unpackNil
-              context.setShort(0.toShort)
-            catch
-              case e: Exception =>
-                context.setError(e)
+            safeUnpackNil(context, u)
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Short"))
@@ -462,12 +433,7 @@ object PrimitiveWeaver:
               case e: Exception =>
                 context.setError(e)
           case ValueType.NIL =>
-            try
-              u.unpackNil
-              context.setChar('\u0000')
-            catch
-              case e: Exception =>
-                context.setError(e)
+            safeUnpackNil(context, u)
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Char"))

--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
@@ -5,11 +5,7 @@ import wvlet.ai.core.weaver.{ObjectWeaver, WeaverConfig, WeaverContext}
 
 object PrimitiveWeaver:
 
-  private def safeUnpack[T](
-      context: WeaverContext,
-      operation: => T,
-      setValue: T => Unit
-  ): Unit =
+  private def safeUnpack[T](context: WeaverContext, operation: => T, setValue: T => Unit): Unit =
     try
       val value = operation
       setValue(value)
@@ -25,14 +21,12 @@ object PrimitiveWeaver:
       typeName: String
   ): Unit =
     try
-      val s = u.unpackString
+      val s              = u.unpackString
       val convertedValue = converter(s)
       setValue(convertedValue)
     catch
       case e: NumberFormatException =>
-        context.setError(
-          new IllegalArgumentException(s"Cannot convert string to ${typeName}", e)
-        )
+        context.setError(new IllegalArgumentException(s"Cannot convert string to ${typeName}", e))
       case e: Exception =>
         context.setError(e)
 
@@ -141,20 +135,35 @@ object PrimitiveWeaver:
             safeUnpack(context, u.unpackLong, context.setLong)
           case ValueType.FLOAT =>
             safeUnpack(
-              context,
-              {
+              context, {
                 val d = u.unpackDouble
-                if d.isWhole && d >= Long.MinValue && d <= Long.MaxValue then d.toLong
-                else throw new IllegalArgumentException(s"Cannot convert double ${d} to Long")
+                if d.isWhole && d >= Long.MinValue && d <= Long.MaxValue then
+                  d.toLong
+                else
+                  throw new IllegalArgumentException(s"Cannot convert double ${d} to Long")
               },
               context.setLong
             )
           case ValueType.STRING =>
             safeConvertFromString(context, u, _.toLong, context.setLong, "Long")
           case ValueType.BOOLEAN =>
-            safeUnpack(context, if u.unpackBoolean then 1L else 0L, context.setLong)
+            safeUnpack(
+              context,
+              if u.unpackBoolean then
+                1L
+              else
+                0L
+              ,
+              context.setLong
+            )
           case ValueType.NIL =>
-            safeUnpack(context, { u.unpackNil; 0L }, context.setLong)
+            safeUnpack(
+              context, {
+                u.unpackNil;
+                0L
+              },
+              context.setLong
+            )
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Long"))
@@ -172,9 +181,23 @@ object PrimitiveWeaver:
           case ValueType.STRING =>
             safeConvertFromString(context, u, _.toDouble, context.setDouble, "Double")
           case ValueType.BOOLEAN =>
-            safeUnpack(context, if u.unpackBoolean then 1.0 else 0.0, context.setDouble)
+            safeUnpack(
+              context,
+              if u.unpackBoolean then
+                1.0
+              else
+                0.0
+              ,
+              context.setDouble
+            )
           case ValueType.NIL =>
-            safeUnpack(context, { u.unpackNil; 0.0 }, context.setDouble)
+            safeUnpack(
+              context, {
+                u.unpackNil;
+                0.0
+              },
+              context.setDouble
+            )
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Double"))
@@ -203,14 +226,12 @@ object PrimitiveWeaver:
                 context.setError(e)
           case ValueType.STRING =>
             try
-              val s = u.unpackString
+              val s          = u.unpackString
               val floatValue = s.toFloat
               context.setFloat(floatValue)
             catch
               case e: NumberFormatException =>
-                context.setError(
-                  new IllegalArgumentException(s"Cannot convert string to Float", e)
-                )
+                context.setError(new IllegalArgumentException(s"Cannot convert string to Float", e))
               case e: Exception =>
                 context.setError(e)
           case ValueType.BOOLEAN =>
@@ -318,14 +339,12 @@ object PrimitiveWeaver:
                 context.setError(e)
           case ValueType.STRING =>
             try
-              val s = u.unpackString
+              val s         = u.unpackString
               val byteValue = s.toByte
               context.setByte(byteValue)
             catch
               case e: NumberFormatException =>
-                context.setError(
-                  new IllegalArgumentException(s"Cannot convert string to Byte", e)
-                )
+                context.setError(new IllegalArgumentException(s"Cannot convert string to Byte", e))
               case e: Exception =>
                 context.setError(e)
           case ValueType.BOOLEAN =>
@@ -381,14 +400,12 @@ object PrimitiveWeaver:
                 context.setError(e)
           case ValueType.STRING =>
             try
-              val s = u.unpackString
+              val s          = u.unpackString
               val shortValue = s.toShort
               context.setShort(shortValue)
             catch
               case e: NumberFormatException =>
-                context.setError(
-                  new IllegalArgumentException(s"Cannot convert string to Short", e)
-                )
+                context.setError(new IllegalArgumentException(s"Cannot convert string to Short", e))
               case e: Exception =>
                 context.setError(e)
           case ValueType.BOOLEAN =>

--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
@@ -100,4 +100,355 @@ object PrimitiveWeaver:
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to String"))
 
+  given longWeaver: ObjectWeaver[Long] =
+    new ObjectWeaver[Long]:
+      override def pack(p: Packer, v: Long, config: WeaverConfig): Unit = p.packLong(v)
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.INTEGER =>
+            try
+              context.setLong(u.unpackLong)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.FLOAT =>
+            try
+              val d = u.unpackDouble
+              if d.isWhole && d >= Long.MinValue && d <= Long.MaxValue then
+                context.setLong(d.toLong)
+              else
+                context.setError(new IllegalArgumentException(s"Cannot convert double ${d} to Long"))
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.STRING =>
+            val s = u.unpackString
+            try
+              val longValue = s.toLong
+              context.setLong(longValue)
+            catch
+              case e: NumberFormatException =>
+                context.setError(
+                  new IllegalArgumentException(s"Cannot convert string '${s}' to Long", e)
+                )
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.BOOLEAN =>
+            try
+              val b = u.unpackBoolean
+              context.setLong(if b then 1L else 0L)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            try
+              u.unpackNil
+              context.setLong(0L)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Long"))
+
+  given doubleWeaver: ObjectWeaver[Double] =
+    new ObjectWeaver[Double]:
+      override def pack(p: Packer, v: Double, config: WeaverConfig): Unit = p.packDouble(v)
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.FLOAT =>
+            try
+              context.setDouble(u.unpackDouble)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.INTEGER =>
+            try
+              context.setDouble(u.unpackLong.toDouble)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.STRING =>
+            val s = u.unpackString
+            try
+              val doubleValue = s.toDouble
+              context.setDouble(doubleValue)
+            catch
+              case e: NumberFormatException =>
+                context.setError(
+                  new IllegalArgumentException(s"Cannot convert string '${s}' to Double", e)
+                )
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.BOOLEAN =>
+            try
+              val b = u.unpackBoolean
+              context.setDouble(if b then 1.0 else 0.0)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            try
+              u.unpackNil
+              context.setDouble(0.0)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Double"))
+
+  given floatWeaver: ObjectWeaver[Float] =
+    new ObjectWeaver[Float]:
+      override def pack(p: Packer, v: Float, config: WeaverConfig): Unit = p.packFloat(v)
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.FLOAT =>
+            try
+              val d = u.unpackDouble
+              if d >= Float.MinValue && d <= Float.MaxValue then
+                context.setFloat(d.toFloat)
+              else
+                context.setError(new IllegalArgumentException(s"Double ${d} out of Float range"))
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.INTEGER =>
+            try
+              context.setFloat(u.unpackLong.toFloat)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.STRING =>
+            val s = u.unpackString
+            try
+              val floatValue = s.toFloat
+              context.setFloat(floatValue)
+            catch
+              case e: NumberFormatException =>
+                context.setError(
+                  new IllegalArgumentException(s"Cannot convert string '${s}' to Float", e)
+                )
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.BOOLEAN =>
+            try
+              val b = u.unpackBoolean
+              context.setFloat(if b then 1.0f else 0.0f)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            try
+              u.unpackNil
+              context.setFloat(0.0f)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Float"))
+
+  given booleanWeaver: ObjectWeaver[Boolean] =
+    new ObjectWeaver[Boolean]:
+      override def pack(p: Packer, v: Boolean, config: WeaverConfig): Unit = p.packBoolean(v)
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.BOOLEAN =>
+            try
+              context.setBoolean(u.unpackBoolean)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.INTEGER =>
+            try
+              val i = u.unpackLong
+              context.setBoolean(i != 0)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.FLOAT =>
+            try
+              val d = u.unpackDouble
+              context.setBoolean(d != 0.0)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.STRING =>
+            val s = u.unpackString
+            s.toLowerCase match
+              case "true" | "1" | "yes" | "on" =>
+                context.setBoolean(true)
+              case "false" | "0" | "no" | "off" | "" =>
+                context.setBoolean(false)
+              case _ =>
+                context.setError(
+                  new IllegalArgumentException(s"Cannot convert string '${s}' to Boolean")
+                )
+          case ValueType.NIL =>
+            try
+              u.unpackNil
+              context.setBoolean(false)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Boolean"))
+
+  given byteWeaver: ObjectWeaver[Byte] =
+    new ObjectWeaver[Byte]:
+      override def pack(p: Packer, v: Byte, config: WeaverConfig): Unit = p.packByte(v)
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.INTEGER =>
+            try
+              val l = u.unpackLong
+              if l >= Byte.MinValue && l <= Byte.MaxValue then
+                context.setByte(l.toByte)
+              else
+                context.setError(new IllegalArgumentException(s"Long ${l} out of Byte range"))
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.FLOAT =>
+            try
+              val d = u.unpackDouble
+              if d.isWhole && d >= Byte.MinValue && d <= Byte.MaxValue then
+                context.setByte(d.toByte)
+              else
+                context.setError(new IllegalArgumentException(s"Cannot convert double ${d} to Byte"))
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.STRING =>
+            val s = u.unpackString
+            try
+              val byteValue = s.toByte
+              context.setByte(byteValue)
+            catch
+              case e: NumberFormatException =>
+                context.setError(
+                  new IllegalArgumentException(s"Cannot convert string '${s}' to Byte", e)
+                )
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.BOOLEAN =>
+            try
+              val b = u.unpackBoolean
+              context.setByte(if b then 1.toByte else 0.toByte)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            try
+              u.unpackNil
+              context.setByte(0.toByte)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Byte"))
+
+  given shortWeaver: ObjectWeaver[Short] =
+    new ObjectWeaver[Short]:
+      override def pack(p: Packer, v: Short, config: WeaverConfig): Unit = p.packShort(v)
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.INTEGER =>
+            try
+              val l = u.unpackLong
+              if l >= Short.MinValue && l <= Short.MaxValue then
+                context.setShort(l.toShort)
+              else
+                context.setError(new IllegalArgumentException(s"Long ${l} out of Short range"))
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.FLOAT =>
+            try
+              val d = u.unpackDouble
+              if d.isWhole && d >= Short.MinValue && d <= Short.MaxValue then
+                context.setShort(d.toShort)
+              else
+                context.setError(new IllegalArgumentException(s"Cannot convert double ${d} to Short"))
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.STRING =>
+            val s = u.unpackString
+            try
+              val shortValue = s.toShort
+              context.setShort(shortValue)
+            catch
+              case e: NumberFormatException =>
+                context.setError(
+                  new IllegalArgumentException(s"Cannot convert string '${s}' to Short", e)
+                )
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.BOOLEAN =>
+            try
+              val b = u.unpackBoolean
+              context.setShort(if b then 1.toShort else 0.toShort)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            try
+              u.unpackNil
+              context.setShort(0.toShort)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Short"))
+
+  given charWeaver: ObjectWeaver[Char] =
+    new ObjectWeaver[Char]:
+      override def pack(p: Packer, v: Char, config: WeaverConfig): Unit = p.packString(v.toString)
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.STRING =>
+            try
+              val s = u.unpackString
+              if s.length == 1 then
+                context.setChar(s.charAt(0))
+              else
+                context.setError(
+                  new IllegalArgumentException(s"Cannot convert string '${s}' to Char - must be single character")
+                )
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.INTEGER =>
+            try
+              val l = u.unpackLong
+              if l >= Char.MinValue && l <= Char.MaxValue then
+                context.setChar(l.toChar)
+              else
+                context.setError(new IllegalArgumentException(s"Long ${l} out of Char range"))
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            try
+              u.unpackNil
+              context.setChar('\u0000')
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Char"))
+
 end PrimitiveWeaver

--- a/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaverTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaverTest.scala
@@ -44,9 +44,10 @@ class PrimitiveWeaverTest extends AirSpec:
       packer.packDouble(floatValue)
       val packed = packer.toByteArray
 
-      intercept[Exception] {
+      val exception = intercept[IllegalArgumentException] {
         ObjectWeaver.unweave[Int](packed)
       }
+      exception.getMessage.contains("Cannot convert double") shouldBe true
   }
 
   test("unpack Int from STRING types") {
@@ -77,9 +78,10 @@ class PrimitiveWeaverTest extends AirSpec:
       packer.packString(stringValue)
       val packed = packer.toByteArray
 
-      intercept[Exception] {
+      val exception = intercept[IllegalArgumentException] {
         ObjectWeaver.unweave[Int](packed)
       }
+      exception.getMessage.contains("Cannot convert string") shouldBe true
   }
 
   test("unpack Int from BOOLEAN types") {
@@ -140,9 +142,9 @@ class PrimitiveWeaverTest extends AirSpec:
 
   test("Long weaver basic operations") {
     val longValues = Seq(0L, 1L, -1L, Long.MaxValue, Long.MinValue, 9223372036854775807L)
-    
+
     for longValue <- longValues do
-      val packed = ObjectWeaver.weave(longValue)
+      val packed   = ObjectWeaver.weave(longValue)
       val unpacked = ObjectWeaver.unweave[Long](packed)
       unpacked shouldBe longValue
   }
@@ -151,48 +153,85 @@ class PrimitiveWeaverTest extends AirSpec:
     // From boolean
     val packerBool = MessagePack.newPacker()
     packerBool.packBoolean(true)
-    val packedBool = packerBool.toByteArray
+    val packedBool   = packerBool.toByteArray
     val unpackedBool = ObjectWeaver.unweave[Long](packedBool)
     unpackedBool shouldBe 1L
 
     // From string
     val packerStr = MessagePack.newPacker()
     packerStr.packString("42")
-    val packedStr = packerStr.toByteArray
+    val packedStr   = packerStr.toByteArray
     val unpackedStr = ObjectWeaver.unweave[Long](packedStr)
     unpackedStr shouldBe 42L
 
     // From nil
     val packerNil = MessagePack.newPacker()
     packerNil.packNil
-    val packedNil = packerNil.toByteArray
+    val packedNil   = packerNil.toByteArray
     val unpackedNil = ObjectWeaver.unweave[Long](packedNil)
     unpackedNil shouldBe 0L
+
+    // From float (whole number)
+    val packerFloat = MessagePack.newPacker()
+    packerFloat.packDouble(123.0)
+    val packedFloat   = packerFloat.toByteArray
+    val unpackedFloat = ObjectWeaver.unweave[Long](packedFloat)
+    unpackedFloat shouldBe 123L
   }
 
   test("Double weaver basic operations") {
     val doubleValues = Seq(0.0, 1.0, -1.0, 3.14159, Double.MaxValue, Double.MinValue)
-    
+
     for doubleValue <- doubleValues do
-      val packed = ObjectWeaver.weave(doubleValue)
+      val packed   = ObjectWeaver.weave(doubleValue)
       val unpacked = ObjectWeaver.unweave[Double](packed)
       unpacked shouldBe doubleValue
   }
 
+  test("Double weaver from various types") {
+    // From integer
+    val packerInt = MessagePack.newPacker()
+    packerInt.packLong(42L)
+    val packedInt   = packerInt.toByteArray
+    val unpackedInt = ObjectWeaver.unweave[Double](packedInt)
+    unpackedInt shouldBe 42.0
+
+    // From string
+    val packerStr = MessagePack.newPacker()
+    packerStr.packString("3.14")
+    val packedStr   = packerStr.toByteArray
+    val unpackedStr = ObjectWeaver.unweave[Double](packedStr)
+    unpackedStr shouldBe 3.14
+
+    // From boolean
+    val packerBool = MessagePack.newPacker()
+    packerBool.packBoolean(false)
+    val packedBool   = packerBool.toByteArray
+    val unpackedBool = ObjectWeaver.unweave[Double](packedBool)
+    unpackedBool shouldBe 0.0
+
+    // From nil
+    val packerNil = MessagePack.newPacker()
+    packerNil.packNil
+    val packedNil   = packerNil.toByteArray
+    val unpackedNil = ObjectWeaver.unweave[Double](packedNil)
+    unpackedNil shouldBe 0.0
+  }
+
   test("Float weaver basic operations") {
     val floatValues = Seq(0.0f, 1.0f, -1.0f, 3.14f, Float.MaxValue, Float.MinValue)
-    
+
     for floatValue <- floatValues do
-      val packed = ObjectWeaver.weave(floatValue)
+      val packed   = ObjectWeaver.weave(floatValue)
       val unpacked = ObjectWeaver.unweave[Float](packed)
       unpacked shouldBe floatValue
   }
 
   test("Boolean weaver basic operations") {
     val boolValues = Seq(true, false)
-    
+
     for boolValue <- boolValues do
-      val packed = ObjectWeaver.weave(boolValue)
+      val packed   = ObjectWeaver.weave(boolValue)
       val unpacked = ObjectWeaver.unweave[Boolean](packed)
       unpacked shouldBe boolValue
   }
@@ -201,14 +240,14 @@ class PrimitiveWeaverTest extends AirSpec:
     // From integer - non-zero is true
     val packerInt = MessagePack.newPacker()
     packerInt.packInt(5)
-    val packedInt = packerInt.toByteArray
+    val packedInt   = packerInt.toByteArray
     val unpackedInt = ObjectWeaver.unweave[Boolean](packedInt)
     unpackedInt shouldBe true
 
     // From integer - zero is false
     val packerZero = MessagePack.newPacker()
     packerZero.packInt(0)
-    val packedZero = packerZero.toByteArray
+    val packedZero   = packerZero.toByteArray
     val unpackedZero = ObjectWeaver.unweave[Boolean](packedZero)
     unpackedZero shouldBe false
 
@@ -217,7 +256,7 @@ class PrimitiveWeaverTest extends AirSpec:
     for trueStr <- trueStrings do
       val packer = MessagePack.newPacker()
       packer.packString(trueStr)
-      val packed = packer.toByteArray
+      val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[Boolean](packed)
       unpacked shouldBe true
 
@@ -226,16 +265,16 @@ class PrimitiveWeaverTest extends AirSpec:
     for falseStr <- falseStrings do
       val packer = MessagePack.newPacker()
       packer.packString(falseStr)
-      val packed = packer.toByteArray
+      val packed   = packer.toByteArray
       val unpacked = ObjectWeaver.unweave[Boolean](packed)
       unpacked shouldBe false
   }
 
   test("Byte weaver basic operations") {
     val byteValues = Seq(0.toByte, 1.toByte, -1.toByte, Byte.MaxValue, Byte.MinValue)
-    
+
     for byteValue <- byteValues do
-      val packed = ObjectWeaver.weave(byteValue)
+      val packed   = ObjectWeaver.weave(byteValue)
       val unpacked = ObjectWeaver.unweave[Byte](packed)
       unpacked shouldBe byteValue
   }
@@ -245,17 +284,18 @@ class PrimitiveWeaverTest extends AirSpec:
     val packer = MessagePack.newPacker()
     packer.packInt(300) // Outside byte range
     val packed = packer.toByteArray
-    
-    intercept[Exception] {
+
+    val exception = intercept[IllegalArgumentException] {
       ObjectWeaver.unweave[Byte](packed)
     }
+    exception.getMessage.contains("out of Byte range") shouldBe true
   }
 
   test("Short weaver basic operations") {
     val shortValues = Seq(0.toShort, 1.toShort, -1.toShort, Short.MaxValue, Short.MinValue)
-    
+
     for shortValue <- shortValues do
-      val packed = ObjectWeaver.weave(shortValue)
+      val packed   = ObjectWeaver.weave(shortValue)
       val unpacked = ObjectWeaver.unweave[Short](packed)
       unpacked shouldBe shortValue
   }
@@ -265,7 +305,7 @@ class PrimitiveWeaverTest extends AirSpec:
     val packer = MessagePack.newPacker()
     packer.packInt(50000) // Outside short range
     val packed = packer.toByteArray
-    
+
     intercept[Exception] {
       ObjectWeaver.unweave[Short](packed)
     }
@@ -273,9 +313,9 @@ class PrimitiveWeaverTest extends AirSpec:
 
   test("Char weaver basic operations") {
     val charValues = Seq('a', 'Z', '0', '9', ' ', '\n', '\u0000', '\uFFFF')
-    
+
     for charValue <- charValues do
-      val packed = ObjectWeaver.weave(charValue)
+      val packed   = ObjectWeaver.weave(charValue)
       val unpacked = ObjectWeaver.unweave[Char](packed)
       unpacked shouldBe charValue
   }
@@ -284,7 +324,7 @@ class PrimitiveWeaverTest extends AirSpec:
     // Single character string
     val packer = MessagePack.newPacker()
     packer.packString("A")
-    val packed = packer.toByteArray
+    val packed   = packer.toByteArray
     val unpacked = ObjectWeaver.unweave[Char](packed)
     unpacked shouldBe 'A'
   }
@@ -294,7 +334,7 @@ class PrimitiveWeaverTest extends AirSpec:
     val packer = MessagePack.newPacker()
     packer.packString("AB")
     val packed = packer.toByteArray
-    
+
     intercept[Exception] {
       ObjectWeaver.unweave[Char](packed)
     }
@@ -304,7 +344,7 @@ class PrimitiveWeaverTest extends AirSpec:
     // Character code conversion
     val packer = MessagePack.newPacker()
     packer.packInt(65) // ASCII 'A'
-    val packed = packer.toByteArray
+    val packed   = packer.toByteArray
     val unpacked = ObjectWeaver.unweave[Char](packed)
     unpacked shouldBe 'A'
   }

--- a/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaverTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaverTest.scala
@@ -100,7 +100,7 @@ class PrimitiveWeaverTest extends AirSpec:
   }
 
   test("unpack Int from NIL type") {
-    // Test nil to int conversion (nil = 0)
+    // Test nil should result in null context, which returns 0 as default
     val packer = MessagePack.newPacker()
     packer.packNil
     val packed   = packer.toByteArray
@@ -164,7 +164,7 @@ class PrimitiveWeaverTest extends AirSpec:
     val unpackedStr = ObjectWeaver.unweave[Long](packedStr)
     unpackedStr shouldBe 42L
 
-    // From nil
+    // From nil (should return default value for Long type)
     val packerNil = MessagePack.newPacker()
     packerNil.packNil
     val packedNil   = packerNil.toByteArray
@@ -210,7 +210,7 @@ class PrimitiveWeaverTest extends AirSpec:
     val unpackedBool = ObjectWeaver.unweave[Double](packedBool)
     unpackedBool shouldBe 0.0
 
-    // From nil
+    // From nil (should return default value for Double type)
     val packerNil = MessagePack.newPacker()
     packerNil.packNil
     val packedNil   = packerNil.toByteArray


### PR DESCRIPTION
## Summary
- Add ObjectWeaver implementations for Long, Double, Float, Boolean, Byte, Short, and Char primitive types
- Previously, only Int and String primitive types were supported in ObjectWeaver
- All new implementations include comprehensive type conversion support and proper error handling

## Test plan
- [x] All existing tests continue to pass
- [x] New comprehensive test suite covers all primitive types with various conversion scenarios
- [x] Range validation tests for numeric types (Byte, Short, Float)
- [x] String parsing tests for Boolean with flexible true/false values
- [x] Char conversion tests from single-character strings and integer char codes
- [x] Error handling tests for unsupported type conversions

🤖 Generated with [Claude Code](https://claude.ai/code)