### PR TITLE
feature: Add List type support to ObjectWeaver

### DIFF
--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
@@ -2,6 +2,7 @@ package wvlet.ai.core.weaver.codec
 
 import wvlet.ai.core.msgpack.spi.{Packer, Unpacker, ValueType}
 import wvlet.ai.core.weaver.{ObjectWeaver, WeaverConfig, WeaverContext}
+import scala.collection.mutable.ListBuffer
 
 object PrimitiveWeaver:
 
@@ -390,5 +391,42 @@ object PrimitiveWeaver:
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Char"))
+
+  given listWeaver[A](using elementWeaver: ObjectWeaver[A]): ObjectWeaver[List[A]] =
+    new ObjectWeaver[List[A]]:
+      override def pack(p: Packer, v: List[A], config: WeaverConfig): Unit =
+        p.packArrayHeader(v.size)
+        v.foreach(elementWeaver.pack(p, _, config))
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.ARRAY =>
+            try
+              val arraySize = u.unpackArrayHeader
+              val buffer    = ListBuffer.empty[A]
+
+              var i        = 0
+              var hasError = false
+              while i < arraySize && !hasError do
+                val elementContext = WeaverContext(context.config)
+                elementWeaver.unpack(u, elementContext)
+
+                if elementContext.hasError then
+                  context.setError(elementContext.getError.get)
+                  hasError = true
+                else
+                  buffer += elementContext.getLastValue.asInstanceOf[A]
+                  i += 1
+
+              if !hasError then
+                context.setObject(buffer.toList)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            safeUnpackNil(context, u)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to List"))
 
 end PrimitiveWeaver

--- a/ai-core/src/test/scala/wvlet/ai/core/weaver/WeaverTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/weaver/WeaverTest.scala
@@ -31,3 +31,40 @@ class WeaverTest extends AirSpec:
     val v2   = ObjectWeaver.fromJson[String](json)
     v shouldBe v2
   }
+
+  test("weave List[Int]") {
+    val v       = List(1, 2, 3, 4, 5)
+    val msgpack = ObjectWeaver.weave(v)
+    val v2      = ObjectWeaver.unweave[List[Int]](msgpack)
+    v shouldBe v2
+  }
+
+  test("weave empty List[Int]") {
+    val v       = List.empty[Int]
+    val msgpack = ObjectWeaver.weave(v)
+    val v2      = ObjectWeaver.unweave[List[Int]](msgpack)
+    v shouldBe v2
+  }
+
+  test("weave List[String]") {
+    val v       = List("hello", "world", "test")
+    val msgpack = ObjectWeaver.weave(v)
+    val v2      = ObjectWeaver.unweave[List[String]](msgpack)
+    v shouldBe v2
+  }
+
+  test("List[Int] toJson") {
+    val v    = List(1, 2, 3)
+    val json = ObjectWeaver.toJson(v)
+    val v2   = ObjectWeaver.fromJson[List[Int]](json)
+    v shouldBe v2
+  }
+
+  test("nested List[List[Int]]") {
+    val v       = List(List(1, 2), List(3, 4), List(5))
+    val msgpack = ObjectWeaver.weave(v)
+    val v2      = ObjectWeaver.unweave[List[List[Int]]](msgpack)
+    v shouldBe v2
+  }
+
+end WeaverTest


### PR DESCRIPTION
## Summary
- Add generic `listWeaver` given instance for List[A] types in PrimitiveWeaver
- Implement proper array packing/unpacking with MessagePack format
- Add comprehensive test coverage for various List scenarios

## Test plan
- [x] Test List[Int] serialization/deserialization  
- [x] Test empty List handling
- [x] Test List[String] support
- [x] Test JSON conversion for List types
- [x] Test nested List[List[Int]] structures
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)