### PR TITLE
docs: Add REST server and router documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -77,6 +77,8 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/http/' },
             { text: 'HTTP Client', link: '/http/client' },
+            { text: 'REST Server', link: '/http/server' },
+            { text: 'Router', link: '/http/router' },
             { text: 'Retry Strategies', link: '/http/retry' }
           ]
         },
@@ -144,6 +146,8 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/http/' },
             { text: 'HTTP Client', link: '/http/client' },
+            { text: 'REST Server', link: '/http/server' },
+            { text: 'Router', link: '/http/router' },
             { text: 'Retry Strategies', link: '/http/retry' }
           ]
         },

--- a/docs/http/index.md
+++ b/docs/http/index.md
@@ -1,12 +1,14 @@
 # HTTP Framework
 
-uni provides a cross-platform HTTP client with automatic retry, streaming support, and reactive integration.
+uni provides a cross-platform HTTP client and a Netty-based HTTP server with automatic retry, streaming support, and reactive integration.
 
 ## Overview
 
 | Component | Description |
 |-----------|-------------|
 | [HTTP Client](./client) | Sync and async HTTP clients |
+| [REST Server](./server) | Netty-based HTTP server with routing |
+| [Router](./router) | Type-safe route definitions |
 | [Retry Strategies](./retry) | Automatic retry for transient failures |
 
 ## Quick Start

