### PR TITLE
doc: Fix Launcher example in CLI docs to use @option annotations

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -37,18 +37,19 @@ bar.finish()
 ### Command Launcher
 
 ```scala
-import wvlet.uni.cli.launcher.Launcher
+import wvlet.uni.cli.launcher.*
 
 case class MyApp(
+  @option(prefix = "-n,--name", description = "User name")
   name: String = "world",
+  @option(prefix = "-v,--verbose", description = "Enable verbose output")
   verbose: Boolean = false
-):
-  def run(): Unit =
-    if verbose then println(s"Running with name: ${name}")
-    println(s"Hello, ${name}!")
+)
 
-// Parse args and run
-Launcher.execute[MyApp](args)
+// Parse command-line arguments
+val app = Launcher.execute[MyApp](args)
+if app.verbose then println(s"Running with name: ${app.name}")
+println(s"Hello, ${app.name}!")
 ```
 
 ## Features


### PR DESCRIPTION
## Summary
- Fixed the Command Launcher example in the CLI documentation to show correct usage with `@option` annotations
- The previous example showed a case class without annotations and a `run()` method, which doesn't reflect how Launcher actually works
- Updated to demonstrate proper argument parsing using `@option` annotations

## Test plan
- [x] Verify the example matches the actual Launcher API usage shown in `docs/cli/launcher.md`
- [ ] Visual inspection of the rendered documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)