### PR TITLE
chore: Add GitHub Actions workflow for documentation

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,4 +1,4 @@
-name: Doc
+name: doc
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
- Add `Doc / build-doc` job to build VitePress documentation
- Add `Doc / deploy-doc` job to deploy to GitHub Pages (main branch only)
- Use `dorny/paths-filter` to run CI only when docs or doc.yml change

## Test plan
- [ ] Verify build-doc job runs on PR with doc changes
- [ ] Verify deploy-doc job only runs on main branch


🤖 Generated with [Claude Code](https://claude.com/claude-code)