### PR TITLE
Configure Scala Steward to reduce AWS SDK update frequency

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,19 @@
+# Scala Steward Configuration
+
+# Limit update frequency for AWS SDK dependencies
+dependencyOverrides = [
+  {
+    dependency = { groupId = "software.amazon.awssdk" },
+    pullRequests = { frequency = "7 days" }
+  }
+]
+
+# Group AWS SDK updates together in a single PR
+pullRequests.grouping = [
+  {
+    name = "aws-sdk",
+    filter = [
+      { group = "software.amazon.awssdk" }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Add `.scala-steward.conf` to limit AWS SDK dependency updates to weekly frequency
- Group AWS SDK updates together in a single PR
- Reduces automated PR noise from daily bedrockruntime updates

## Motivation
The project has been receiving daily automated PRs for bedrockruntime updates (2.31.66 → 2.31.70 in just 5 days). This configuration reduces the update frequency to weekly while still keeping dependencies reasonably up-to-date.

## Changes
- Created `.scala-steward.conf` with:
  - Weekly update frequency limit for `software.amazon.awssdk` group
  - Grouping of all AWS SDK updates into a single PR

## Test plan
- [x] Configuration follows [Scala Steward documentation](https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md)
- [ ] Scala Steward will respect this configuration on next scheduled run

🤖 Generated with [Claude Code](https://claude.ai/code)