--- a/docs/http/router.md
+++ b/docs/http/router.md
@@ -1,0 +1,254 @@
+# Router
+
+The router framework extracts endpoint definitions from controllers at compile-time and matches incoming requests to handler methods.
+
+## Router Builder
+
+### Creating a Router
+
+Use `Router.of[T]` to extract routes from a controller class:
+
+```scala
+import wvlet.uni.http.HttpMethod
+import wvlet.uni.http.router.{Endpoint, Router}
+
+class UserController:
+  @Endpoint(HttpMethod.GET, "/users")
+  def listUsers(): String = "[]"
+
+  @Endpoint(HttpMethod.GET, "/users/:id")
+  def getUser(id: String): String = s"""{"id":"${id}"}"""
+
+val router = Router.of[UserController]
+
+// Check extracted routes
+println(router.routeSummary)
+// Router:
+//   GET /users -> listUsers
+//   GET /users/:id -> getUser
+```
+
+The macro extracts all methods annotated with `@Endpoint` and creates route definitions.
+
+### Combining Routers
+
+Use `andThen` to combine multiple routers:
+
+```scala
+class UserController:
+  @Endpoint(HttpMethod.GET, "/users")
+  def listUsers(): String = "[]"
+
+class ItemController:
+  @Endpoint(HttpMethod.GET, "/items")
+  def listItems(): String = "[]"
+
+class HealthController:
+  @Endpoint(HttpMethod.GET, "/health")
+  def health(): String = "ok"
+
+val router = Router.of[HealthController]
+  .andThen(Router.of[UserController])
+  .andThen(Router.of[ItemController])
+```
+
+Routes are matched in the order they are added.
+
+### Empty Router
+
+Create an empty router to combine with others:
+
+```scala
+val baseRouter = Router.empty
+val fullRouter = baseRouter
+  .andThen(Router.of[Controller1])
+  .andThen(Router.of[Controller2])
+```
+
+## Controller Provider
+
+The `ControllerProvider` interface determines how controller instances are created.
+
+### SimpleControllerProvider
+
+The default provider creates instances using reflection:
+
+```scala
+import wvlet.uni.http.router.SimpleControllerProvider
+import wvlet.uni.http.netty.RouterHandler
+
+val router = Router.of[UserController]
+val handler = RouterHandler(router)  // Uses SimpleControllerProvider
+
+// Equivalent to:
+val handler2 = RouterHandler(router, SimpleControllerProvider())
+```
+
+Controllers must have a no-argument constructor.
+
+### MapControllerProvider
+
+For pre-configured instances (useful for testing or dependency injection):
+
+```scala
+import wvlet.uni.http.router.MapControllerProvider
+
+class UserController(userService: UserService):
+  @Endpoint(HttpMethod.GET, "/users")
+  def listUsers(): Seq[User] = userService.findAll()
+
+// Create controller with dependencies
+val userService = UserService()
+val controller = UserController(userService)
+
+// Register pre-created instance
+val provider = MapControllerProvider(controller)
+val handler = RouterHandler(router, provider)
+```
+
+Multiple controllers:
+
+```scala
+val provider = MapControllerProvider(
+  UserController(userService),
+  ItemController(itemService),
+  HealthController()
+)
+```
+
+### Custom Provider
+
+Implement `ControllerProvider` for custom instantiation logic:
+
+```scala
+import wvlet.uni.http.router.ControllerProvider
+import wvlet.uni.surface.Surface
+
+class DIControllerProvider(container: DIContainer) extends ControllerProvider:
+  override def get(surface: Surface): Any =
+    container.getInstance(surface.rawType)
+
+  override def getFilter(surface: Surface): Any =
+    container.getInstance(surface.rawType)
+```
+
+## Route Matching
+
+### Match Order
+
+Routes are matched sequentially in the order they were added:
+
+```scala
+val router = Router.of[SpecificController]  // Matched first
+  .andThen(Router.of[GeneralController])    // Matched second
+```
+
+More specific routes should be added before general ones.
+
+### Path Matching
+
+Routes match when:
+1. HTTP method matches exactly
+2. Number of path segments matches
+3. Each segment matches (literal or parameter)
+
+```scala
+// Route: GET /users/:id
+// Matches: GET /users/123      -> id = "123"
+// Matches: GET /users/alice    -> id = "alice"
+// No match: GET /users/123/posts  (different segment count)
+// No match: POST /users/123       (different method)
+```
+
+### Path Components
+
+Paths are parsed into components:
+
+| Pattern | Component Type | Matches |
+|---------|---------------|---------|
+| `users` | Literal | Exact string "users" |
+| `:id` | Parameter | Any string (captured) |
+
+```scala
+// GET /users/:userId/posts/:postId
+// Matches: GET /users/1/posts/42
+// Extracted: userId = "1", postId = "42"
+```
+
+## Router with Filters
+
+Add filters that apply to all routes in a router:
+
+```scala
+import wvlet.uni.http.netty.RxHttpFilter
+
+class AuthFilter extends RxHttpFilter:
+  def apply(request: Request, next: RxHttpHandler): Rx[Response] =
+    if isAuthenticated(request) then
+      next.handle(request)
+    else
+      Rx.single(Response.unauthorized)
+
+val router = Router
+  .filter[AuthFilter]
+  .andThen(Router.of[ProtectedController])
+```
+
+The filter is instantiated using the same `ControllerProvider` as controllers.
+
+## RouterHandler
+
+The `RouterHandler` connects a router to the Netty server:
+
+```scala
+import wvlet.uni.http.netty.{RouterHandler, NettyServer}
+
+val router = Router.of[MyController]
+val handler = RouterHandler(router)
+
+NettyServer
+  .withPort(8080)
+  .withRxHandler(handler)
+  .start()
+```
+
+### With Custom Provider
+
+```scala
+val handler = RouterHandler(router, myControllerProvider)
+```
+
+### With Pre-registered Controllers
+
+```scala
+val handler = RouterHandler.withControllers(
+  router,
+  controller1,
+  controller2
+)
+```
+
+## Request Mapping
+
+The `HttpRequestMapper` binds request data to method parameters in this order:
+
+1. **Path parameters** - From URL path (`:id` -> value)
+2. **Query parameters** - From URL query string
+3. **Default values** - Method parameter defaults
+4. **Request object** - If parameter type is `Request`
+
+```scala
+@Endpoint(HttpMethod.GET, "/search/:category")
+def search(
+    category: String,        // From path: /search/books
+    query: String,           // From query: ?query=scala
+    limit: Int = 10,         // From query or default
+    request: Request         // The full request
+): Response = ???
+```
+
+Request: `GET /search/books?query=scala&limit=20`
+- `category` = "books"
+- `query` = "scala"
+- `limit` = 20
+- `request` = full Request object

