### PR TITLE
docs: Add Google Analytics to track site usage

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,6 +16,16 @@ export default defineConfig({
 
   head: [
     ['link', { rel: 'icon', href: '/uni/favicon.ico' }],
+    // Google Analytics
+    ['script', { async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-55G099WF5N' }],
+    [
+      'script',
+      {},
+      `window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-55G099WF5N');`
+    ],
     // Open Graph
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:title', content: 'Uni - Essential Scala Utilities' }],


### PR DESCRIPTION
## Summary
- Add Google Analytics (GA4) tracking to the VitePress documentation site
- Use the same tracking ID (`G-55G099WF5N`) as the wvlet/wvlet repo for unified analytics across wvlet.org sites

## Test plan
- [x] Verified docs build successfully with `npm run docs:build`
- [x] Confirmed GA script is included in generated HTML files

🤖 Generated with [Claude Code](https://claude.com/claude-code)