### PR TITLE
feature: Add ListMap support to ObjectWeaver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,10 @@ sbt integrationTest/test
 - Follow .github/pull_request_template.md format
 - Merge with squash via `gh pr merge --squash --auto` for clean history
 
+### Code Reviews
+
+- Gemini will review pull requests for code quality, adherence to guidelines, and test coverage. Reflect on feedback and make necessary changes.
+
 ## Important Implementation Notes
 
 - BedrockChat implements streaming responses using AWS SDK's ConverseStream API

--- a/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
+++ b/ai-core/src/main/scala/wvlet/ai/core/weaver/codec/PrimitiveWeaver.scala
@@ -567,4 +567,74 @@ object PrimitiveWeaver:
               new IllegalArgumentException(s"Cannot convert ${other} to java.util.List")
             )
 
+  given listMapWeaver[K, V](using
+      keyWeaver: ObjectWeaver[K],
+      valueWeaver: ObjectWeaver[V]
+  ): ObjectWeaver[scala.collection.immutable.ListMap[K, V]] =
+    new ObjectWeaver[scala.collection.immutable.ListMap[K, V]]:
+      override def pack(
+          p: Packer,
+          v: scala.collection.immutable.ListMap[K, V],
+          config: WeaverConfig
+      ): Unit =
+        p.packMapHeader(v.size)
+        v.foreach { case (key, value) =>
+          keyWeaver.pack(p, key, config)
+          valueWeaver.pack(p, value, config)
+        }
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.MAP =>
+            try
+              val mapSize = u.unpackMapHeader
+              val buffer  = scala.collection.mutable.ListBuffer.empty[(K, V)]
+
+              var i        = 0
+              var hasError = false
+              while i < mapSize && !hasError do
+                // Unpack key
+                val keyContext = WeaverContext(context.config)
+                keyWeaver.unpack(u, keyContext)
+
+                if keyContext.hasError then
+                  context.setError(keyContext.getError.get)
+                  hasError = true
+                  // Skip remaining pairs to keep unpacker in consistent state
+                  while i < mapSize do
+                    u.skipValue // Skip key
+                    u.skipValue // Skip value
+                    i += 1
+                else
+                  val key = keyContext.getLastValue.asInstanceOf[K]
+
+                  // Unpack value
+                  val valueContext = WeaverContext(context.config)
+                  valueWeaver.unpack(u, valueContext)
+
+                  if valueContext.hasError then
+                    context.setError(valueContext.getError.get)
+                    hasError = true
+                    // Skip remaining pairs to keep unpacker in consistent state
+                    while i + 1 < mapSize do
+                      u.skipValue // Skip key
+                      u.skipValue // Skip value
+                      i += 1
+                  else
+                    val value = valueContext.getLastValue.asInstanceOf[V]
+                    buffer += (key -> value)
+                    i += 1
+              end while
+
+              if !hasError then
+                context.setObject(scala.collection.immutable.ListMap.from(buffer))
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            safeUnpackNil(context, u)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to ListMap"))
+
 end PrimitiveWeaver


### PR DESCRIPTION
## Summary
- Add serialization/deserialization support for `scala.collection.immutable.ListMap`
- ListMap preserves insertion order of key-value pairs, unlike regular Map
- Includes comprehensive tests covering basic operations, JSON serialization, nested structures, and error handling

## Test plan
- [x] Basic ListMap serialization/deserialization 
- [x] Empty ListMap handling
- [x] JSON round-trip conversion
- [x] Nested ListMap structures
- [x] Insertion order preservation verification
- [x] Error handling for malformed data
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)