### PR TITLE
feature: Add JSONC support to JSON parser

### DIFF
--- a/docs/core/json.md
+++ b/docs/core/json.md
@@ -71,7 +71,7 @@ json match
   case JSONLong(n) => // Integer value
   case JSONDouble(d) => // Floating point
   case JSONBoolean(b) => // Boolean
-  case JSONNull => // Null value
+  case _: JSONNull => // Null value
 ```
 
 ## Creating JSON
@@ -138,6 +138,63 @@ val result = Try(JSON.parse(maybeInvalidJson))
 result match
   case scala.util.Success(json) => // Use json
   case scala.util.Failure(e) => // Handle parse failure
+```
+
+## JSONC Support
+
+uni's JSON parser supports [JSONC](https://jsonc.org/) (JSON with Comments) out of the box. Line comments (`//`), block comments (`/* */`), and trailing commas are all accepted by `JSON.parse`:
+
+```scala
+val config = JSON.parse("""
+{
+  // Database configuration
+  "host": "localhost", // server address
+  "port": 5432,
+  "options": {
+    /* Connection pool settings */
+    "minConnections": 5,
+    "maxConnections": 20,
+  }
+}
+""")
+```
+
+### Comment Round-Tripping
+
+Comments are preserved as mutable metadata on value nodes for round-tripping:
+
+```scala
+val v = JSON.parse("""{"key": "value" // important}""")
+
+// Comments are attached to nearby value nodes
+val keyVal = v("key")
+keyVal.trailingComment // Some(JSONComment("// important"))
+
+// toJSON outputs valid JSON (no comments)
+v.toJSON // {"key":"value"}
+
+// toJSONC preserves comments
+v.toJSONC // {"key":"value" // important}
+
+// JSON.format pretty-prints with comments
+JSON.format(v)
+// {
+//   "key": "value" // important
+// }
+```
+
+### Comment Attachment Rules
+
+- **New-line comments** are attached as `leadingComments` on the **next** value node
+- **Inline comments** (same line) are attached as `trailingComment` on the **previous** value node
+
+### JSONComment
+
+```scala
+val comment = JSONComment("// server host")
+comment.commentBody    // "server host"
+comment.isLineComment  // true
+comment.isBlockComment // false
 ```
 
 ## YAML Output

