### PR TITLE
chore: Move uni-netty package from wvlet.uni.netty to wvlet.uni.http.netty

### DIFF
--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyHttpServer.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyHttpServer.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.uni.netty
+package wvlet.uni.http.netty
 
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel.{Channel, ChannelFuture, ChannelInitializer, ChannelOption, EventLoopGroup}

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyRequestHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyRequestHandler.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.uni.netty
+package wvlet.uni.http.netty
 
 import io.netty.buffer.Unpooled
 import io.netty.channel.{ChannelFutureListener, ChannelHandlerContext, SimpleChannelInboundHandler}

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyServer.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyServer.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.uni.netty
+package wvlet.uni.http.netty
 
 import wvlet.uni.http.{HttpHandler, Request, Response}
 import wvlet.uni.rx.Rx

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.uni.netty
+package wvlet.uni.http.netty
 
 import wvlet.uni.http.{Request, Response}
 import wvlet.uni.http.router.*

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/RxHttpHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/RxHttpHandler.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.uni.netty
+package wvlet.uni.http.netty
 
 import wvlet.uni.http.{HttpFilter, HttpHandler, Request, Response}
 import wvlet.uni.rx.Rx

--- a/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
+++ b/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.uni.netty
+package wvlet.uni.http.netty
 
 import wvlet.uni.http.{HttpHandler, HttpMethod, Request, Response}
 import wvlet.uni.rx.Rx


### PR DESCRIPTION
## Summary
- Move all uni-netty source files from `wvlet.uni.netty` to `wvlet.uni.http.netty` package
- Update package declarations in all 5 source files and 1 test file
- Better aligns the netty server implementation with its HTTP-specific purpose

## Changes
- `NettyHttpServer.scala` - HTTP server implementation
- `NettyRequestHandler.scala` - Channel handler for HTTP requests
- `NettyServer.scala` - Server config and entry point
- `RouterHandler.scala` - Router-based request handler
- `RxHttpHandler.scala` - Reactive HTTP handler traits
- `NettyServerTest.scala` - Server tests

## Test plan
- [x] `./sbt netty/compile` - Compilation passes
- [x] `./sbt netty/test` - All 13 tests pass
- [x] `./sbt scalafmtAll` - Code formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)