### PR TITLE
feature: Support single test selection in IntelliJ

### DIFF
--- a/uni-test/.jvm/src/main/scala/wvlet/uni/test/spi/UniTestEngine.scala
+++ b/uni-test/.jvm/src/main/scala/wvlet/uni/test/spi/UniTestEngine.scala
@@ -152,19 +152,28 @@ class UniTestEngine extends TestEngine:
           val instance = classDesc.testClass.getDeclaredConstructor().newInstance()
 
           // Get the set of test names that were discovered (selected for execution)
-          val discoveredTests = classDesc
-            .getChildren
-            .asScala
-            .collect { case m: UniTestMethodDescriptor => m.testName }
-            .toSet
+          val discoveredTests =
+            classDesc
+              .getChildren
+              .asScala
+              .collect { case m: UniTestMethodDescriptor =>
+                m.testName
+              }
+              .toSet
 
           // Use queue-based approach to handle dynamically registered nested tests
           // Filter to only discovered tests (enables single test selection in IDE)
-          val testQueue = scala.collection.mutable.Queue.from(
-            instance.registeredTests.filter { testDef =>
-              discoveredTests.isEmpty || discoveredTests.contains(testDef.fullName)
-            }
-          )
+          val testQueue = scala
+            .collection
+            .mutable
+            .Queue
+            .from(
+              instance
+                .registeredTests
+                .filter { testDef =>
+                  discoveredTests.isEmpty || discoveredTests.contains(testDef.fullName)
+                }
+            )
           val executedTests = scala.collection.mutable.Set.empty[String]
 
           while testQueue.nonEmpty do


### PR DESCRIPTION
## Summary
- Filter test execution based on discovered descriptors from JUnit Platform
- When IntelliJ requests to run a single test via `UniqueIdSelector`, only run tests that were discovered
- Preserve behavior when running all tests (no filtering when all tests discovered)

## Background
PR #309 added JUnit 5 Platform integration for IntelliJ. However, clicking "Run" on a single test would run all tests in the class. This was because the execution phase ignored the filter established during discovery.

This fix extracts the discovered test names from `classDesc.getChildren` and filters `testQueue` to only include those tests.

## Test plan
- [x] `sbt unitestJVM/test` passes (all 23 tests)
- [ ] Verify in IntelliJ:
  - Click run icon next to a single test → only that test runs
  - Click run icon next to class → all tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)