### PR TITLE
chore: Rename core module variable to uni in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val log = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
   .nativeSettings(nativeBuildSettings)
 
-// core library for Scala JVM, Scala.js and Scala Native
+// The 'uni' library for Scala JVM, Scala.js and Scala Native
 lazy val uni = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("uni"))


### PR DESCRIPTION
## Summary
- Rename the sbt variable from `core` to `uni` for consistency with the folder name (`uni/`) and artifact name (`uni`)
- Allows using `sbt uniJVM/test` instead of `sbt coreJVM/test`

## Test plan
- [x] `sbt compile` passes
- [x] `sbt uniJVM/test` passes (460 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)