### PR TITLE
Add MCP (Model Context Protocol) client implementation (Phase 2)

### DIFF
--- a/ai-agent/src/main/scala/wvlet/ai/agent/mcp/JsonRpc.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/mcp/JsonRpc.scala
@@ -1,0 +1,87 @@
+package wvlet.ai.agent.mcp
+
+import wvlet.airframe.codec.MessageCodec
+
+/**
+  * JSON-RPC 2.0 protocol messages for MCP communication.
+  *
+  * Based on: https://www.jsonrpc.org/specification
+  */
+object JsonRpc:
+
+  /**
+    * JSON-RPC request message
+    */
+  case class Request(
+      jsonrpc: String = "2.0",
+      id: Option[Any],
+      method: String,
+      params: Option[Map[String, Any]] = None
+  ):
+    def withParams(params: Map[String, Any]): Request = copy(params = Some(params))
+    def noParams: Request                             = copy(params = None)
+
+  /**
+    * JSON-RPC response message
+    */
+  case class Response(
+      jsonrpc: String = "2.0",
+      id: Option[Any],
+      result: Option[Any] = None,
+      error: Option[ErrorObject] = None
+  )
+
+  /**
+    * JSON-RPC error object
+    */
+  case class ErrorObject(code: Int, message: String, data: Option[Any] = None)
+
+  /**
+    * JSON-RPC notification (request without id)
+    */
+  case class Notification(
+      jsonrpc: String = "2.0",
+      method: String,
+      params: Option[Map[String, Any]] = None
+  ):
+    def withParams(params: Map[String, Any]): Notification = copy(params = Some(params))
+    def noParams: Notification                             = copy(params = None)
+
+  /**
+    * Standard JSON-RPC error codes
+    */
+  object ErrorCode:
+    val ParseError     = -32700
+    val InvalidRequest = -32600
+    val MethodNotFound = -32601
+    val InvalidParams  = -32602
+    val InternalError  = -32603
+
+  /**
+    * Parse a JSON string into a JSON-RPC message
+    */
+  def parse(json: String): Either[ErrorObject, Request | Response | Notification] =
+    try
+      val parsed = MessageCodec.fromJson[Map[String, Any]](json)
+      // Check if it has an id field to distinguish request/response from notification
+      val hasId     = parsed.contains("id")
+      val hasMethod = parsed.contains("method")
+      val hasResult = parsed.contains("result")
+      val hasError  = parsed.contains("error")
+
+      if hasMethod && hasId then
+        val codec = MessageCodec.of[Request]
+        Right(codec.fromMap(parsed))
+      else if hasMethod && !hasId then
+        val codec = MessageCodec.of[Notification]
+        Right(codec.fromMap(parsed))
+      else if hasResult || hasError then
+        val codec = MessageCodec.of[Response]
+        Right(codec.fromMap(parsed))
+      else
+        Left(ErrorObject(ErrorCode.InvalidRequest, "Invalid JSON-RPC message format"))
+    catch
+      case e: Exception =>
+        Left(ErrorObject(ErrorCode.ParseError, s"Failed to parse JSON: ${e.getMessage}"))
+
+end JsonRpc

--- a/ai-agent/src/main/scala/wvlet/ai/agent/mcp/MCPClient.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/mcp/MCPClient.scala
@@ -1,0 +1,61 @@
+package wvlet.ai.agent.mcp
+
+import wvlet.airframe.rx.Rx
+import wvlet.ai.agent.mcp.MCPMessages.*
+
+/**
+  * Client interface for communicating with MCP servers.
+  */
+trait MCPClient:
+  /**
+    * Initialize the connection with the MCP server.
+    *
+    * @return
+    *   Server capabilities and information
+    */
+  def initialize(): Rx[InitializeResult]
+
+  /**
+    * List available tools from the MCP server.
+    *
+    * @return
+    *   List of available tools
+    */
+  def listTools(): Rx[ListToolsResult]
+
+  /**
+    * Call a tool on the MCP server.
+    *
+    * @param toolName
+    *   Name of the tool to call
+    * @param arguments
+    *   Arguments to pass to the tool
+    * @return
+    *   Tool execution result
+    */
+  def callTool(toolName: String, arguments: Map[String, Any]): Rx[CallToolResult]
+
+  /**
+    * Send a raw JSON-RPC request to the server.
+    *
+    * @param request
+    *   The JSON-RPC request
+    * @return
+    *   The JSON-RPC response
+    */
+  def sendRequest(request: JsonRpc.Request): Rx[JsonRpc.Response]
+
+  /**
+    * Close the connection to the MCP server.
+    */
+  def close(): Unit
+
+  /**
+    * Check if the client is connected to the server.
+    *
+    * @return
+    *   true if connected, false otherwise
+    */
+  def isConnected: Boolean
+
+end MCPClient