--- a/docs/core/json.md
+++ b/docs/core/json.md
@@ -164,7 +164,9 @@ val config = JSON.parse("""
 Comments are preserved as mutable metadata on value nodes for round-tripping:
 
 ```scala
-val v = JSON.parse("""{"key": "value" // important}""")
+val v = JSON.parse("""{
+  "key": "value" // important
+}""")
 
 // Comments are attached to nearby value nodes
 val keyVal = v("key")
@@ -172,9 +174,6 @@ keyVal.trailingComment // Some(JSONComment("// important"))
 
 // toJSON outputs valid JSON (no comments)
 v.toJSON // {"key":"value"}
-
-// toJSONC preserves comments
-v.toJSONC // {"key":"value" // important}
 
 // JSON.format pretty-prints with comments
 JSON.format(v)

--- a/uni/src/main/scala/wvlet/uni/json/JSON.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSON.scala
@@ -168,22 +168,24 @@ object JSON extends LogSupport:
       this match
         case x: JSONObject =>
           sb.append("{")
-          val entries = x.v.toIndexedSeq
-          for i <- entries.indices do
-            val (k, v) = entries(i)
+          var first = true
+          for (k, v) <- x.v do
+            if !first then
+              sb.append(",")
             sb.append("\"")
             sb.append(quoteJSONString(k))
             sb.append("\":")
             sb.append(v.toJSONC)
-            if i < entries.size - 1 then
-              sb.append(",")
+            first = false
           sb.append("}")
         case x: JSONArray =>
           sb.append("[")
-          for i <- x.v.indices do
-            sb.append(x.v(i).toJSONC)
-            if i < x.v.size - 1 then
+          var first = true
+          for elem <- x.v do
+            if !first then
               sb.append(",")
+            sb.append(elem.toJSONC)
+            first = false
           sb.append("]")
         case _ =>
           sb.append(toJSON)

--- a/uni/src/main/scala/wvlet/uni/json/JSON.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSON.scala
@@ -165,12 +165,37 @@ object JSON extends LogSupport:
       for c <- leadingComments do
         sb.append(c.text)
         sb.append("\n")
-      sb.append(toJSON)
+      this match
+        case x: JSONObject =>
+          sb.append("{")
+          val entries = x.v.toIndexedSeq
+          for i <- entries.indices do
+            val (k, v) = entries(i)
+            sb.append("\"")
+            sb.append(quoteJSONString(k))
+            sb.append("\":")
+            sb.append(v.toJSONC)
+            if i < entries.size - 1 then
+              sb.append(",")
+          sb.append("}")
+        case x: JSONArray =>
+          sb.append("[")
+          for i <- x.v.indices do
+            sb.append(x.v(i).toJSONC)
+            if i < x.v.size - 1 then
+              sb.append(",")
+          sb.append("]")
+        case _ =>
+          sb.append(toJSON)
       trailingComment.foreach { c =>
         sb.append(" ")
         sb.append(c.text)
       }
       sb.result()
+
+    end toJSONC
+
+  end JSONValue
 
   case class JSONNull() extends JSONValue:
     override def toJSON: String = "null"

--- a/uni/src/main/scala/wvlet/uni/json/JSON.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSON.scala
@@ -16,6 +16,24 @@ package wvlet.uni.json
 import wvlet.uni.log.LogSupport
 
 /**
+  * Represents a comment in JSONC. The text includes delimiters (e.g., "// comment" or "/​* block
+  * *​/").
+  */
+case class JSONComment(text: String):
+  def commentBody: String =
+    if text.startsWith("//") then
+      text.substring(2).trim
+    else if text.startsWith("/*") && text.endsWith("*/") then
+      text.substring(2, text.length - 2).trim
+    else
+      text
+
+  def isLineComment: Boolean  = text.startsWith("//")
+  def isBlockComment: Boolean = text.startsWith("/*")
+
+end JSONComment
+
+/**
   */
 object JSON extends LogSupport:
 
@@ -59,50 +77,78 @@ object JSON extends LogSupport:
     * Format JSON value
     */
   def format(v: JSONValue): String =
-    def formatInternal(v: JSONValue, level: Int = 0): String =
-      val s = new StringBuilder()
+    def indent(level: Int): String = "  " * level
+
+    def appendComments(sb: StringBuilder, comments: Seq[JSONComment], level: Int): Unit =
+      for c <- comments do
+        sb.append(indent(level))
+        sb.append(c.text)
+        sb.append("\n")
+
+    // Format a value without its leading/trailing comments (those are handled by the caller)
+    def formatValue(v: JSONValue, level: Int): String =
       v match
         case x: JSONObject =>
           if x.v.isEmpty then
-            s.append("{}")
+            "{}"
           else
+            val s = new StringBuilder()
             s.append("{\n")
-            s.append {
-              x.v
-                .map { case (k, v: JSONValue) =>
-                  val ss = new StringBuilder
-                  ss.append("  " * (level + 1))
-                  ss.append("\"")
-                  ss.append(quoteJSONString(k))
-                  ss.append("\": ")
-                  ss.append(formatInternal(v, level + 1))
-                  ss.result()
+            val entries = x.v.toIndexedSeq
+            for i <- entries.indices do
+              val (k, ev) = entries(i)
+              appendComments(s, ev.leadingComments, level + 1)
+              s.append(indent(level + 1))
+              s.append("\"")
+              s.append(quoteJSONString(k))
+              s.append("\": ")
+              s.append(formatValue(ev, level + 1))
+              if i < entries.size - 1 then
+                s.append(",")
+              ev.trailingComment
+                .foreach { c =>
+                  s.append(" ")
+                  s.append(c.text)
                 }
-                .mkString("", ",\n", "\n")
-            }
-            s.append("  " * level)
+              s.append("\n")
+            s.append(indent(level))
             s.append("}")
+            s.result()
         case x: JSONArray =>
           if x.v.isEmpty then
-            s.append("[]")
+            "[]"
           else
+            val s = new StringBuilder()
             s.append("[\n")
-            s.append(
-              x.v
-                .map { x =>
-                  ("  " * (level + 1)) + formatInternal(x, level + 1)
+            for i <- x.v.indices do
+              val elem = x.v(i)
+              appendComments(s, elem.leadingComments, level + 1)
+              s.append(indent(level + 1))
+              s.append(formatValue(elem, level + 1))
+              if i < x.v.size - 1 then
+                s.append(",")
+              elem
+                .trailingComment
+                .foreach { c =>
+                  s.append(" ")
+                  s.append(c.text)
                 }
-                .mkString("", ",\n", "\n")
-            )
-            s.append("  " * level)
+              s.append("\n")
+            s.append(indent(level))
             s.append("]")
+            s.result()
         case x =>
-          s.append(x.toJSON)
-      end match
-      s.result()
-    end formatInternal
+          x.toJSON
 
-    formatInternal(v, 0)
+    val sb = new StringBuilder()
+    appendComments(sb, v.leadingComments, 0)
+    sb.append(formatValue(v, 0))
+    v.trailingComment
+      .foreach { c =>
+        sb.append(" ")
+        sb.append(c.text)
+      }
+    sb.result()
 
   end format
 
@@ -110,7 +156,23 @@ object JSON extends LogSupport:
     override def toString = toJSON
     def toJSON: String
 
-  case object JSONNull extends JSONValue:
+    // Mutable comment annotations for JSONC round-tripping
+    var leadingComments: Seq[JSONComment]    = Nil
+    var trailingComment: Option[JSONComment] = None
+
+    def toJSONC: String =
+      val sb = StringBuilder()
+      for c <- leadingComments do
+        sb.append(c.text)
+        sb.append("\n")
+      sb.append(toJSON)
+      trailingComment.foreach { c =>
+        sb.append(" ")
+        sb.append(c.text)
+      }
+      sb.result()
+
+  case class JSONNull() extends JSONValue:
     override def toJSON: String = "null"
 
   final case class JSONBoolean(val v: Boolean) extends JSONValue:

--- a/uni/src/main/scala/wvlet/uni/json/JSONEventHandler.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSONEventHandler.scala
@@ -40,3 +40,9 @@ trait JSONContext[Expr] extends JSONHandler[Expr]:
   def addUnescapedString(s: String): Unit
   def addNumber(s: JSONSource, start: Int, end: Int, dotIndex: Int, expIndex: Int): Unit
   def addBoolean(s: JSONSource, v: Boolean, start: Int, end: Int): Unit
+
+  /**
+    * Called when a JSONC comment is found. isTrailing is true when the comment is on the same line
+    * as the previous value (inline comment).
+    */
+  def addComment(comment: JSONComment, isTrailing: Boolean): Unit = {}

--- a/uni/src/main/scala/wvlet/uni/json/JSONScanner.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSONScanner.scala
@@ -172,10 +172,14 @@ end JSONScanner
 
 class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler[J])
     extends LogSupport:
-  private var cursor: Int       = 0
-  private var lineStartPos: Int = 0
-  private var line: Int         = 0
-  private val sb                = new StringBuilder()
+  private var cursor: Int        = 0
+  private var lineStartPos: Int  = 0
+  private var line: Int          = 0
+  private var lastValueLine: Int = -1
+  private val sb                 = new StringBuilder()
+
+  // Buffer for comments collected during whitespace skipping
+  private val commentBuffer = scala.collection.mutable.ArrayBuffer[(JSONComment, Boolean)]()
 
   import JSONScanner.*
   import JSONToken.*
@@ -191,8 +195,55 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
           cursor += 1
           line += 1
           lineStartPos = cursor
+        case Slash =>
+          if cursor + 1 < s.length then
+            val next = s(cursor + 1)
+            if next == Slash then
+              scanLineComment()
+            else if next == '*' then
+              scanBlockComment()
+            else
+              toContinue = false
+          else
+            toContinue = false
         case _ =>
           toContinue = false
+
+  private def scanLineComment(): Unit =
+    val commentLine = line
+    val start       = cursor
+    cursor += 2 // skip //
+    while cursor < s.length && s(cursor) != WS_N do
+      cursor += 1
+    val text       = s.substring(start, cursor)
+    val isTrailing = commentLine == lastValueLine && lastValueLine >= 0
+    commentBuffer += ((JSONComment(text), isTrailing))
+
+  private def scanBlockComment(): Unit =
+    val commentLine = line
+    val start       = cursor
+    cursor += 2 // skip /*
+    var found = false
+    while !found && cursor + 1 < s.length do
+      if s(cursor) == '*' && s(cursor + 1) == Slash then
+        cursor += 2
+        found = true
+      else
+        if s(cursor) == WS_N then
+          line += 1
+          lineStartPos = cursor + 1
+        cursor += 1
+    if !found then
+      throw new UnexpectedEOF(line, cursor - lineStartPos, cursor, "Unterminated block comment")
+    val text       = s.substring(start, cursor)
+    val isTrailing = commentLine == lastValueLine && lastValueLine >= 0
+    commentBuffer += ((JSONComment(text), isTrailing))
+
+  private def flushComments(ctx: JSONContext[J]): Unit =
+    if commentBuffer.nonEmpty then
+      for (comment, isTrailing) <- commentBuffer do
+        ctx.addComment(comment, isTrailing)
+      commentBuffer.clear()
 
   private def unexpected(expected: String): Exception =
     val char = s(cursor)
@@ -206,6 +257,14 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
   def scan: Unit =
     try
       skipWhiteSpaces
+      if cursor >= s.length then
+        throw new UnexpectedEOF(line, cursor - lineStartPos, cursor, "Unexpected EOF")
+      // Flush leading comments to handler (root context)
+      handler match
+        case ctx: JSONContext[J @unchecked] =>
+          flushComments(ctx)
+        case _ =>
+          commentBuffer.clear()
       (s(cursor): @switch) match
         case LBracket =>
           cursor += 1
@@ -215,6 +274,13 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
           rscan(ARRAY_START, handler.arrayContext(s, cursor - 1) :: Nil)
         case other =>
           throw unexpected("object or array")
+      // Scan trailing comments after the root value
+      skipWhiteSpaces
+      handler match
+        case ctx: JSONContext[J @unchecked] =>
+          flushComments(ctx)
+        case _ =>
+          commentBuffer.clear()
     catch
       case e: ArrayIndexOutOfBoundsException =>
         throw new UnexpectedEOF(line, cursor - lineStartPos, cursor, s"Unexpected EOF")
@@ -229,45 +295,57 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
 
   private final def scanAny(ctx: JSONContext[J]): J =
     skipWhiteSpaces
+    flushComments(ctx)
     if cursor >= s.length then
       throw new UnexpectedEOF(line, cursor - lineStartPos, cursor, "Unexpected EOF")
     (s(cursor): @switch) match
       case DoubleQuote =>
         scanString(ctx)
+        markValueLine()
       case LBracket =>
         val objectCtx = ctx.objectContext(s, cursor)
         cursor += 1
         rscan(OBJECT_START, objectCtx :: Nil)
         ctx.add(objectCtx.result)
+        markValueLine()
       case LSquare =>
         val arrayCtx = ctx.arrayContext(s, cursor)
         cursor += 1
         rscan(ARRAY_START, arrayCtx :: Nil)
         ctx.add(arrayCtx.result)
+        markValueLine()
       case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
         scanNumber(ctx)
+        markValueLine()
       case 't' =>
         scanTrue(ctx)
+        markValueLine()
       case 'f' =>
         scanFalse(ctx)
+        markValueLine()
       case 'n' =>
         scanNull(ctx)
+        markValueLine()
       case _ =>
         throw unexpected("unknown json token")
+    end match
+    // Scan trailing comments
+    skipWhiteSpaces
+    flushComments(ctx)
     ctx.result
+
+  end scanAny
+
+  private def markValueLine(): Unit = lastValueLine = line
 
   @tailrec
   private final def rscan(state: Int, stack: List[JSONContext[J]]): Unit =
+    skipWhiteSpaces
+    if cursor >= s.length then
+      throw new UnexpectedEOF(line, cursor - lineStartPos, cursor, "Unexpected EOF")
+    flushComments(stack.head)
     val ch = s(cursor)
-    if ch == WS_N then
-      cursor += 1
-      line += 1
-      lineStartPos = cursor
-      rscan(state, stack)
-    else if ch == WS || ch == WS_T || ch == WS_R then
-      cursor += 1
-      rscan(state, stack)
-    else if state == DATA then
+    if state == DATA then
       if ch == LSquare then
         cursor += 1
         rscan(ARRAY_START, stack.head.arrayContext(s, cursor - 1) :: stack)
@@ -278,21 +356,38 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
         val ctx = stack.head
         if (ch >= '0' && ch <= '9') || ch == '-' then
           scanNumber(ctx)
+          markValueLine()
           rscan(ctx.endScannerState, stack)
         else if ch == DoubleQuote then
           scanString(ctx)
+          markValueLine()
           rscan(ctx.endScannerState, stack)
         else if ch == 't' then
           scanTrue(ctx)
+          markValueLine()
           rscan(ctx.endScannerState, stack)
         else if ch == 'f' then
           scanFalse(ctx)
+          markValueLine()
           rscan(ctx.endScannerState, stack)
         else if ch == 'n' then
           scanNull(ctx)
+          markValueLine()
           rscan(ctx.endScannerState, stack)
+        // Trailing comma support: closing bracket after comma in DATA state
+        else if (ch == RSquare && !stack.head.isObjectContext) ||
+          (ch == RBracket && stack.head.isObjectContext)
+        then
+          val ctx1 = stack.head
+          val tail = stack.tail
+          ctx1.closeContext(s, cursor)
+          cursor += 1
+          markValueLine()
+          if tail.nonEmpty then
+            rscan(tail.head.endScannerState, tail)
         else
           throw unexpected("json value")
+        end if
     else if (ch == RSquare && (state == ARRAY_END || state == ARRAY_START)) ||
       (ch == RBracket && (state == OBJECT_END || state == OBJECT_START))
     then
@@ -301,9 +396,9 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
       else
         val ctx1 = stack.head
         val tail = stack.tail
-
         ctx1.closeContext(s, cursor)
         cursor += 1
+        markValueLine()
         if tail.isEmpty then {
           // root context
         } else
@@ -313,6 +408,15 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
       if ch == DoubleQuote then
         scanString(stack.head)
         rscan(SEPARATOR, stack)
+      // Trailing comma support: closing bracket after comma in OBJECT_KEY state
+      else if ch == RBracket then
+        val ctx1 = stack.head
+        val tail = stack.tail
+        ctx1.closeContext(s, cursor)
+        cursor += 1
+        markValueLine()
+        if tail.nonEmpty then
+          rscan(tail.head.endScannerState, tail)
       else
         throw unexpected("DoubleQuote")
     else if state == SEPARATOR then

--- a/uni/src/main/scala/wvlet/uni/json/JSONScanner.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSONScanner.scala
@@ -254,17 +254,19 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
       f"Found '${String.valueOf(char.toChar)}' 0x${char}%02x. expected: ${expected}"
     )
 
+  private def flushHandlerComments(): Unit =
+    handler match
+      case ctx: JSONContext[J @unchecked] =>
+        flushComments(ctx)
+      case _ =>
+        commentBuffer.clear()
+
   def scan: Unit =
     try
       skipWhiteSpaces
       if cursor >= s.length then
         throw new UnexpectedEOF(line, cursor - lineStartPos, cursor, "Unexpected EOF")
-      // Flush leading comments to handler (root context)
-      handler match
-        case ctx: JSONContext[J @unchecked] =>
-          flushComments(ctx)
-        case _ =>
-          commentBuffer.clear()
+      flushHandlerComments()
       (s(cursor): @switch) match
         case LBracket =>
           cursor += 1
@@ -274,13 +276,8 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
           rscan(ARRAY_START, handler.arrayContext(s, cursor - 1) :: Nil)
         case other =>
           throw unexpected("object or array")
-      // Scan trailing comments after the root value
       skipWhiteSpaces
-      handler match
-        case ctx: JSONContext[J @unchecked] =>
-          flushComments(ctx)
-        case _ =>
-          commentBuffer.clear()
+      flushHandlerComments()
     catch
       case e: ArrayIndexOutOfBoundsException =>
         throw new UnexpectedEOF(line, cursor - lineStartPos, cursor, s"Unexpected EOF")
@@ -316,16 +313,12 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
         markValueLine()
       case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
         scanNumber(ctx)
-        markValueLine()
       case 't' =>
         scanTrue(ctx)
-        markValueLine()
       case 'f' =>
         scanFalse(ctx)
-        markValueLine()
       case 'n' =>
         scanNull(ctx)
-        markValueLine()
       case _ =>
         throw unexpected("unknown json token")
     end match
@@ -356,7 +349,6 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
         val ctx = stack.head
         if (ch >= '0' && ch <= '9') || ch == '-' then
           scanNumber(ctx)
-          markValueLine()
           rscan(ctx.endScannerState, stack)
         else if ch == DoubleQuote then
           scanString(ctx)
@@ -364,15 +356,12 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
           rscan(ctx.endScannerState, stack)
         else if ch == 't' then
           scanTrue(ctx)
-          markValueLine()
           rscan(ctx.endScannerState, stack)
         else if ch == 'f' then
           scanFalse(ctx)
-          markValueLine()
           rscan(ctx.endScannerState, stack)
         else if ch == 'n' then
           scanNull(ctx)
-          markValueLine()
           rscan(ctx.endScannerState, stack)
         // Trailing comma support: closing bracket after comma in DATA state
         else if (ch == RSquare && !stack.head.isObjectContext) ||
@@ -502,6 +491,7 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
     val numberEnd = cursor
     if numberStart < numberEnd then
       ctx.addNumber(s, numberStart, numberEnd, dotIndex, expIndex)
+    markValueLine()
 
   end scanNumber
 
@@ -519,6 +509,7 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
     if s(cursor) == 't' && s(cursor + 1) == 'r' && s(cursor + 2) == 'u' && s(cursor + 3) == 'e' then
       cursor += 4
       ctx.addBoolean(s, true, cursor - 4, cursor)
+      markValueLine()
     else
       throw unexpected("true")
 
@@ -529,6 +520,7 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
     then
       cursor += 5
       ctx.addBoolean(s, false, cursor - 5, cursor)
+      markValueLine()
     else
       throw unexpected("false")
 
@@ -537,6 +529,7 @@ class JSONScanner[J](private val s: JSONSource, private val handler: JSONHandler
     if s(cursor) == 'n' && s(cursor + 1) == 'u' && s(cursor + 2) == 'l' && s(cursor + 3) == 'l' then
       cursor += 4
       ctx.addNull(s, cursor - 4, cursor)
+      markValueLine()
     else
       throw unexpected("null")
 

--- a/uni/src/main/scala/wvlet/uni/json/JSONTraverser.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSONTraverser.scala
@@ -51,5 +51,5 @@ object JSONTraverser:
         visitor.visitNumber(v)
       case v: JSONBoolean =>
         visitor.visitBoolean(v)
-      case JSONNull =>
+      case _: JSONNull =>
         visitor.visitNull

--- a/uni/src/main/scala/wvlet/uni/json/JSONValueBuilder.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSONValueBuilder.scala
@@ -26,24 +26,48 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
   override def closeContext(s: JSONSource, end: Int): Unit = {}
   def add(v: JSONValue): Unit                              = {}
 
+  // Comment buffering for JSONC support (protected so inner builders access their own instance)
+  protected val pendingLeadingComments    = scala.collection.mutable.ArrayBuffer[JSONComment]()
+  protected var lastAddedValue: JSONValue = null
+
+  override def addComment(comment: JSONComment, isTrailing: Boolean): Unit =
+    if isTrailing && lastAddedValue != null then
+      lastAddedValue.trailingComment = Some(comment)
+    else
+      pendingLeadingComments += comment
+
+  protected def attachPendingComments(v: JSONValue): Unit =
+    if pendingLeadingComments.nonEmpty then
+      v.leadingComments = pendingLeadingComments.toSeq
+      pendingLeadingComments.clear()
+    lastAddedValue = v
+
   override def singleContext(s: JSONSource, start: Int): JSONContext[JSONValue] =
     new JSONValueBuilder:
       private var holder: JSONValue                            = uninitialized
       override def isObjectContext                             = false
       override def closeContext(s: JSONSource, end: Int): Unit = {}
-      override def add(v: JSONValue): Unit                     = holder = v
-      override def result: JSONValue                           = holder
+      override def add(v: JSONValue): Unit                     =
+        attachPendingComments(v)
+        holder = v
+      override def result: JSONValue = holder
 
   override def objectContext(s: JSONSource, start: Int): JSONContext[JSONValue] =
     new JSONValueBuilder:
       private var key: String                                  = null
       private val list                                         = Seq.newBuilder[(String, JSONValue)]
-      override def closeContext(s: JSONSource, end: Int): Unit = self.add(result)
-      override def isObjectContext: Boolean                    = true
-      override def add(v: JSONValue): Unit                     =
+      override def closeContext(s: JSONSource, end: Int): Unit =
+        // Any remaining pending comments at end of container go as trailing on last element
+        if pendingLeadingComments.nonEmpty && lastAddedValue != null then
+          lastAddedValue.trailingComment = Some(pendingLeadingComments.head)
+          pendingLeadingComments.clear()
+        self.add(result)
+      override def isObjectContext: Boolean = true
+      override def add(v: JSONValue): Unit  =
         if key == null then
           key = v.toString
         else
+          attachPendingComments(v)
           list += key -> v
           key = null
       override def result: JSONValue = JSONObject(list.result())
@@ -52,11 +76,18 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
     new JSONValueBuilder:
       private val list                                         = IndexedSeq.newBuilder[JSONValue]
       override def isObjectContext: Boolean                    = false
-      override def closeContext(s: JSONSource, end: Int): Unit = self.add(result)
-      override def add(v: JSONValue): Unit                     = list += v
-      override def result: JSONValue                           = JSONArray(list.result())
+      override def closeContext(s: JSONSource, end: Int): Unit =
+        // Any remaining pending comments at end of container go as trailing on last element
+        if pendingLeadingComments.nonEmpty && lastAddedValue != null then
+          lastAddedValue.trailingComment = Some(pendingLeadingComments.head)
+          pendingLeadingComments.clear()
+        self.add(result)
+      override def add(v: JSONValue): Unit =
+        attachPendingComments(v)
+        list += v
+      override def result: JSONValue = JSONArray(list.result())
 
-  override def addNull(s: JSONSource, start: Int, end: Int): Unit   = add(JSONNull)
+  override def addNull(s: JSONSource, start: Int, end: Int): Unit   = add(JSONNull())
   override def addString(s: JSONSource, start: Int, end: Int): Unit = add(
     JSONString(s.substring(start, end))
   )
@@ -79,9 +110,9 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
   override def addBoolean(s: JSONSource, v: Boolean, start: Int, end: Int): Unit =
     val b =
       if v then
-        JSONTrue
+        JSONBoolean(true)
       else
-        JSONFalse
+        JSONBoolean(false)
     add(b)
 
 end JSONValueBuilder

--- a/uni/src/main/scala/wvlet/uni/json/JSONValueBuilder.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSONValueBuilder.scala
@@ -58,13 +58,10 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
       private val list                                         = Seq.newBuilder[(String, JSONValue)]
       override def closeContext(s: JSONSource, end: Int): Unit =
         val r = result
-        // Remaining comments at end of container
         if pendingLeadingComments.nonEmpty then
           if lastAddedValue != null then
-            // Attach as trailing on last element
             lastAddedValue.trailingComment = Some(pendingLeadingComments.head)
           else
-            // Empty container: attach comments to the container itself
             r.leadingComments = pendingLeadingComments.toSeq
           pendingLeadingComments.clear()
         self.add(r)
@@ -84,7 +81,6 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
       override def isObjectContext: Boolean                    = false
       override def closeContext(s: JSONSource, end: Int): Unit =
         val r = result
-        // Remaining comments at end of container
         if pendingLeadingComments.nonEmpty then
           if lastAddedValue != null then
             lastAddedValue.trailingComment = Some(pendingLeadingComments.head)

--- a/uni/src/main/scala/wvlet/uni/json/JSONValueBuilder.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSONValueBuilder.scala
@@ -57,11 +57,17 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
       private var key: String                                  = null
       private val list                                         = Seq.newBuilder[(String, JSONValue)]
       override def closeContext(s: JSONSource, end: Int): Unit =
-        // Any remaining pending comments at end of container go as trailing on last element
-        if pendingLeadingComments.nonEmpty && lastAddedValue != null then
-          lastAddedValue.trailingComment = Some(pendingLeadingComments.head)
+        val r = result
+        // Remaining comments at end of container
+        if pendingLeadingComments.nonEmpty then
+          if lastAddedValue != null then
+            // Attach as trailing on last element
+            lastAddedValue.trailingComment = Some(pendingLeadingComments.head)
+          else
+            // Empty container: attach comments to the container itself
+            r.leadingComments = pendingLeadingComments.toSeq
           pendingLeadingComments.clear()
-        self.add(result)
+        self.add(r)
       override def isObjectContext: Boolean = true
       override def add(v: JSONValue): Unit  =
         if key == null then
@@ -77,11 +83,15 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
       private val list                                         = IndexedSeq.newBuilder[JSONValue]
       override def isObjectContext: Boolean                    = false
       override def closeContext(s: JSONSource, end: Int): Unit =
-        // Any remaining pending comments at end of container go as trailing on last element
-        if pendingLeadingComments.nonEmpty && lastAddedValue != null then
-          lastAddedValue.trailingComment = Some(pendingLeadingComments.head)
+        val r = result
+        // Remaining comments at end of container
+        if pendingLeadingComments.nonEmpty then
+          if lastAddedValue != null then
+            lastAddedValue.trailingComment = Some(pendingLeadingComments.head)
+          else
+            r.leadingComments = pendingLeadingComments.toSeq
           pendingLeadingComments.clear()
-        self.add(result)
+        self.add(r)
       override def add(v: JSONValue): Unit =
         attachPendingComments(v)
         list += v

--- a/uni/src/main/scala/wvlet/uni/json/JSONValueBuilder.scala
+++ b/uni/src/main/scala/wvlet/uni/json/JSONValueBuilder.scala
@@ -42,6 +42,25 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
       pendingLeadingComments.clear()
     lastAddedValue = v
 
+  /**
+    * Flush orphaned comments at end of container. Merges multiple comments into a single
+    * JSONComment. Attaches to last element as trailing, or to container as leading if empty.
+    */
+  protected def flushOrphanedComments(container: JSONValue): Unit =
+    if pendingLeadingComments.nonEmpty then
+      val merged = JSONComment(pendingLeadingComments.map(_.text).mkString("\n"))
+      if lastAddedValue != null then
+        // Merge with existing trailing comment if present
+        lastAddedValue.trailingComment =
+          lastAddedValue.trailingComment match
+            case Some(existing) =>
+              Some(JSONComment(existing.text + "\n" + merged.text))
+            case None =>
+              Some(merged)
+      else
+        container.leadingComments = pendingLeadingComments.toSeq
+      pendingLeadingComments.clear()
+
   override def singleContext(s: JSONSource, start: Int): JSONContext[JSONValue] =
     new JSONValueBuilder:
       private var holder: JSONValue                            = uninitialized
@@ -58,12 +77,7 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
       private val list                                         = Seq.newBuilder[(String, JSONValue)]
       override def closeContext(s: JSONSource, end: Int): Unit =
         val r = result
-        if pendingLeadingComments.nonEmpty then
-          if lastAddedValue != null then
-            lastAddedValue.trailingComment = Some(pendingLeadingComments.head)
-          else
-            r.leadingComments = pendingLeadingComments.toSeq
-          pendingLeadingComments.clear()
+        flushOrphanedComments(r)
         self.add(r)
       override def isObjectContext: Boolean = true
       override def add(v: JSONValue): Unit  =
@@ -81,12 +95,7 @@ class JSONValueBuilder extends JSONContext[JSONValue] with LogSupport:
       override def isObjectContext: Boolean                    = false
       override def closeContext(s: JSONSource, end: Int): Unit =
         val r = result
-        if pendingLeadingComments.nonEmpty then
-          if lastAddedValue != null then
-            lastAddedValue.trailingComment = Some(pendingLeadingComments.head)
-          else
-            r.leadingComments = pendingLeadingComments.toSeq
-          pendingLeadingComments.clear()
+        flushOrphanedComments(r)
         self.add(r)
       override def add(v: JSONValue): Unit =
         attachPendingComments(v)

--- a/uni/src/main/scala/wvlet/uni/json/YAMLFormatter.scala
+++ b/uni/src/main/scala/wvlet/uni/json/YAMLFormatter.scala
@@ -144,7 +144,7 @@ object YAMLFormatter:
     override def visitString(v: JSONString): Unit   = emitPrimitive(v)
     override def visitNumber(n: JSONNumber): Unit   = emitPrimitive(n)
     override def visitBoolean(n: JSONBoolean): Unit = emitPrimitive(n)
-    override def visitNull: Unit                    = emitPrimitive(JSONNull)
+    override def visitNull: Unit                    = emitPrimitive(JSONNull())
 
   end YamlWriter
 

--- a/uni/src/main/scala/wvlet/uni/json/package.scala
+++ b/uni/src/main/scala/wvlet/uni/json/package.scala
@@ -52,7 +52,7 @@ package object json:
 
     def getValue: Any =
       jsonValue match
-        case JSONNull =>
+        case _: JSONNull =>
           null
         case JSONDouble(x) =>
           x
@@ -73,7 +73,7 @@ package object json:
     )
     def value: Any = getValue
 
-    def isNull: Boolean = jsonValue == JSONNull
+    def isNull: Boolean = jsonValue.isInstanceOf[JSONNull]
 
     def toStringValue: String                 = jsonValue.asInstanceOf[JSONString].v
     def toDoubleValue: Double                 = jsonValue.asInstanceOf[JSONDouble].v

--- a/uni/src/main/scala/wvlet/uni/weaver/codec/JSONWeaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/codec/JSONWeaver.scala
@@ -51,7 +51,7 @@ object JSONWeaver extends Weaver[String]:
         }
       case JSONString(s) =>
         p.packString(s)
-      case JSONNull =>
+      case _: JSONNull =>
         p.packNil
       case JSONBoolean(v) =>
         p.packBoolean(v)
@@ -86,7 +86,7 @@ object JSONValueWeaver extends Weaver[JSONValue]:
     u.getNextValueType match
       case ValueType.NIL =>
         u.unpackNil
-        JSONNull
+        JSONNull()
       case ValueType.STRING =>
         JSONString(u.unpackString)
       case ValueType.FLOAT =>

--- a/uni/src/test/scala/wvlet/uni/json/JSONCTest.scala
+++ b/uni/src/test/scala/wvlet/uni/json/JSONCTest.scala
@@ -190,10 +190,29 @@ class JSONCTest extends UniTest:
   }
 
   test("empty object and array with comments") {
-    JSON.parse("{ /* empty */ }") shouldMatch { case obj: JSONObject =>
+    val obj = JSON.parse("{ /* empty */ }")
+    obj shouldMatch { case _: JSONObject =>
     }
-    JSON.parse("[ /* empty */ ]") shouldMatch { case arr: JSONArray =>
+    // Comments in empty container are preserved on the container itself
+    obj.leadingComments.size shouldBe 1
+    obj.leadingComments.head.commentBody shouldBe "empty"
+
+    val arr = JSON.parse("[ /* empty */ ]")
+    arr shouldMatch { case _: JSONArray =>
     }
+    arr.leadingComments.size shouldBe 1
+  }
+
+  test("toJSONC recurses into nested structures") {
+    val jsonc =
+      """{
+        |  // comment
+        |  "key": "value"
+        |}""".stripMargin
+    val v      = JSON.parse(jsonc)
+    val jsonc2 = v.toJSONC
+    jsonc2 shouldContain "// comment"
+    jsonc2 shouldContain "\"key\""
   }
 
   test("comments between array elements") {

--- a/uni/src/test/scala/wvlet/uni/json/JSONCTest.scala
+++ b/uni/src/test/scala/wvlet/uni/json/JSONCTest.scala
@@ -26,9 +26,8 @@ class JSONCTest extends UniTest:
       |}""".stripMargin
     val v = JSON.parse(jsonc)
     v shouldMatch { case obj: JSONObject =>
+      obj.get("key") shouldBe Some(JSONString("value"))
     }
-    val obj = v.asInstanceOf[JSONObject]
-    obj.get("key") shouldBe Some(JSONString("value"))
   }
 
   test("parse JSONC with block comments") {
@@ -37,9 +36,10 @@ class JSONCTest extends UniTest:
       |  /* block comment */
       |  "key": 42
       |}""".stripMargin
-    val v   = JSON.parse(jsonc)
-    val obj = v.asInstanceOf[JSONObject]
-    obj.get("key") shouldBe Some(JSONLong(42))
+    val v = JSON.parse(jsonc)
+    v shouldMatch { case obj: JSONObject =>
+      obj.get("key") shouldBe Some(JSONLong(42))
+    }
   }
 
   test("parse JSONC with inline trailing comments") {
@@ -48,29 +48,31 @@ class JSONCTest extends UniTest:
       |  "host": "localhost", // server host
       |  "port": 5432
       |}""".stripMargin
-    val v   = JSON.parse(jsonc)
-    val obj = v.asInstanceOf[JSONObject]
-    obj.get("host") shouldBe Some(JSONString("localhost"))
-    obj.get("port") shouldBe Some(JSONLong(5432))
-    // Check trailing comment is attached
-    val hostVal = obj.v.find(_._1 == "host").get._2
-    hostVal.trailingComment.isDefined shouldBe true
-    hostVal.trailingComment.get.text shouldBe "// server host"
+    val v = JSON.parse(jsonc)
+    v shouldMatch { case obj: JSONObject =>
+      obj.get("host") shouldBe Some(JSONString("localhost"))
+      obj.get("port") shouldBe Some(JSONLong(5432))
+      val hostVal = obj.v.find(_._1 == "host").get._2
+      hostVal.trailingComment.isDefined shouldBe true
+      hostVal.trailingComment.get.text shouldBe "// server host"
+    }
   }
 
   test("parse JSONC with trailing commas in objects") {
     val jsonc = """{"a": 1, "b": 2,}"""
     val v     = JSON.parse(jsonc)
-    val obj   = v.asInstanceOf[JSONObject]
-    obj.get("a") shouldBe Some(JSONLong(1))
-    obj.get("b") shouldBe Some(JSONLong(2))
+    v shouldMatch { case obj: JSONObject =>
+      obj.get("a") shouldBe Some(JSONLong(1))
+      obj.get("b") shouldBe Some(JSONLong(2))
+    }
   }
 
   test("parse JSONC with trailing commas in arrays") {
     val jsonc = """[1, 2, 3,]"""
     val v     = JSON.parse(jsonc)
-    val arr   = v.asInstanceOf[JSONArray]
-    arr.size shouldBe 3
+    v shouldMatch { case arr: JSONArray =>
+      arr.size shouldBe 3
+    }
   }
 
   test("parse JSONC with multi-line block comment") {
@@ -82,9 +84,10 @@ class JSONCTest extends UniTest:
       |   */
       |  "key": "value"
       |}""".stripMargin
-    val v   = JSON.parse(jsonc)
-    val obj = v.asInstanceOf[JSONObject]
-    obj.get("key") shouldBe Some(JSONString("value"))
+    val v = JSON.parse(jsonc)
+    v shouldMatch { case obj: JSONObject =>
+      obj.get("key") shouldBe Some(JSONString("value"))
+    }
   }
 
   test("preserve leading comments on values") {
@@ -93,22 +96,24 @@ class JSONCTest extends UniTest:
       |  // comment about name
       |  "name": "test"
       |}""".stripMargin
-    val v       = JSON.parse(jsonc)
-    val obj     = v.asInstanceOf[JSONObject]
-    val nameVal = obj.v.find(_._1 == "name").get._2
-    nameVal.leadingComments.size shouldBe 1
-    nameVal.leadingComments.head.text shouldBe "// comment about name"
-    nameVal.leadingComments.head.isLineComment shouldBe true
-    nameVal.leadingComments.head.commentBody shouldBe "comment about name"
+    val v = JSON.parse(jsonc)
+    v shouldMatch { case obj: JSONObject =>
+      val nameVal = obj.v.find(_._1 == "name").get._2
+      nameVal.leadingComments.size shouldBe 1
+      nameVal.leadingComments.head.text shouldBe "// comment about name"
+      nameVal.leadingComments.head.isLineComment shouldBe true
+      nameVal.leadingComments.head.commentBody shouldBe "comment about name"
+    }
   }
 
   test("preserve trailing inline comments") {
     val jsonc = """[1, 2 /* count */]"""
     val v     = JSON.parse(jsonc)
-    val arr   = v.asInstanceOf[JSONArray]
-    arr.v(1).trailingComment.isDefined shouldBe true
-    arr.v(1).trailingComment.get.isBlockComment shouldBe true
-    arr.v(1).trailingComment.get.commentBody shouldBe "count"
+    v shouldMatch { case arr: JSONArray =>
+      arr.v(1).trailingComment.isDefined shouldBe true
+      arr.v(1).trailingComment.get.isBlockComment shouldBe true
+      arr.v(1).trailingComment.get.commentBody shouldBe "count"
+    }
   }
 
   test("round-trip JSONC with comments via format") {
@@ -162,9 +167,10 @@ class JSONCTest extends UniTest:
   test("parse standard JSON still works") {
     val json = """{"id": 1, "name": "test"}"""
     val v    = JSON.parse(json)
-    val obj  = v.asInstanceOf[JSONObject]
-    obj.get("id") shouldBe Some(JSONLong(1))
-    obj.get("name") shouldBe Some(JSONString("test"))
+    v shouldMatch { case obj: JSONObject =>
+      obj.get("id") shouldBe Some(JSONLong(1))
+      obj.get("name") shouldBe Some(JSONString("test"))
+    }
   }
 
   test("parseAny with JSONC comments") {
@@ -181,19 +187,20 @@ class JSONCTest extends UniTest:
       |    "port": 5432
       |  }
       |}""".stripMargin
