### PR TITLE
chore: Skip CI tests for doc-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,8 @@ jobs:
           detailed_summary: true
   test_js:
     name: Scala.js
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -89,6 +91,8 @@ jobs:
           detailed_summary: true
   test_native_3:
     name: Scala Native
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -108,6 +112,8 @@ jobs:
           detailed_summary: true
   test_integration:
     name: Integration test
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add `needs: changes` and `if` conditions to `test_js`, `test_native_3`, and `test_integration` jobs in CI workflow
- These jobs now use the existing `dorny/paths-filter` setup to skip builds when only documentation files change
- The `code_format` and `test_scala_3` jobs already had these conditions; this completes the paths-filter coverage

## Test plan
- [ ] Verify CI workflow skips test jobs on doc-only PRs
- [ ] Verify CI workflow runs test jobs on source code changes

🤖 Generated with [Claude Code](https://claude.ai/code)