--- a/ai-agent/src/main/scala/wvlet/ai/agent/mcp/MCPMessages.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/mcp/MCPMessages.scala
@@ -1,0 +1,139 @@
+package wvlet.ai.agent.mcp
+
+/**
+  * MCP-specific message types that extend JSON-RPC protocol.
+  *
+  * Based on: https://modelcontextprotocol.io/specification/basic/messages/
+  */
+object MCPMessages:
+
+  /**
+    * MCP protocol version
+    */
+  val PROTOCOL_VERSION = "2024-11-05"
+
+  /**
+    * Client capabilities
+    */
+  case class ClientCapabilities(
+      experimental: Option[Map[String, Any]] = None,
+      sampling: Option[Map[String, Any]] = None
+  )
+
+  /**
+    * Server capabilities
+    */
+  case class ServerCapabilities(
+      experimental: Option[Map[String, Any]] = None,
+      logging: Option[Map[String, Any]] = None,
+      prompts: Option[PromptsCapability] = None,
+      resources: Option[ResourcesCapability] = None,
+      tools: Option[ToolsCapability] = None
+  )
+
+  case class PromptsCapability(listChanged: Option[Boolean] = None)
+  case class ResourcesCapability(
+      subscribe: Option[Boolean] = None,
+      listChanged: Option[Boolean] = None
+  )
+
+  case class ToolsCapability(listChanged: Option[Boolean] = None)
+
+  /**
+    * Implementation details
+    */
+  case class Implementation(name: String, version: String)
+
+  /**
+    * Initialize request parameters
+    */
+  case class InitializeParams(
+      protocolVersion: String = PROTOCOL_VERSION,
+      capabilities: ClientCapabilities,
+      clientInfo: Implementation
+  )
+
+  /**
+    * Initialize result
+    */
+  case class InitializeResult(
+      protocolVersion: String = PROTOCOL_VERSION,
+      capabilities: ServerCapabilities,
+      serverInfo: Implementation
+  )
+
+  /**
+    * Tool definition from MCP server
+    */
+  case class MCPTool(
+      name: String,
+      description: Option[String] = None,
+      inputSchema: Map[String, Any]
+  )
+
+  /**
+    * List tools result
+    */
+  case class ListToolsResult(tools: Seq[MCPTool])
+
+  /**
+    * Tool call request
+    */
+  case class CallToolParams(name: String, arguments: Option[Map[String, Any]] = None)
+
+  /**
+    * Tool call result
+    */
+  case class CallToolResult(content: Seq[Map[String, Any]], isError: Option[Boolean] = None)
+
+  /**
+    * Content types for tool results
+    */
+  sealed trait ToolResultContent
+  case class TextContent(`type`: String = "text", text: String) extends ToolResultContent
+  case class ImageContent(`type`: String = "image", data: String, mimeType: String)
+      extends ToolResultContent
+
+  case class ResourceContent(`type`: String = "resource", resource: ResourceReference)
+      extends ToolResultContent
+
+  /**
+    * Resource reference
+    */
+  case class ResourceReference(uri: String, mimeType: Option[String] = None)
+
+  /**
+    * Create an initialize request
+    */
+  def createInitializeRequest(clientName: String, clientVersion: String): JsonRpc.Request = JsonRpc
+    .Request(
+      id = Some("init"),
+      method = "initialize",
+      params = Some(
+        Map(
+          "protocolVersion" -> PROTOCOL_VERSION,
+          "capabilities"    -> Map.empty[String, Any],
+          "clientInfo"      -> Map("name" -> clientName, "version" -> clientVersion)
+        )
+      )
+    )
+
+  /**
+    * Create a list tools request
+    */
+  def createListToolsRequest(): JsonRpc.Request = JsonRpc.Request(
+    id = Some("list-tools"),
+    method = "tools/list"
+  )
+
+  /**
+    * Create a tool call request
+    */
+  def createCallToolRequest(toolName: String, arguments: Map[String, Any]): JsonRpc.Request =
+    JsonRpc.Request(
+      id = Some(s"call-$toolName-${System.currentTimeMillis()}"),
+      method = "tools/call",
+      params = Some(Map("name" -> toolName, "arguments" -> arguments))
+    )
+
+end MCPMessages

