### PR TITLE
fix: Set VitePress base path for hosting at /uni/

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,6 +4,7 @@ export default defineConfig({
   title: 'Wvlet Uni',
   description: 'Essential Scala Utilities - Refined for Scala 3 with minimal dependencies',
 
+  base: '/uni/',
   cleanUrls: true,
 
   markdown: {


### PR DESCRIPTION
## Summary
- Add `base: '/uni/'` to VitePress config for proper subdirectory hosting

## Problem
CSS and assets fail to load when hosted at https://wvlet.org/uni/ because VitePress generates asset paths relative to root `/` instead of `/uni/`.

## Solution
Set `base: '/uni/'` in the VitePress configuration so all asset paths are correctly prefixed.

## Test plan
- [ ] Verify build succeeds
- [ ] Verify deployed site at https://wvlet.org/uni/ loads CSS properly


🤖 Generated with [Claude Code](https://claude.com/claude-code)