### PR TITLE
chore: Rename unitest to test, simplify Framework configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ libraryDependencies ++= Seq(
 )
 
 // Enable uni-test framework
-testFrameworks += new TestFramework("wvlet.uni.test.spi.UniTestFramework")
+testFrameworks += new TestFramework("wvlet.uni.test.Framework")
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val buildSettings = Seq[Setting[?]](
       // For PreDestroy, PostConstruct annotations
       "javax.annotation" % "javax.annotation-api" % "1.3.2" % Test
     ),
-  testFrameworks += new TestFramework("wvlet.uni.test.spi.UniTestFramework")
+  testFrameworks += new TestFramework("wvlet.uni.test.Framework")
 )
 
 val jsBuildSettings = Seq[Setting[?]](
@@ -78,9 +78,9 @@ lazy val root = project
   .settings(buildSettings, name := "uni", publish / skip := true)
   .aggregate((jvmProjects ++ jsProjects ++ nativeProjects): _*)
 
-lazy val jvmProjects: Seq[ProjectReference]    = Seq(log.jvm, uni.jvm, agent, bedrock, unitest.jvm)
-lazy val jsProjects: Seq[ProjectReference]     = Seq(log.js, uni.js, unitest.js)
-lazy val nativeProjects: Seq[ProjectReference] = Seq(log.native, uni.native, unitest.native)
+lazy val jvmProjects: Seq[ProjectReference]    = Seq(log.jvm, uni.jvm, agent, bedrock, test.jvm)
+lazy val jsProjects: Seq[ProjectReference]     = Seq(log.js, uni.js, test.js)
+lazy val nativeProjects: Seq[ProjectReference] = Seq(log.native, uni.native, test.native)
 
 lazy val projectJVM = project
   .settings(noPublish)
@@ -128,17 +128,17 @@ lazy val uni = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .settings(buildSettings, name := "uni", description := "Scala unified core library")
   .jsSettings(jsBuildSettings)
   .nativeSettings(nativeBuildSettings)
-  .dependsOn(log, unitest % Test)
+  .dependsOn(log, test % Test)
 
-// UniTest - Lightweight testing framework with AirSpec syntax
-lazy val unitest = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+// uni-test - Lightweight testing framework with AirSpec syntax
+lazy val test = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("uni-test"))
   .settings(
     buildSettings,
     name           := "uni-test",
     description    := "Lightweight testing framework with AirSpec syntax",
-    testFrameworks := Seq(new TestFramework("wvlet.uni.test.spi.UniTestFramework")),
+    testFrameworks := Seq(new TestFramework("wvlet.uni.test.Framework")),
     libraryDependencies ++=
       Seq(
         // ScalaCheck for property-based testing
@@ -189,7 +189,7 @@ lazy val agent = project
         "org.wvlet.airframe" %% "airframe-codec" % AIRFRAME_VERSION
       )
   )
-  .dependsOn(uni.jvm, unitest.jvm % Test)
+  .dependsOn(uni.jvm, test.jvm % Test)
 
 lazy val bedrock = project
   .in(file("uni-agent-bedrock"))
@@ -207,7 +207,7 @@ lazy val bedrock = project
         "dev.langchain4j" % "langchain4j-bedrock" % "1.10.0" % Test
       )
   )
-  .dependsOn(agent, unitest.jvm % Test)
+  .dependsOn(agent, test.jvm % Test)
 
 lazy val integrationTest = project
   .in(file("uni-integration-test"))
@@ -218,4 +218,4 @@ lazy val integrationTest = project
     description    := "Integration test for agent applications",
     ideSkipProject := false
   )
-  .dependsOn(bedrock, unitest.jvm % Test)
+  .dependsOn(bedrock, test.jvm % Test)

--- a/uni-test/src/main/scala/wvlet/uni/test/Framework.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/Framework.scala
@@ -11,25 +11,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.uni.test.spi
+package wvlet.uni.test
 
 import sbt.testing.Fingerprint
-import sbt.testing.Framework
 import sbt.testing.Runner
 
 /**
-  * sbt test framework entry point for UniTest
+  * sbt test framework entry point for uni-test
   */
-class UniTestFramework extends Framework:
-  override def name(): String = "UniTest"
+class Framework extends sbt.testing.Framework:
+  override def name(): String = "uni-test"
 
-  override def fingerprints(): Array[Fingerprint] = Array(UniTestFingerprint)
+  override def fingerprints(): Array[Fingerprint] = Array(spi.UniTestFingerprint)
 
   override def runner(
       args: Array[String],
       remoteArgs: Array[String],
       testClassLoader: ClassLoader
-  ): Runner = UniTestRunner(args, remoteArgs, testClassLoader)
+  ): Runner = spi.UniTestRunner(args, remoteArgs, testClassLoader)
 
   /**
     * Scala.js slave runner - used for remote test execution. For now, we just create a standard
@@ -40,4 +39,4 @@ class UniTestFramework extends Framework:
       remoteArgs: Array[String],
       testClassLoader: ClassLoader,
       send: String => Unit
-  ): Runner = UniTestRunner(args, remoteArgs, testClassLoader)
+  ): Runner = spi.UniTestRunner(args, remoteArgs, testClassLoader)


### PR DESCRIPTION
## Summary
- Rename sbt project variable from `unitest` to `test` (distinguishes from `uni`)
- Move `UniTestFramework` from `spi` package to main package as `Framework`

## Changes

**Before:**
```scala
lazy val unitest = crossProject(...)
testFrameworks += new TestFramework("wvlet.uni.test.spi.UniTestFramework")
```

**After:**
```scala
lazy val test = crossProject(...)
testFrameworks += new TestFramework("wvlet.uni.test.Framework")
```

## Test plan
- [x] `sbt testJVM/test` passes (23 tests)
- [x] `sbt testJS/test` passes (23 tests)
- [x] `sbt testNative/test` passes (23 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)