--- a/docs/http/server.md
+++ b/docs/http/server.md
@@ -1,0 +1,380 @@
+# REST Server
+
+uni provides a Netty-based HTTP server with a type-safe router framework for building REST APIs.
+
+## Quick Start
+
+```scala
+import wvlet.uni.http.{HttpMethod, Request, Response}
+import wvlet.uni.http.router.{Endpoint, Router}
+import wvlet.uni.http.netty.{NettyServer, RouterHandler}
+
+// Define a controller
+class UserController:
+  @Endpoint(HttpMethod.GET, "/users")
+  def listUsers(): String = """["alice", "bob"]"""
+
+  @Endpoint(HttpMethod.GET, "/users/:id")
+  def getUser(id: String): String = s"""{"id": "${id}"}"""
+
+// Create router and start server
+val router = Router.of[UserController]
+val handler = RouterHandler(router)
+
+NettyServer
+  .withPort(8080)
+  .withRxHandler(handler)
+  .start { server =>
+    println(s"Server running on port ${server.localPort}")
+    // Server runs until the block completes
+  }
+```
+
+## Defining Endpoints
+
+Use the `@Endpoint` annotation to mark controller methods as HTTP endpoints:
+
+```scala
+import wvlet.uni.http.HttpMethod
+import wvlet.uni.http.router.Endpoint
+
+class ApiController:
+  @Endpoint(HttpMethod.GET, "/health")
+  def health(): String = "ok"
+
+  @Endpoint(HttpMethod.POST, "/data")
+  def createData(request: Request): Response =
+    val body = request.content.toContentString
+    Response.ok(s"Received: ${body}")
+
+  @Endpoint(HttpMethod.PUT, "/items/:id")
+  def updateItem(id: String, request: Request): Response =
+    Response.ok(s"Updated item ${id}")
+
+  @Endpoint(HttpMethod.DELETE, "/items/:id")
+  def deleteItem(id: String): Response =
+    Response.noContent
+```
+
+### Path Parameters
+
+Use `:paramName` syntax in the path to capture path segments:
+
+```scala
+class ItemController:
+  @Endpoint(HttpMethod.GET, "/items/:id")
+  def getItem(id: String): String = s"Item ${id}"
+
+  @Endpoint(HttpMethod.GET, "/users/:userId/posts/:postId")
+  def getUserPost(userId: String, postId: String): String =
+    s"User ${userId}, Post ${postId}"
+```
+
+Path parameter names must match the method parameter names.
+
+### Query Parameters
+
+Method parameters that don't match path parameters are automatically bound from query string:
+
+```scala
+class SearchController:
+  @Endpoint(HttpMethod.GET, "/search")
+  def search(query: String, limit: Int = 10): String =
+    s"Searching for '${query}' with limit ${limit}"
+```
+
+Request: `GET /search?query=hello&limit=20`
+
+Supported parameter types:
+- `String`
+- `Int`, `Long`, `Short`, `Byte`
+- `Double`, `Float`
+- `Boolean`
+- `Option[T]` for optional parameters
+
+### Request Object Access
+
+Add a `Request` parameter to access the full request:
+
+```scala
+class MyController:
+  @Endpoint(HttpMethod.POST, "/upload")
+  def upload(request: Request): Response =
+    val contentType = request.headers.get("Content-Type")
+    val body = request.content.toContentString
+    Response.ok(s"Received ${body.length} bytes")
+```
+
+## Request and Response
+
+### Request Properties
+
+```scala
+request.method              // HttpMethod (GET, POST, etc.)
+request.uri                 // Full URI string
+request.path                // Path portion of URI
+request.headers             // HttpHeaders
+request.content             // HttpContent (request body)
+request.getQueryParam(name) // Option[String]
+```
+
+### Response Factory Methods
+
+```scala
+Response.ok                        // 200 OK
+Response.ok("body")                // 200 with text body
+Response.created                   // 201 Created
+Response.noContent                 // 204 No Content
+Response.badRequest("message")     // 400 Bad Request
+Response.notFound                  // 404 Not Found
+Response.notFound("message")       // 404 with message
+Response.internalServerError(msg)  // 500 Internal Server Error
+```
+
+### Response Content
+
+```scala
+Response.ok
+  .withTextContent("Hello")           // text/plain
+  .withJsonContent("""{"a": 1}""")    // application/json
+  .withBytesContent(bytes)            // application/octet-stream
+  .withContent(HttpContent.json(str)) // Custom content
+  .addHeader("X-Custom", "value")     // Add header
+```
+
+## Response Conversion
+
+Controller methods can return various types that are automatically converted to responses:
+
+| Return Type | Conversion |
+|-------------|------------|
+| `Response` | Returned as-is |
+| `Rx[Response]` | Async response |
+| `String` | 200 OK with text/plain |
+| `Seq[T]` | 200 OK with JSON array |
+| `Map[K, V]` | 200 OK with JSON object |
+| `Option[T]` | Value or 204 No Content |
+| `Unit` | 204 No Content |
+| Other types | Serialized to JSON |
+
+```scala
+class DataController:
+  @Endpoint(HttpMethod.GET, "/text")
+  def getText(): String = "plain text"
+
+  @Endpoint(HttpMethod.GET, "/list")
+  def getList(): Seq[String] = Seq("a", "b", "c")
+
+  @Endpoint(HttpMethod.GET, "/map")
+  def getMap(): Map[String, Int] = Map("count" -> 42)
+
+  @Endpoint(HttpMethod.GET, "/async")
+  def getAsync(): Rx[Response] =
+    Rx.single(Response.ok("async result"))
+```
+
+## Filters
+
+Use `RxHttpFilter` to intercept requests and responses:
+
+```scala
+import wvlet.uni.http.netty.{RxHttpFilter, RxHttpHandler}
+
+val loggingFilter = RxHttpFilter { (request, next) =>
+  println(s"Request: ${request.method} ${request.path}")
+  next
+    .handle(request)
+    .map { response =>
+      println(s"Response: ${response.status}")
+      response
+    }
+}
+
+val authFilter = RxHttpFilter { (request, next) =>
+  request.headers.get("Authorization") match
+    case Some(token) if isValid(token) =>
+      next.handle(request.addHeader("X-User-Id", extractUserId(token)))
+    case _ =>
+      Rx.single(Response.unauthorized("Missing or invalid token"))
+}
+```
+
+### Applying Filters
+
+```scala
+// Apply filter to server
+NettyServer
+  .withPort(8080)
+  .withFilter(loggingFilter)
+  .withFilter(authFilter)
+  .withRxHandler(handler)
+  .start()
+
+// Or compose filters
+val combinedFilter = loggingFilter.andThen(authFilter)
+```
+
+### Router-Level Filters
+
+Define filters that apply to specific controllers:
+
+```scala
+class LogFilter extends RxHttpFilter:
+  def apply(request: Request, next: RxHttpHandler): Rx[Response] =
+    println(s"Handling: ${request.path}")
+    next.handle(request)
+
+val router = Router
+  .filter[LogFilter]
+  .andThen(Router.of[UserController])
+```
+
+## Server Configuration
+
+### NettyServerConfig Options
+
+```scala
+NettyServer
+  .withPort(8080)                      // Port to listen on (0 for random)
+  .withHost("0.0.0.0")                 // Bind address
+  .withName("my-server")               // Server name for logging
+  .withMaxContentLength(1024 * 1024)   // Max request body size (1MB)
+  .withMaxHeaderSize(8192)             // Max header size
+  .withMaxInitialLineLength(4096)      // Max request line length
+  .noNativeTransport                   // Disable native transport (epoll/kqueue)
+  .withHandler(handler)
+  .start()
+```
+
+### Server Lifecycle
+
+```scala
+// Start and get server instance
+val server = NettyServer
+  .withPort(8080)
+  .withHandler(handler)
+  .start()
+
+println(s"Running on port ${server.localPort}")
+server.isRunning  // true
+
+// Stop when done
+server.stop()
+server.isRunning  // false
+```
+
+### Block-based Server
+
+For simpler use cases, use the block form that automatically stops the server:
+
+```scala
+NettyServer
+  .withPort(8080)
+  .withHandler(handler)
+  .start { server =>
+    // Server runs while this block executes
+    println(s"Server on port ${server.localPort}")
+    Thread.sleep(60000)  // Run for 1 minute
+  }
+// Server automatically stopped here
+```
+
+## Simple Handler
+
+For simple cases without routing, use a direct handler:
+
+```scala
+NettyServer
+  .withPort(8080)
+  .withHandler { request =>
+    Response.ok(s"Hello from ${request.path}")
+  }
+  .start()
+```
+
+Or with async responses:
+
+```scala
+NettyServer
+  .withPort(8080)
+  .withRxHandler { request =>
+    Rx.single(Response.ok("async response"))
+  }
+  .start()
+```
+
+## Combining Controllers
+
+Combine multiple controllers into a single router:
+
+```scala
+class UserController:
+  @Endpoint(HttpMethod.GET, "/users")
+  def listUsers(): String = "[]"
+
+class ItemController:
+  @Endpoint(HttpMethod.GET, "/items")
+  def listItems(): String = "[]"
+
+val router = Router.of[UserController]
+  .andThen(Router.of[ItemController])
+
+val handler = RouterHandler(router)
+```
+
+## Example: Complete REST API
+
+```scala
+import wvlet.uni.http.{HttpMethod, Request, Response}
+import wvlet.uni.http.router.{Endpoint, Router}
+import wvlet.uni.http.netty.{NettyServer, RouterHandler, RxHttpFilter}
+import wvlet.uni.rx.Rx
+
+case class User(id: String, name: String)
+
+class UserController:
+  private var users = Map(
+    "1" -> User("1", "Alice"),
+    "2" -> User("2", "Bob")
+  )
+
+  @Endpoint(HttpMethod.GET, "/users")
+  def listUsers(): Seq[User] = users.values.toSeq
+
+  @Endpoint(HttpMethod.GET, "/users/:id")
+  def getUser(id: String): Response =
+    users.get(id) match
+      case Some(user) => Response.ok.withJsonContent(s"""{"id":"${user.id}","name":"${user.name}"}""")
+      case None => Response.notFound(s"User ${id} not found")
+
+  @Endpoint(HttpMethod.POST, "/users")
+  def createUser(request: Request): Response =
+    // Parse and create user
+    Response.created.withJsonContent("""{"id":"3","name":"New User"}""")
+
+  @Endpoint(HttpMethod.DELETE, "/users/:id")
+  def deleteUser(id: String): Response =
+    users -= id
+    Response.noContent
+
+val loggingFilter = RxHttpFilter { (request, next) =>
+  val start = System.currentTimeMillis()
+  next.handle(request).map { response =>
+    val duration = System.currentTimeMillis() - start
+    println(s"${request.method} ${request.path} -> ${response.status} (${duration}ms)")
+    response
+  }
+}
+
+val router = Router.of[UserController]
+val handler = RouterHandler(router)
+
+NettyServer
+  .withPort(8080)
+  .withFilter(loggingFilter)
+  .withRxHandler(handler)
+  .start { server =>
+    println(s"API running at http://localhost:${server.localPort}")
+    Thread.currentThread().join()  // Run indefinitely
+  }
+```


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for the REST Router Framework introduced in #357
- Document `server.md`: endpoint definitions, path/query parameters, request/response handling, filters, server configuration
- Document `router.md`: router builder API, controller providers, route matching, request mapping
- Update HTTP overview and sidebar navigation

## Test plan
- [x] Verified docs build successfully with `npm run docs:build`
- [x] Verified pages render correctly with `npm run docs:dev`
- [x] Codex review passed with no issues

🤖 Generated with [Claude Code](https://claude.ai/code)