--- a/ai-agent/src/main/scala/wvlet/ai/agent/mcp/MCPToolExecutor.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/mcp/MCPToolExecutor.scala
@@ -1,0 +1,206 @@
+package wvlet.ai.agent.mcp
+
+import wvlet.ai.agent.chat.{ChatMessage, ToolSpec, ToolParameter}
+import wvlet.ai.agent.chat.ChatMessage.{ToolCallRequest, ToolResultMessage}
+import wvlet.ai.agent.tool.ToolExecutor
+import wvlet.ai.agent.core.DataType
+import wvlet.airframe.rx.Rx
+import wvlet.airframe.codec.MessageCodec
+import wvlet.log.LogSupport
+
+/**
+  * ToolExecutor implementation that executes tools via MCP protocol.
+  *
+  * @param client
+  *   The MCP client to use for communication
+  */
+class MCPToolExecutor(private val client: MCPClient) extends ToolExecutor with LogSupport:
+
+  private var cachedTools: Seq[ToolSpec] = Seq.empty
+  private var initialized: Boolean       = false
+
+  /**
+    * Initialize the MCP connection and discover available tools.
+    */
+  def initialize(): Rx[Unit] =
+    if initialized then
+      Rx.single(())
+    else
+      client
+        .initialize()
+        .flatMap { initResult =>
+          debug(s"MCP server initialized: ${initResult.serverInfo}")
+
+          // List available tools
+          client
+            .listTools()
+            .map { toolsResult =>
+              cachedTools = toolsResult.tools.map(convertMCPToolToSpec)
+              initialized = true
+              debug(s"Discovered ${cachedTools.size} tools from MCP server")
+            }
+        }
+
+  override def executeToolCall(toolCall: ToolCallRequest): Rx[ToolResultMessage] =
+    // Ensure we're initialized
+    val initRx =
+      if initialized then
+        Rx.single(())
+      else
+        initialize()
+
+    initRx.flatMap { _ =>
+      debug(s"Executing MCP tool: ${toolCall.name}")
+
+      client
+        .callTool(toolCall.name, toolCall.args)
+        .map { result =>
+          // Convert MCP result to ToolResultMessage
+          val text = result
+            .content
+            .map { contentMap =>
+              contentMap.get("type") match
+                case Some("text") =>
+                  contentMap.getOrElse("text", "").toString
+                case Some("image") =>
+                  val data     = contentMap.getOrElse("data", "").toString
+                  val mimeType = contentMap.getOrElse("mimeType", "").toString
+                  s"""{"type": "image", "mimeType": "$mimeType", "data": "$data"}"""
+                case Some("resource") =>
+                  contentMap.get("resource") match
+                    case Some(res: Map[String, Any]) =>
+                      val uri = res.getOrElse("uri", "").toString
+                      s"""{"type": "resource", "uri": "$uri"}"""
+                    case _ =>
+                      """{"type": "resource", "uri": ""}"""
+                case _ =>
+                  MessageCodec.toJson(contentMap)
+            }
+            .mkString("\n")
+
+          ToolResultMessage(id = toolCall.id, toolName = toolCall.name, text = text)
+        }
+        .recover { case e: Exception =>
+          error(s"MCP tool execution failed: ${e.getMessage}", e)
+          ToolResultMessage(
+            id = toolCall.id,
+            toolName = toolCall.name,
+            text = s"""{"error": "${e.getMessage}"}"""
+          )
+        }
+    }
+
+  end executeToolCall
+
+  override def availableTools: Seq[ToolSpec] = cachedTools
+
+  /**
+    * Convert an MCP tool definition to a ToolSpec.
+    */
+  private def convertMCPToolToSpec(mcpTool: MCPMessages.MCPTool): ToolSpec =
+    val parameters = extractParameters(mcpTool.inputSchema)
+
+    ToolSpec(
+      name = mcpTool.name,
+      description = mcpTool.description.getOrElse(""),
+      parameters = parameters,
+      returnType = DataType.JsonType // MCP tools typically return JSON
+    )
+
+  /**
+    * Extract parameters from JSON Schema.
+    */
+  private def extractParameters(schema: Map[String, Any]): List[ToolParameter] =
+    schema.get("properties") match
+      case Some(props: Map[String, Any]) =>
+        val required =
+          schema.get("required") match
+            case Some(req: List[String]) =>
+              req.toSet
+            case _ =>
+              Set.empty[String]
+
+        props
+          .map { case (name, propSchemaAny) =>
+            val propSchema = propSchemaAny.asInstanceOf[Map[String, Any]]
+            val description =
+              propSchema.get("description") match
+                case Some(desc: String) =>
+                  desc
+                case _ =>
+                  ""
+
+            val paramType: DataType =
+              propSchema.get("type") match
+                case Some(t: String) =>
+                  t match
+                    case "string" =>
+                      DataType.StringType
+                    case "number" =>
+                      DataType.FloatType
+                    case "integer" =>
+                      DataType.IntegerType
+                    case "boolean" =>
+                      DataType.BooleanType
+                    case "array" =>
+                      DataType.ArrayType(DataType.AnyType)
+                    case "object" =>
+                      DataType.JsonType
+                    case _ =>
+                      DataType.JsonType
+                case _ =>
+                  DataType.JsonType
+
+            val defaultValue = propSchema.get("default")
+
+            ToolParameter(
+              name = name,
+              description = description,
+              dataType = paramType,
+              defaultValue = defaultValue
+            )
+          }
+          .toList
+
+      case _ =>
+        List.empty
+
+  /**
+    * Close the MCP connection.
+    */
+  def close(): Unit =
+    client.close()
+    initialized = false
+    cachedTools = Seq.empty
+
+end MCPToolExecutor
+
+/**
+  * Factory for creating MCPToolExecutor instances.
+  */
+object MCPToolExecutor:
+  /**
+    * Create an MCPToolExecutor with a stdio-based MCP server.
+    *
+    * @param command
+    *   Command to start the MCP server
+    * @param args
+    *   Arguments for the command
+    * @param env
+    *   Environment variables
+    * @param workingDir
+    *   Working directory
+    * @return
+    *   An Rx stream that emits the initialized executor
+    */
+  def fromCommand(
+      command: String,
+      args: Seq[String] = Seq.empty,
+      env: Map[String, String] = Map.empty,
+      workingDir: Option[String] = None
+  ): Rx[MCPToolExecutor] =
+    val client   = StdioMCPClient(command, args, env, workingDir)
+    val executor = MCPToolExecutor(client)
+    executor.initialize().map(_ => executor)
+
+end MCPToolExecutor

