### PR TITLE
doc: Change title from Wvlet Uni to Uni

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wvlet Uni
+# Uni
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress'
 
 export default defineConfig({
-  title: 'Wvlet Uni',
+  title: 'Uni',
   description: 'Essential Scala Utilities - Refined for Scala 3 with minimal dependencies',
 
   base: '/uni/',

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,8 +1,8 @@
 # Introduction
 
-**Wvlet Uni** — Essential Scala Utilities, refined for Scala 3 with minimal dependencies.
+**Uni** — Essential Scala Utilities, refined for Scala 3 with minimal dependencies.
 
-Wvlet Uni provides small, reusable building blocks that complement the Scala standard library. It consolidates foundational utilities from the [wvlet/airframe](https://github.com/wvlet/airframe) project into a single, cohesive library.
+Uni provides small, reusable building blocks that complement the Scala standard library. It consolidates foundational utilities from the [wvlet/airframe](https://github.com/wvlet/airframe) project into a single, cohesive library.
 
 ## What is Uni?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 layout: home
 
 hero:
-  name: Wvlet Uni
+  name: Uni
   text: Essential Scala Utilities
   tagline: Refined for Scala 3 with minimal dependencies
   actions:


### PR DESCRIPTION
## Summary
- Change documentation title from "Wvlet Uni" to "Uni"

## Files changed
- `docs/.vitepress/config.mts` - Site title
- `docs/index.md` - Hero name
- `docs/guide/index.md` - Introduction text
- `README.md` - Repository title


🤖 Generated with [Claude Code](https://claude.com/claude-code)