### PR TITLE
feature: Add Map type support to ObjectWeaver

### DIFF
--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
@@ -428,4 +428,70 @@ object PrimitiveWeaver:
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to List"))
 
+  given mapWeaver[K, V](using
+      keyWeaver: ObjectWeaver[K],
+      valueWeaver: ObjectWeaver[V]
+  ): ObjectWeaver[Map[K, V]] =
+    new ObjectWeaver[Map[K, V]]:
+      override def pack(p: Packer, v: Map[K, V], config: WeaverConfig): Unit =
+        p.packMapHeader(v.size)
+        v.foreach { case (key, value) =>
+          keyWeaver.pack(p, key, config)
+          valueWeaver.pack(p, value, config)
+        }
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.MAP =>
+            try
+              val mapSize = u.unpackMapHeader
+              val buffer  = scala.collection.mutable.Map.empty[K, V]
+
+              var i        = 0
+              var hasError = false
+              while i < mapSize && !hasError do
+                // Unpack key
+                val keyContext = WeaverContext(context.config)
+                keyWeaver.unpack(u, keyContext)
+
+                if keyContext.hasError then
+                  context.setError(keyContext.getError.get)
+                  hasError = true
+                  // Skip remaining pairs to keep unpacker in consistent state
+                  while i < mapSize do
+                    u.skipValue // Skip remaining key if this was a value error
+                    u.skipValue // Skip value
+                    i += 1
+                else
+                  val key = keyContext.getLastValue.asInstanceOf[K]
+
+                  // Unpack value
+                  val valueContext = WeaverContext(context.config)
+                  valueWeaver.unpack(u, valueContext)
+
+                  if valueContext.hasError then
+                    context.setError(valueContext.getError.get)
+                    hasError = true
+                    // Skip remaining pairs to keep unpacker in consistent state
+                    while i + 1 < mapSize do
+                      u.skipValue // Skip key
+                      u.skipValue // Skip value
+                      i += 1
+                  else
+                    val value = valueContext.getLastValue.asInstanceOf[V]
+                    buffer += (key -> value)
+                    i += 1
+              end while
+
+              if !hasError then
+                context.setObject(buffer.toMap)
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            safeUnpackNil(context, u)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to Map"))
+
 end PrimitiveWeaver

--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
@@ -459,7 +459,7 @@ object PrimitiveWeaver:
                   hasError = true
                   // Skip remaining pairs to keep unpacker in consistent state
                   while i < mapSize do
-                    u.skipValue // Skip remaining key if this was a value error
+                    u.skipValue // Skip key
                     u.skipValue // Skip value
                     i += 1
                 else

--- a/ai-core/src/test/scala/wvlet/ai/core/weaver/WeaverTest.scala
+++ b/ai-core/src/test/scala/wvlet/ai/core/weaver/WeaverTest.scala
@@ -90,4 +90,98 @@ class WeaverTest extends AirSpec:
     result.get.getMessage.contains("Cannot convert") shouldBe true
   }
 
