### PR TITLE
doc: Add social preview meta tags for documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -15,7 +15,18 @@ export default defineConfig({
   },
 
   head: [
-    ['link', { rel: 'icon', href: '/uni/favicon.ico' }]
+    ['link', { rel: 'icon', href: '/uni/favicon.ico' }],
+    // Open Graph
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:title', content: 'Uni - Essential Scala Utilities' }],
+    ['meta', { property: 'og:description', content: 'Essential Scala Utilities - Refined for Scala 3 with minimal dependencies' }],
+    ['meta', { property: 'og:image', content: 'https://wvlet.org/uni/uni-banner-1280x640.png' }],
+    ['meta', { property: 'og:url', content: 'https://wvlet.org/uni/' }],
+    // Twitter Card
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ['meta', { name: 'twitter:title', content: 'Uni - Essential Scala Utilities' }],
+    ['meta', { name: 'twitter:description', content: 'Essential Scala Utilities - Refined for Scala 3 with minimal dependencies' }],
+    ['meta', { name: 'twitter:image', content: 'https://wvlet.org/uni/uni-banner-1280x640.png' }]
   ],
 
   themeConfig: {


### PR DESCRIPTION
## Summary
- Add Open Graph meta tags (og:title, og:description, og:image, og:url, og:type) for social platforms
- Add Twitter Card meta tags with `summary_large_image` card type for full banner display
- Uses the existing `uni-banner-1280x640.png` banner image

## Test plan
- [ ] Deploy documentation and verify meta tags are present in page source
- [ ] Test social preview using [Twitter Card Validator](https://cards-dev.twitter.com/validator) or [OpenGraph.xyz](https://www.opengraph.xyz/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)