-    val v       = JSON.parse(jsonc)
-    val obj     = v.asInstanceOf[JSONObject]
-    val db      = obj.get("db").get.asInstanceOf[JSONObject]
-    val hostVal = db.v.find(_._1 == "host").get._2
-    hostVal.leadingComments.size shouldBe 1
-    hostVal.leadingComments.head.commentBody shouldBe "connection settings"
+    val v = JSON.parse(jsonc)
+    v shouldMatch { case obj: JSONObject =>
+      obj.get("db").get shouldMatch { case db: JSONObject =>
+        val hostVal = db.v.find(_._1 == "host").get._2
+        hostVal.leadingComments.size shouldBe 1
+        hostVal.leadingComments.head.commentBody shouldBe "connection settings"
+      }
+    }
   }
 
   test("empty object and array with comments") {
     val obj = JSON.parse("{ /* empty */ }")
     obj shouldMatch { case _: JSONObject =>
     }
-    // Comments in empty container are preserved on the container itself
     obj.leadingComments.size shouldBe 1
     obj.leadingComments.head.commentBody shouldBe "empty"
 
@@ -223,11 +230,12 @@ class JSONCTest extends UniTest:
       |  2,
       |  3
       |]""".stripMargin
-    val v   = JSON.parse(jsonc)
-    val arr = v.asInstanceOf[JSONArray]
-    arr.size shouldBe 3
-    arr.v(1).leadingComments.size shouldBe 1
-    arr.v(1).leadingComments.head.commentBody shouldBe "separator"
+    val v = JSON.parse(jsonc)
+    v shouldMatch { case arr: JSONArray =>
+      arr.size shouldBe 3
+      arr.v(1).leadingComments.size shouldBe 1
+      arr.v(1).leadingComments.head.commentBody shouldBe "separator"
+    }
   }
 
 end JSONCTest

--- a/uni/src/test/scala/wvlet/uni/json/JSONCTest.scala
+++ b/uni/src/test/scala/wvlet/uni/json/JSONCTest.scala
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.json
+
+import wvlet.uni.json.JSON.*
+import wvlet.uni.test.UniTest
+
+class JSONCTest extends UniTest:
+
+  test("parse JSONC with line comments") {
+    val jsonc =
+      """{
+      |  // This is a comment
+      |  "key": "value"
+      |}""".stripMargin
+    val v = JSON.parse(jsonc)
+    v shouldMatch { case obj: JSONObject =>
+    }
+    val obj = v.asInstanceOf[JSONObject]
+    obj.get("key") shouldBe Some(JSONString("value"))
+  }
+
+  test("parse JSONC with block comments") {
+    val jsonc =
+      """{
+      |  /* block comment */
+      |  "key": 42
+      |}""".stripMargin
+    val v   = JSON.parse(jsonc)
+    val obj = v.asInstanceOf[JSONObject]
+    obj.get("key") shouldBe Some(JSONLong(42))
+  }
+
+  test("parse JSONC with inline trailing comments") {
+    val jsonc =
+      """{
+      |  "host": "localhost", // server host
+      |  "port": 5432
+      |}""".stripMargin
+    val v   = JSON.parse(jsonc)
+    val obj = v.asInstanceOf[JSONObject]
+    obj.get("host") shouldBe Some(JSONString("localhost"))
+    obj.get("port") shouldBe Some(JSONLong(5432))
+    // Check trailing comment is attached
+    val hostVal = obj.v.find(_._1 == "host").get._2
+    hostVal.trailingComment.isDefined shouldBe true
+    hostVal.trailingComment.get.text shouldBe "// server host"
+  }
+
+  test("parse JSONC with trailing commas in objects") {
+    val jsonc = """{"a": 1, "b": 2,}"""
+    val v     = JSON.parse(jsonc)
+    val obj   = v.asInstanceOf[JSONObject]
+    obj.get("a") shouldBe Some(JSONLong(1))
+    obj.get("b") shouldBe Some(JSONLong(2))
+  }
+
+  test("parse JSONC with trailing commas in arrays") {
+    val jsonc = """[1, 2, 3,]"""
+    val v     = JSON.parse(jsonc)
+    val arr   = v.asInstanceOf[JSONArray]
+    arr.size shouldBe 3
+  }
+
+  test("parse JSONC with multi-line block comment") {
+    val jsonc =
+      """{
+      |  /*
+      |   * Multi-line
+      |   * block comment
+      |   */
+      |  "key": "value"
+      |}""".stripMargin
+    val v   = JSON.parse(jsonc)
+    val obj = v.asInstanceOf[JSONObject]
+    obj.get("key") shouldBe Some(JSONString("value"))
+  }
+
+  test("preserve leading comments on values") {
+    val jsonc =
+      """{
+      |  // comment about name
+      |  "name": "test"
+      |}""".stripMargin
+    val v       = JSON.parse(jsonc)
+    val obj     = v.asInstanceOf[JSONObject]
+    val nameVal = obj.v.find(_._1 == "name").get._2
+    nameVal.leadingComments.size shouldBe 1
+    nameVal.leadingComments.head.text shouldBe "// comment about name"
+    nameVal.leadingComments.head.isLineComment shouldBe true
+    nameVal.leadingComments.head.commentBody shouldBe "comment about name"
+  }
+
+  test("preserve trailing inline comments") {
+    val jsonc = """[1, 2 /* count */]"""
+    val v     = JSON.parse(jsonc)
+    val arr   = v.asInstanceOf[JSONArray]
+    arr.v(1).trailingComment.isDefined shouldBe true
+    arr.v(1).trailingComment.get.isBlockComment shouldBe true
+    arr.v(1).trailingComment.get.commentBody shouldBe "count"
+  }
+
+  test("round-trip JSONC with comments via format") {
+    val jsonc =
+      """{
+      |  // Database settings
+      |  "host": "localhost", // server host
+      |  "port": 5432
+      |}""".stripMargin
+    val v         = JSON.parse(jsonc)
+    val formatted = JSON.format(v)
+    formatted shouldContain "// Database settings"
+    formatted shouldContain "// server host"
+    formatted shouldContain "\"host\": \"localhost\""
+  }
+
+  test("toJSON strips comments") {
+    val jsonc =
+      """{
+      |  // comment
+      |  "key": "value" // trailing
+      |}""".stripMargin
+    val v    = JSON.parse(jsonc)
+    val json = v.toJSON
+    (json.contains("//")) shouldBe false
+    json shouldContain "\"key\""
+  }
+
+  test("toJSONC includes comments") {
+    val v = JSONString("hello")
+    v.leadingComments = Seq(JSONComment("// greeting"))
+    v.trailingComment = Some(JSONComment("// end"))
+    val jsonc = v.toJSONC
+    jsonc shouldContain "// greeting"
+    jsonc shouldContain "\"hello\""
+    jsonc shouldContain "// end"
+  }
+
+  test("JSONComment helper methods") {
+    val line = JSONComment("// line comment")
+    line.isLineComment shouldBe true
+    line.isBlockComment shouldBe false
+    line.commentBody shouldBe "line comment"
+
+    val block = JSONComment("/* block comment */")
+    block.isLineComment shouldBe false
+    block.isBlockComment shouldBe true
+    block.commentBody shouldBe "block comment"
+  }
+
+  test("parse standard JSON still works") {
+    val json = """{"id": 1, "name": "test"}"""
+    val v    = JSON.parse(json)
+    val obj  = v.asInstanceOf[JSONObject]
+    obj.get("id") shouldBe Some(JSONLong(1))
+    obj.get("name") shouldBe Some(JSONString("test"))
+  }
+
+  test("parseAny with JSONC comments") {
+    JSON.parseAny("// comment\n42") shouldBe JSONLong(42)
+    JSON.parseAny("/* block */ true") shouldBe JSONBoolean(true)
+  }
+
+  test("nested JSONC with comments") {
+    val jsonc =
+      """{
+      |  "db": {
+      |    // connection settings
+      |    "host": "localhost",
+      |    "port": 5432
+      |  }
+      |}""".stripMargin
+    val v       = JSON.parse(jsonc)
+    val obj     = v.asInstanceOf[JSONObject]
+    val db      = obj.get("db").get.asInstanceOf[JSONObject]
+    val hostVal = db.v.find(_._1 == "host").get._2
+    hostVal.leadingComments.size shouldBe 1
+    hostVal.leadingComments.head.commentBody shouldBe "connection settings"
+  }
+
+  test("empty object and array with comments") {
+    JSON.parse("{ /* empty */ }") shouldMatch { case obj: JSONObject =>
+    }
+    JSON.parse("[ /* empty */ ]") shouldMatch { case arr: JSONArray =>
+    }
+  }
+
+  test("comments between array elements") {
+    val jsonc =
+      """[
+      |  1,
+      |  // separator
+      |  2,
+      |  3
+      |]""".stripMargin
+    val v   = JSON.parse(jsonc)
+    val arr = v.asInstanceOf[JSONArray]
+    arr.size shouldBe 3
+    arr.v(1).leadingComments.size shouldBe 1
+    arr.v(1).leadingComments.head.commentBody shouldBe "separator"
+  }
+
+end JSONCTest

--- a/uni/src/test/scala/wvlet/uni/json/JSONParserTest.scala
+++ b/uni/src/test/scala/wvlet/uni/json/JSONParserTest.scala
@@ -43,7 +43,7 @@ class JSONParserTest extends UniTest:
 
   test("parse any json values") {
     val v = JSON.parseAny("null")
-    v shouldBe JSONNull
+    v shouldBe JSONNull()
     JSON.parseAny("0") shouldBe JSONLong(0L)
     JSON.parseAny("1") shouldBe JSONLong(1L)
     JSON.parseAny("1.23") shouldBe JSONDouble(1.23)

--- a/uni/src/test/scala/wvlet/uni/json/JSONTest.scala
+++ b/uni/src/test/scala/wvlet/uni/json/JSONTest.scala
@@ -78,7 +78,7 @@ class JSONTest extends UniTest:
     users2(0).toObjectValue shouldBe
       Map("id" -> JSONLong(1), "name" -> JSONString("a"), "flag" -> JSONBoolean(true))
     users2(1).toObjectValue shouldBe
-      Map("id" -> JSONLong(2), "name" -> JSONString("b"), "flag" -> JSONNull)
+      Map("id" -> JSONLong(2), "name" -> JSONString("b"), "flag" -> JSONNull())
   }
 
   test("Extract nested properties by JSON DSL") {


### PR DESCRIPTION
## Summary

- Add JSONC (JSON with Comments) support per [jsonc.org](https://jsonc.org/) specification
- Support `//` line comments, `/* */` block comments, and trailing commas in the existing `JSON.parse`
- Comments attached as mutable metadata (`leadingComments`, `trailingComment`) on nearby `JSONValue` nodes for round-tripping
- `JSONComment` case class with helpers: `commentBody`, `isLineComment`, `isBlockComment`
- `toJSONC` method outputs JSONC with comments; `toJSON` outputs clean JSON
- `JSON.format` includes comments in pretty-printed output
- No separate JSONC entry point — comments enabled by default in `JSON.parse`

## Design decisions

- **Comments are metadata, not nodes**: `JSONComment` does not extend `JSONValue`. Comments are mutable fields on value nodes.
- **Two attachment rules**: new-line comments → `leadingComments` on next value; inline comments → `trailingComment` on previous value
- **JSONNull changed to case class**: from `case object` to `case class JSONNull()` so each instance carries its own comments
- **Raw comment text**: `JSONComment(text)` stores the full comment including delimiters (`// ...` or `/* ... */`) to preserve exact formatting

## Test plan

- [x] Parse JSONC with line and block comments
- [x] Trailing commas in objects and arrays
- [x] Leading comment attachment to next value
- [x] Trailing comment attachment to previous inline value
- [x] Round-trip: parse JSONC → format → comments preserved
- [x] `toJSON` strips comments, `toJSONC` includes them
- [x] Nested structures with comments
- [x] Backward compatibility: all existing JSON tests pass (1422 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)