--- a/ai-agent/src/main/scala/wvlet/ai/agent/mcp/StdioMCPClient.scala
+++ b/ai-agent/src/main/scala/wvlet/ai/agent/mcp/StdioMCPClient.scala
@@ -1,0 +1,232 @@
+package wvlet.ai.agent.mcp
+
+import wvlet.airframe.rx.Rx
+import wvlet.airframe.codec.MessageCodec
+import wvlet.ai.agent.mcp.MCPMessages.*
+import wvlet.log.LogSupport
+import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
+import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.{Promise, ExecutionContext}
+import scala.jdk.CollectionConverters.*
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+  * MCP client that communicates with servers via stdio (stdin/stdout).
+  *
+  * @param command
+  *   Command to start the MCP server process
+  * @param args
+  *   Arguments for the command
+  * @param env
+  *   Environment variables for the process
+  * @param workingDir
+  *   Working directory for the process
+  */
+class StdioMCPClient(
+    command: String,
+    args: Seq[String] = Seq.empty,
+    env: Map[String, String] = Map.empty,
+    workingDir: Option[String] = None
+) extends MCPClient
+    with LogSupport:
+
+  private var process: Option[Process]       = None
+  private var reader: Option[BufferedReader] = None
+  private var writer: Option[BufferedWriter] = None
+  private val connected                      = AtomicBoolean(false)
+  private val pendingRequests              = ConcurrentHashMap[String, Promise[JsonRpc.Response]]()
+  private var readerThread: Option[Thread] = None
+
+  /**
+    * Start the MCP server process and establish communication.
+    */
+  private def startProcess(): Unit =
+    if process.isEmpty then
+      debug(s"Starting MCP server: $command ${args.mkString(" ")}")
+
+      val pb = ProcessBuilder((command +: args).asJava)
+      workingDir.foreach(dir => pb.directory(java.io.File(dir)))
+
+      // Add environment variables
+      if env.nonEmpty then
+        val processEnv = pb.environment()
+        env.foreach { case (k, v) =>
+          processEnv.put(k, v)
+        }
+
+      val proc = pb.start()
+      process = Some(proc)
+
+      // Set up readers and writers
+      reader = Some(BufferedReader(InputStreamReader(proc.getInputStream)))
+      writer = Some(BufferedWriter(OutputStreamWriter(proc.getOutputStream)))
+
+      // Start reader thread to handle responses
+      readerThread = Some(Thread(() => readResponses()))
+      readerThread.foreach(_.start())
+
+      connected.set(true)
+      debug("MCP server process started")
+
+  /**
+    * Read responses from the server in a separate thread.
+    */
+  private def readResponses(): Unit =
+    try
+      reader.foreach { r =>
+        var line = r.readLine()
+        while line != null && connected.get() do
+          debug(s"Received from server: $line")
+          handleResponse(line)
+          line = r.readLine()
+      }
+    catch
+      case e: Exception =>
+        if connected.get() then
+          error(s"Error reading from MCP server", e)
+    finally
+      connected.set(false)
+
+  /**
+    * Handle a response line from the server.
+    */
+  private def handleResponse(line: String): Unit =
+    JsonRpc.parse(line) match
+      case Right(response: JsonRpc.Response) =>
+        response.id match
+          case Some(id) =>
+            val idStr = id.toString
+            Option(pendingRequests.remove(idStr)).foreach { promise =>
+              promise.success(response)
+            }
+          case None =>
+            warn(s"Received response without id: $line")
+
+      case Right(notification: JsonRpc.Notification) =>
+        debug(s"Received notification: ${notification.method}")
+        // Handle notifications if needed
+
+      case Right(request: JsonRpc.Request) =>
+        warn(s"Received unexpected request from server: ${request.method}")
+
+      case Left(err) =>
+        error(s"Failed to parse response: ${err.message}")
+
+  override def initialize(): Rx[InitializeResult] =
+    if !connected.get() then
+      startProcess()
+
+    val request = MCPMessages.createInitializeRequest("scala-ai", "1.0.0")
+    sendRequest(request).map { response =>
+      response.result match
+        case Some(result) =>
+          val codec = MessageCodec.of[InitializeResult]
+          codec.fromMap(result.asInstanceOf[Map[String, Any]])
+        case None =>
+          throw new RuntimeException(s"Initialize failed: ${response.error}")
+    }
+
+  override def listTools(): Rx[ListToolsResult] =
+    val request = MCPMessages.createListToolsRequest()
+    sendRequest(request).map { response =>
+      response.result match
+        case Some(result) =>
+          val codec = MessageCodec.of[ListToolsResult]
+          codec.fromMap(result.asInstanceOf[Map[String, Any]])
+        case None =>
+          throw new RuntimeException(s"List tools failed: ${response.error}")
+    }
+
+  override def callTool(toolName: String, arguments: Map[String, Any]): Rx[CallToolResult] =
+    val request = MCPMessages.createCallToolRequest(toolName, arguments)
+    sendRequest(request).map { response =>
+      response.result match
+        case Some(result) =>
+          val codec = MessageCodec.of[CallToolResult]
+          codec.fromMap(result.asInstanceOf[Map[String, Any]])
+        case None =>
+          throw new RuntimeException(s"Tool call failed: ${response.error}")
+    }
+
+  override def sendRequest(request: JsonRpc.Request): Rx[JsonRpc.Response] =
+    if !connected.get() then
+      throw new IllegalStateException("MCP client not connected")
+
+    val promise = Promise[JsonRpc.Response]()
+
+    request.id match
+      case Some(id) =>
+        pendingRequests.put(id.toString, promise)
+
+        // Send the request
+        val json = MessageCodec.toJson(request)
+        debug(s"Sending request: $json")
+
+        writer.foreach { w =>
+          w.write(json)
+          w.newLine()
+          w.flush()
+        }
+
+        // Convert Promise to Rx
+        Rx.fromFuture(promise.future)
+          .recover { case e: Exception =>
+            pendingRequests.remove(id.toString)
+            JsonRpc.Response(
+              id = request.id,
+              error = Some(
+                JsonRpc.ErrorObject(
+                  JsonRpc.ErrorCode.InternalError,
+                  s"Request failed: ${e.getMessage}"
+                )
+              )
+            )
+          }
+
+      case None =>
+        Rx.single(
+          JsonRpc.Response(
+            id = None,
+            error = Some(
+              JsonRpc.ErrorObject(JsonRpc.ErrorCode.InvalidRequest, "Request must have an id")
+            )
+          )
+        )
+
+    end match
+
+  end sendRequest
+
+  override def close(): Unit =
+    if connected.get() then
+      connected.set(false)
+
+      // Close streams
+      writer.foreach(_.close())
+      reader.foreach(_.close())
+
+      // Terminate process
+      process.foreach { p =>
+        p.destroy()
+        if !p.waitFor(5, TimeUnit.SECONDS) then
+          p.destroyForcibly()
+      }
+
+      // Stop reader thread
+      readerThread.foreach(_.interrupt())
+
+      // Clear pending requests
+      pendingRequests
+        .values()
+        .asScala
+        .foreach { promise =>
+          promise.failure(new RuntimeException("Client closed"))
+        }
+      pendingRequests.clear()
+
+      debug("MCP client closed")
+
+  override def isConnected: Boolean = connected.get()
+
+end StdioMCPClient

