### PR TITLE
docs: Feature UniTest on landing page instead of LLM Agent Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ libraryDependencies += "org.wvlet.uni" %% "uni" % "(version)"
 | Module | Description |
 |--------|-------------|
 | `uni` | Core utilities: Design, logging, JSON, MessagePack, HTTP, Rx |
+| `uni-test` | Lightweight testing framework with cross-platform support |
+| `uni-netty` | Netty-based HTTP server |
 | `uni-agent` | LLM agent framework with tool integration |
-| `uni-test` | Lightweight testing framework |
+| `uni-bedrock` | AWS Bedrock chat model integration |
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,9 +27,9 @@ features:
   - title: CLI Utilities
     details: Terminal styling, progress indicators, and type-safe command-line argument parsing.
     link: /cli/
-  - title: LLM Agent Framework
-    details: Build AI agents with tool calling, chat sessions, and AWS Bedrock integration.
-    link: /agent/
+  - title: UniTest
+    details: Lightweight testing framework with expressive assertions, property-based testing, and cross-platform support.
+    link: /core/unitest
 ---
 
 ## Getting Started
@@ -66,6 +66,7 @@ class MyService extends LogSupport:
 | Module | Description |
 |--------|-------------|
 | `uni` | Core utilities: Design, logging, JSON, MessagePack, Rx, HTTP client |
+| `uni-test` | Lightweight testing framework with cross-platform support |
 | `uni-agent` | LLM agent framework with tool integration |
 | `uni-bedrock` | AWS Bedrock chat model integration |
 


### PR DESCRIPTION
## Summary

- Replace "LLM Agent Framework" feature card with "UniTest" on landing page
- Update modules table in docs to feature `uni-test` before `uni-agent`
- Update README.md modules table with all modules: `uni-test`, `uni-netty`, `uni-agent`, `uni-bedrock`

UniTest is a mature, cross-platform testing framework that deserves more visibility. The Agent Framework remains accessible via the sidebar navigation.

## Test plan

- [ ] Run `npm run docs:dev` and verify landing page shows UniTest as a featured module
- [ ] Verify the modules table ordering is correct on landing page
- [ ] Verify README.md modules table includes all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)