### PR TITLE
doc: Fix logging documentation examples and add macro explanation

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -77,20 +77,11 @@ The logging methods use Scala 3 `inline` macros, which means:
 2. **Zero overhead**: If the log level is disabled, there is no runtime cost for creating log messages
 
 ```scala
-// This is safe and efficient - expensiveComputation() is only called if DEBUG is enabled
+// expensiveComputation() is only called if DEBUG is enabled
 debug(s"Result: ${expensiveComputation()}")
 ```
 
-Unlike traditional logging frameworks, you don't need to wrap expensive computations with level checks:
-
-```scala
-// NOT needed - the macro handles this automatically
-if logger.isDebugEnabled then
-  debug(s"Expensive computation: ${computeDetails()}")
-
-// Just use the log method directly
-debug(s"Expensive computation: ${computeDetails()}")
-```
+Unlike traditional logging frameworks, you don't need to wrap expensive computations with level checks.
 
 ## Source Location
 


### PR DESCRIPTION
- Correct source location format to match actual output (- (file:line) at end)
- Replace misleading "Conditional Logging" section with "Zero-Overhead Logging"
- Explain that Scala 3 inline macros handle lazy evaluation automatically
- No need for manual isDebugEnabled checks due to macro-based implementation