--- a/ai-agent/src/test/scala/wvlet/ai/agent/mcp/JsonRpcTest.scala
+++ b/ai-agent/src/test/scala/wvlet/ai/agent/mcp/JsonRpcTest.scala
@@ -1,0 +1,90 @@
+package wvlet.ai.agent.mcp
+
+import wvlet.airspec.AirSpec
+import wvlet.airframe.codec.MessageCodec
+
+class JsonRpcTest extends AirSpec:
+
+  test("parse JSON-RPC request") {
+    val json = """{"jsonrpc":"2.0","id":"123","method":"test","params":{"foo":"bar"}}"""
+
+    JsonRpc.parse(json) shouldMatch { case Right(request: JsonRpc.Request) =>
+      request.jsonrpc shouldBe "2.0"
+      request.id shouldBe Some("123")
+      request.method shouldBe "test"
+      request.params shouldBe Some(Map("foo" -> "bar"))
+    }
+  }
+
+  test("parse JSON-RPC response with result") {
+    val json = """{"jsonrpc":"2.0","id":"123","result":{"status":"ok"}}"""
+
+    JsonRpc.parse(json) shouldMatch { case Right(response: JsonRpc.Response) =>
+      response.jsonrpc shouldBe "2.0"
+      response.id shouldBe Some("123")
+      response.result shouldBe Some(Map("status" -> "ok"))
+      response.error shouldBe None
+    }
+  }
+
+  test("parse JSON-RPC response with error") {
+    val json =
+      """{"jsonrpc":"2.0","id":"123","error":{"code":-32601,"message":"Method not found"}}"""
+
+    JsonRpc.parse(json) shouldMatch { case Right(response: JsonRpc.Response) =>
+      response.jsonrpc shouldBe "2.0"
+      response.id shouldBe Some("123")
+      response.result shouldBe None
+      response.error shouldMatch { case Some(error) =>
+        error.code shouldBe -32601
+        error.message shouldBe "Method not found"
+      }
+    }
+  }
+
+  test("parse JSON-RPC notification") {
+    val json = """{"jsonrpc":"2.0","method":"notify","params":{"event":"update"}}"""
+
+    JsonRpc.parse(json) shouldMatch { case Right(notification: JsonRpc.Notification) =>
+      notification.jsonrpc shouldBe "2.0"
+      notification.method shouldBe "notify"
+      notification.params shouldBe Some(Map("event" -> "update"))
+    }
+  }
+
+  test("handle parse error") {
+    val json = """{"invalid json"""
+
+    JsonRpc.parse(json) shouldMatch { case Left(error) =>
+      error.code shouldBe JsonRpc.ErrorCode.ParseError
+      error.message shouldContain "Failed to parse JSON"
+    }
+  }
+
+  test("create request with params") {
+    val request = JsonRpc.Request(
+      id = Some("test-1"),
+      method = "tools/call",
+      params = Some(Map("name" -> "calculator", "args" -> Map("x" -> 1, "y" -> 2)))
+    )
+
+    val json = MessageCodec.toJson(request)
+    json shouldContain "\"jsonrpc\":\"2.0\""
+    json shouldContain "\"id\":\"test-1\""
+    json shouldContain "\"method\":\"tools/call\""
+    json shouldContain "\"params\""
+  }
+
+  test("create notification") {
+    val notification = JsonRpc.Notification(
+      method = "log",
+      params = Some(Map("level" -> "info", "message" -> "test"))
+    )
+
+    val json = MessageCodec.toJson(notification)
+    json shouldContain "\"jsonrpc\":\"2.0\""
+    json shouldContain "\"method\":\"log\""
+    json shouldNotContain "\"id\""
+  }
+
+end JsonRpcTest

