### PR TITLE
fix: StringWeaver now returns null for NIL MessagePack input

### DIFF
--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
@@ -119,12 +119,7 @@ object PrimitiveWeaver:
           case ValueType.BOOLEAN =>
             withSafeUnpack(context, u.unpackBoolean, _.toString)
           case ValueType.NIL =>
-            try
-              u.unpackNil
-              context.setString("")
-            catch
-              case e: Exception =>
-                context.setError(e)
+            safeUnpackNil(context, u)
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to String"))

--- a/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/StringWeaverTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/weaver/codec/StringWeaverTest.scala
@@ -69,12 +69,12 @@ class StringWeaverTest extends AirSpec:
   }
 
   test("unpack String from NIL type") {
-    // Test nil to String conversion (nil = empty string)
+    // Test nil to String conversion (nil = null)
     val packer = MessagePack.newPacker()
     packer.packNil
     val packed   = packer.toByteArray
     val unpacked = ObjectWeaver.unweave[String](packed)
-    unpacked shouldBe ""
+    unpacked shouldBe null
   }
 
   test("unpack String from unsupported types") {


### PR DESCRIPTION
## Summary
- Fix StringWeaver to return `null` for NIL MessagePack input instead of empty string
- Update test to verify the correct behavior
- Make StringWeaver consistent with other primitive weavers' NIL handling

## Test plan
- [x] Updated existing test to expect `null` for NIL input
- [x] Verified all StringWeaver tests pass
- [x] Verified all primitive weaver tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)