### PR TITLE
deps: Update Scala version from 3.7.3 to 3.8.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtide.Keys.ideSkipProject
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val SCALA_3                             = "3.7.3"
+val SCALA_3                             = "3.8.1"
 val AIRFRAME_VERSION                    = "2025.1.27"
 val AWS_SDK_VERSION                     = "2.41.10"
 val JS_JAVA_LOGGING_VERSION             = "1.0.0"


### PR DESCRIPTION
## Summary
- Update Scala version from 3.7.3 to 3.8.1 (latest stable 3.8.x release)
- 3.8.1 is a hotfix release that addresses JVM linkage errors found in 3.8.0

## Test plan
- [x] Compiled successfully across all platforms (JVM, JS, Native)
- [x] All 1001 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)