+  test("weave Map[String, Int]") {
+    val v       = Map("a" -> 1, "b" -> 2, "c" -> 3)
+    val msgpack = ObjectWeaver.weave(v)
+    val v2      = ObjectWeaver.unweave[Map[String, Int]](msgpack)
+    v shouldBe v2
+  }
+
+  test("weave empty Map[String, Int]") {
+    val v       = Map.empty[String, Int]
+    val msgpack = ObjectWeaver.weave(v)
+    val v2      = ObjectWeaver.unweave[Map[String, Int]](msgpack)
+    v shouldBe v2
+  }
+
+  test("weave Map[Int, String]") {
+    val v       = Map(1 -> "one", 2 -> "two", 3 -> "three")
+    val msgpack = ObjectWeaver.weave(v)
+    val v2      = ObjectWeaver.unweave[Map[Int, String]](msgpack)
+    v shouldBe v2
+  }
+
+  test("Map[String, Int] toJson") {
+    val v    = Map("x" -> 10, "y" -> 20)
+    val json = ObjectWeaver.toJson(v)
+    val v2   = ObjectWeaver.fromJson[Map[String, Int]](json)
+    v shouldBe v2
+  }
+
+  test("nested Map[String, List[Int]]") {
+    val v       = Map("numbers" -> List(1, 2, 3), "more" -> List(4, 5), "empty" -> List.empty[Int])
+    val msgpack = ObjectWeaver.weave(v)
+    val v2      = ObjectWeaver.unweave[Map[String, List[Int]]](msgpack)
+    v shouldBe v2
+  }
+
+  test("nested Map[String, Map[String, Int]]") {
+    val v = Map(
+      "group1" -> Map("a" -> 1, "b" -> 2),
+      "group2" -> Map("x" -> 10, "y" -> 20),
+      "empty"  -> Map.empty[String, Int]
+    )
+    val msgpack = ObjectWeaver.weave(v)
+    val v2      = ObjectWeaver.unweave[Map[String, Map[String, Int]]](msgpack)
+    v shouldBe v2
+  }
+
+  test("handle malformed map data gracefully") {
+    import wvlet.ai.core.msgpack.spi.MessagePack
+    // Create a malformed msgpack where we claim there are more pairs than we provide
+    val packer = MessagePack.newPacker()
+    packer.packMapHeader(3)   // Say we have 3 key-value pairs
+    packer.packString("key1") // Valid first key
+    packer.packInt(1)         // Valid first value
+    packer.packString("key2") // Valid second key
+    packer.packInt(2)         // Valid second value
+    // Missing third key-value pair!
+
+    val malformedMsgpack = packer.toByteArray
+
+    val result =
+      try
+        ObjectWeaver.unweave[Map[String, Int]](malformedMsgpack)
+        None
+      catch
+        case e: Exception =>
+          Some(e)
+
+    result.isDefined shouldBe true
+  }
+
+  test("handle malformed map value gracefully") {
+    import wvlet.ai.core.msgpack.spi.MessagePack
+    // Create a malformed msgpack map with wrong value type
+    val packer = MessagePack.newPacker()
+    packer.packMapHeader(2)      // Say we have 2 key-value pairs
+    packer.packString("key1")    // Valid first key
+    packer.packInt(1)            // Valid first value
+    packer.packString("key2")    // Valid second key
+    packer.packString("invalid") // Invalid second value for Map[String, Int]
+
+    val malformedMsgpack = packer.toByteArray
+
+    val result =
+      try
+        ObjectWeaver.unweave[Map[String, Int]](malformedMsgpack)
+        None
+      catch
+        case e: Exception =>
+          Some(e)
+
+    result.isDefined shouldBe true
+    result.get.getMessage.contains("Cannot convert") shouldBe true
+  }
+
 end WeaverTest


### PR DESCRIPTION
## Summary
- Add Map[K, V] serialization/deserialization support to ObjectWeaver
- Extends existing primitive weaver system to handle Maps with any key/value types that have ObjectWeaver instances
- Follows same patterns as List support for consistency and maintainability

## Features Added
- **Map serialization**: Convert Map[K, V] to MessagePack format using map headers
- **Map deserialization**: Reconstruct Maps from MessagePack with proper error handling
- **Type safety**: Uses given instances to ensure both keys and values have proper ObjectWeaver support
- **Nested support**: Works with nested Maps and Maps containing Lists or other complex types
- **JSON support**: Maps work seamlessly with toJson/fromJson functionality

## Test Coverage
- Basic Map[String, Int] and Map[Int, String] operations
- Empty Map handling
- JSON serialization/deserialization
- Nested Maps: Map[String, List[Int]] and Map[String, Map[String, Int]]
- Error handling for malformed MessagePack data
- Graceful handling of type conversion errors

## Implementation Details
- Leverages MessagePack MAP type for efficient binary serialization
- Uses mutable.Map as intermediate buffer during deserialization for performance
- Comprehensive error handling with proper unpacker state management
- Follows existing code patterns from List weaver implementation

🤖 Generated with [Claude Code](https://claude.ai/code)