--- a/ai-agent/src/test/scala/wvlet/ai/agent/mcp/MCPMessagesTest.scala
+++ b/ai-agent/src/test/scala/wvlet/ai/agent/mcp/MCPMessagesTest.scala
@@ -1,0 +1,98 @@
+package wvlet.ai.agent.mcp
+
+import wvlet.airspec.AirSpec
+import wvlet.airframe.codec.MessageCodec
+
+class MCPMessagesTest extends AirSpec:
+
+  test("create initialize request") {
+    val request = MCPMessages.createInitializeRequest("test-client", "1.0.0")
+
+    request.id shouldBe Some("init")
+    request.method shouldBe "initialize"
+    request.params shouldMatch { case Some(params: Map[String, Any]) =>
+      params("protocolVersion") shouldBe MCPMessages.PROTOCOL_VERSION
+      params("clientInfo") shouldMatch { case info: Map[String, Any] =>
+        info("name") shouldBe "test-client"
+        info("version") shouldBe "1.0.0"
+      }
+    }
+  }
+
+  test("create list tools request") {
+    val request = MCPMessages.createListToolsRequest()
+
+    request.id shouldBe Some("list-tools")
+    request.method shouldBe "tools/list"
+    request.params shouldBe None
+  }
+
+  test("create call tool request") {
+    val request = MCPMessages.createCallToolRequest(
+      "calculator",
+      Map("operation" -> "add", "x" -> 1, "y" -> 2)
+    )
+
+    request.id shouldMatch { case Some(id: String) =>
+      id shouldContain "call-calculator-"
+    }
+    request.method shouldBe "tools/call"
+    request.params shouldMatch { case Some(params: Map[String, Any]) =>
+      params("name") shouldBe "calculator"
+      params("arguments") shouldBe Map("operation" -> "add", "x" -> 1, "y" -> 2)
+    }
+  }
+
+  test("serialize MCP tool") {
+    val tool = MCPMessages.MCPTool(
+      name = "get_weather",
+      description = Some("Get current weather"),
+      inputSchema = Map(
+        "type"       -> "object",
+        "properties" -> Map("location" -> Map("type" -> "string")),
+        "required"   -> List("location")
+      )
+    )
+
+    val json = MessageCodec.toJson(tool)
+    json shouldContain "\"name\":\"get_weather\""
+    json shouldContain "\"description\":\"Get current weather\""
+    json shouldContain "\"inputSchema\""
+  }
+
+  test("serialize tool result with text content") {
+    val result = MCPMessages.CallToolResult(content =
+      Seq(Map("type" -> "text", "text" -> "The weather is sunny"))
+    )
+
+    val json = MessageCodec.toJson(result)
+    json shouldContain "\"type\":\"text\""
+    json shouldContain "\"text\":\"The weather is sunny\""
+  }
+
+  test("serialize tool result with error") {
+    val result = MCPMessages.CallToolResult(
+      content = Seq(Map("type" -> "text", "text" -> "Tool execution failed")),
+      isError = Some(true)
+    )
+
+    val json = MessageCodec.toJson(result)
+    json shouldContain "\"isError\":true"
+  }
+
+  test("serialize initialize result") {
+    val result = MCPMessages.InitializeResult(
+      capabilities = MCPMessages.ServerCapabilities(tools =
+        Some(MCPMessages.ToolsCapability(listChanged = Some(true)))
+      ),
+      serverInfo = MCPMessages.Implementation("test-server", "1.0.0")
+    )
+
+    val json = MessageCodec.toJson(result)
+    json shouldContain "\"protocolVersion\""
+    json shouldContain "\"serverInfo\""
+    json shouldContain "\"name\":\"test-server\""
+    json shouldContain "\"version\":\"1.0.0\""
+  }
+
+end MCPMessagesTest

--- a/ai-agent/src/test/scala/wvlet/ai/agent/mcp/MCPToolExecutorTest.scala
+++ b/ai-agent/src/test/scala/wvlet/ai/agent/mcp/MCPToolExecutorTest.scala
@@ -1,0 +1,203 @@
+package wvlet.ai.agent.mcp
+
+import wvlet.airspec.AirSpec
+import wvlet.ai.agent.chat.ChatMessage.ToolCallRequest
+import wvlet.airframe.rx.Rx
+
+class MCPToolExecutorTest extends AirSpec:
+
+  // Mock MCP client for testing
+  class MockMCPClient extends MCPClient:
+    var initialized = false
+    var toolsCalled = Map.empty[String, Map[String, Any]]
+
+    override def initialize(): Rx[MCPMessages.InitializeResult] =
+      initialized = true
+      Rx.single(
+        MCPMessages.InitializeResult(
+          capabilities = MCPMessages.ServerCapabilities(tools =
+            Some(MCPMessages.ToolsCapability())
+          ),
+          serverInfo = MCPMessages.Implementation("mock-server", "1.0.0")
+        )
+      )
+
+    override def listTools(): Rx[MCPMessages.ListToolsResult] = Rx.single(
+      MCPMessages.ListToolsResult(tools =
+        Seq(
+          MCPMessages.MCPTool(
+            name = "calculator",
+            description = Some("Perform calculations"),
+            inputSchema = Map(
+              "type" -> "object",
+              "properties" ->
+                Map(
+                  "operation" -> Map("type" -> "string", "description" -> "Operation to perform"),
+                  "x"         -> Map("type" -> "number", "description" -> "First operand"),
+                  "y"         -> Map("type" -> "number", "description" -> "Second operand")
+                ),
+              "required" -> List("operation", "x", "y")
+            )
+          ),
+          MCPMessages.MCPTool(
+            name = "echo",
+            description = Some("Echo back the input"),
+            inputSchema = Map(
+              "type"       -> "object",
+              "properties" -> Map("message" -> Map("type" -> "string", "default" -> "Hello"))
+            )
+          )
+        )
+      )
+    )
+
+    override def callTool(
+        toolName: String,
+        arguments: Map[String, Any]
+    ): Rx[MCPMessages.CallToolResult] =
+      toolsCalled = toolsCalled.updated(toolName, arguments)
+
+      toolName match
+        case "calculator" =>
+          val result =
+            arguments.get("operation") match
+              case Some("add") =>
+                val x = arguments.getOrElse("x", 0).toString.toDouble
+                val y = arguments.getOrElse("y", 0).toString.toDouble
+                (x + y).toString
+              case Some("multiply") =>
+                val x = arguments.getOrElse("x", 1).toString.toDouble
+                val y = arguments.getOrElse("y", 1).toString.toDouble
+                (x * y).toString
+              case _ =>
+                "Unknown operation"
+
+          Rx.single(
+            MCPMessages.CallToolResult(content = Seq(Map("type" -> "text", "text" -> result)))
+          )
+
+        case "echo" =>
+          val message = arguments.getOrElse("message", "Hello").toString
+          Rx.single(
+            MCPMessages.CallToolResult(content =
+              Seq(Map("type" -> "text", "text" -> s"Echo: $message"))
+            )
+          )
+
+        case _ =>
+          Rx.single(
+            MCPMessages.CallToolResult(
+              content = Seq(Map("type" -> "text", "text" -> s"Unknown tool: $toolName")),
+              isError = Some(true)
+            )
+          )
+
+      end match
+
+    end callTool
+
+    override def sendRequest(request: JsonRpc.Request): Rx[JsonRpc.Response] = Rx.single(
+      JsonRpc.Response(id = request.id)
+    )
+
+    override def close(): Unit = initialized = false
+
+    override def isConnected: Boolean = initialized
+
+  end MockMCPClient
+
+  test("initialize and discover tools") {
+    val client   = MockMCPClient()
+    val executor = MCPToolExecutor(client)
+
+    // Initially no tools
+    executor.availableTools.size shouldBe 0
+
+    // Initialize
+    executor.initialize().toSeq
+
+    // Should discover tools
+    val tools = executor.availableTools
+    tools.size shouldBe 2
+
+    tools.find(_.name == "calculator") shouldMatch { case Some(tool) =>
+      tool.description shouldBe "Perform calculations"
+      tool.parameters.size shouldBe 3
+      tool.parameters.map(_.name).toSet shouldBe Set("operation", "x", "y")
+    }
+
+    tools.find(_.name == "echo") shouldMatch { case Some(tool) =>
+      tool.description shouldBe "Echo back the input"
+      tool.parameters.size shouldBe 1
+      tool.parameters.head.name shouldBe "message"
+      tool.parameters.head.defaultValue shouldBe Some("Hello")
+    }
+  }
+
+  test("execute tool call") {
+    val client   = MockMCPClient()
+    val executor = MCPToolExecutor(client)
+
+    val toolCall = ToolCallRequest(
+      id = "calc-1",
+      name = "calculator",
+      args = Map("operation" -> "add", "x" -> 5, "y" -> 3)
+    )
+
+    val result = executor.executeToolCall(toolCall).toSeq.head
+
+    result.id shouldBe "calc-1"
+    result.toolName shouldBe "calculator"
+    result.text shouldBe "8.0"
+    result.text shouldNotContain "error"
+
+    // Verify the tool was called with correct args
+    client.toolsCalled("calculator") shouldBe Map("operation" -> "add", "x" -> 5, "y" -> 3)
+  }
+
+  test("handle tool execution error") {
+    val client   = MockMCPClient()
+    val executor = MCPToolExecutor(client)
+
+    val toolCall = ToolCallRequest(id = "unknown-1", name = "unknown_tool", args = Map())
+
+    val result = executor.executeToolCall(toolCall).toSeq.head
+
+    result.id shouldBe "unknown-1"
+    result.toolName shouldBe "unknown_tool"
+    result.text shouldContain "Unknown tool"
+    result.text shouldContain "Unknown tool"
+  }
+
+  test("execute multiple tool calls") {
+    val client   = MockMCPClient()
+    val executor = MCPToolExecutor(client)
+
+    val toolCalls = Seq(
+      ToolCallRequest("1", "calculator", Map("operation" -> "add", "x" -> 10, "y" -> 20)),
+      ToolCallRequest("2", "echo", Map("message" -> "Hello MCP")),
+      ToolCallRequest("3", "calculator", Map("operation" -> "multiply", "x" -> 4, "y" -> 5))
+    )
+
+    val results = executor.executeToolCalls(toolCalls).toSeq.head
+
+    results.size shouldBe 3
+
+    results(0).text shouldBe "30.0"
+    results(1).text shouldBe "Echo: Hello MCP"
+    results(2).text shouldBe "20.0"
+  }
+
+  test("close executor") {
+    val client   = MockMCPClient()
+    val executor = MCPToolExecutor(client)
+
+    executor.initialize().toSeq
+    client.isConnected shouldBe true
+
+    executor.close()
+    client.isConnected shouldBe false
+    executor.availableTools.size shouldBe 0
+  }
+
+end MCPToolExecutorTest


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the Model Context Protocol (MCP) support (#159) by adding the MCP client implementation with stdio transport. This enables scala-ai to communicate with MCP servers via JSON-RPC protocol.

## What's Implemented

### JSON-RPC Protocol Layer
- `JsonRpc` object with support for Request/Response/Notification messages
- Standard JSON-RPC 2.0 error codes and message parsing
- Type-safe message construction with proper serialization

### MCP Protocol Messages  
- `MCPMessages` with all MCP-specific message types
- Initialize, ListTools, and CallTool protocol support
- Content types for tool results (text, image, resource)

### Client Implementation
- `MCPClient` trait defining the client interface
- `StdioMCPClient` for process-based MCP server communication
- Asynchronous message handling with Rx streams
- Proper process lifecycle management

### Tool Integration
- `MCPToolExecutor` bridges MCP tools with ToolExecutor interface
- Automatic tool discovery from MCP servers
- JSON Schema parameter extraction and type mapping
- Support for multiple content types in tool results

## Features

- ✅ Full JSON-RPC 2.0 protocol support
- ✅ Stdio transport for subprocess-based MCP servers
- ✅ Tool discovery and automatic parameter extraction
- ✅ Asynchronous execution using Airframe Rx
- ✅ Proper error handling and recovery
- ✅ Comprehensive test coverage

## Usage Example

```scala
// Create MCP client for a stdio-based server
val client = StdioMCPClient("mcp-server", args = Seq("--port", "8080"))

// Create tool executor
val executor = MCPToolExecutor(client)
executor.initialize().map { _ =>
  // Tools are now available
  val tools = executor.availableTools
  println(s"Discovered ${tools.size} tools")
}

// Or use the factory method
MCPToolExecutor.fromCommand("mcp-server").map { executor =>
  // Ready to execute tools
  val result = executor.executeToolCall(
    ToolCallRequest("1", "get_weather", Map("location" -> "Tokyo"))
  )
}
```

## Testing

Added comprehensive test suites:
- `JsonRpcTest` - Tests JSON-RPC message parsing and serialization
- `MCPMessagesTest` - Tests MCP protocol messages
- `MCPToolExecutorTest` - Tests tool discovery and execution with mock client

All tests pass:
```
[info] Passed: Total 19, Failed 0, Errors 0, Passed 19
```

## Next Steps

This completes Phase 2 of MCP support. Next phases will include:
- Phase 3: Tool adaptation and parameter validation
- Phase 4: Integration tests with real MCP servers

## Related Issues

- #159 - Support MCP (Model Context Protocol) tool calling

🤖 Generated with [Claude Code](https://claude.ai/code)