### PR TITLE
feature: Add cross-platform filesystem watcher (IOWatch)

### DIFF
--- a/uni-core/.js/src/main/scala/wvlet/uni/io/FileSystemImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/FileSystemImpl.scala
@@ -670,8 +670,9 @@ end FileSystemJS
   * Scala.js FileSystem initialization.
   */
 object FileSystemInit:
-  // Register JS implementation
+  // Register JS implementations
   FileSystem.setImplementation(FileSystemJS)
+  IOWatch.setImplementation(IOWatchJS)
 
   /**
     * Ensures the FileSystem is initialized.

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -57,7 +57,7 @@ private[io] object IOWatchJS extends IOWatchBase:
           "Use non-recursive watching or switch to JVM."
       )
 
-    val watchOptions = js.Dynamic.literal(recursive = options.recursive, persistent = false)
+    val watchOptions = js.Dynamic.literal(recursive = options.recursive, persistent = true)
 
     val listener: js.Function2[String, String, Unit] =
       (eventType: String, filename: String) =>

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -40,12 +40,22 @@ private[io] object IOWatchJS extends IOWatchBase:
       !js.isUndefined(js.Dynamic.global.process.versions) &&
       !js.isUndefined(js.Dynamic.global.process.versions.node)
 
+  private def supportsRecursiveWatch: Boolean =
+    val platform = NodeOSModule.platform()
+    platform == "darwin" || platform == "win32"
+
   override def watch(path: IOPath, options: WatchOptions)(handler: WatchEvent => Unit): IOWatcher =
     if !isNodeEnv then
       throw UnsupportedOperationException("IOWatch is not supported in browser environments")
 
     if !NodeFSModule.existsSync(path.path) || !NodeFSModule.statSync(path.path).isDirectory() then
       throw IOOperationException(s"Watch path is not a directory: ${path.path}")
+
+    if options.recursive && !supportsRecursiveWatch then
+      throw UnsupportedOperationException(
+        "Recursive watching is not supported on this platform in Node.js. " +
+          "Use non-recursive watching or switch to JVM."
+      )
 
     val watchOptions = js.Dynamic.literal(recursive = options.recursive, persistent = false)
 

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -62,19 +62,23 @@ private[io] object IOWatchJS extends IOWatchBase:
     val listener: js.Function2[String, String, Unit] =
       (eventType: String, filename: String) =>
         if filename != null then
-          val fullPath       = IOPath.parse(NodePathModule.join(path.path, filename))
-          val watchEventType =
-            eventType match
-              case "rename" =>
-                if NodeFSModule.existsSync(fullPath.path) then
-                  WatchEventType.Created
-                else
-                  WatchEventType.Deleted
-              case "change" =>
-                WatchEventType.Modified
-              case _ =>
-                WatchEventType.Modified
-          handler(WatchEvent(watchEventType, fullPath))
+          try
+            val fullPath       = IOPath.parse(NodePathModule.join(path.path, filename))
+            val watchEventType =
+              eventType match
+                case "rename" =>
+                  if NodeFSModule.existsSync(fullPath.path) then
+                    WatchEventType.Created
+                  else
+                    WatchEventType.Deleted
+                case "change" =>
+                  WatchEventType.Modified
+                case _ =>
+                  WatchEventType.Modified
+            handler(WatchEvent(watchEventType, fullPath))
+          catch
+            case _: Throwable =>
+              ()
 
     val fsWatcher = NodeFSWatchModule.watch(path.path, watchOptions, listener)
 

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+/**
+  * Node.js fs.watch facade.
+  */
+@js.native
+private[io] trait NodeFSWatcher extends js.Object:
+  def close(): Unit = js.native
+
+private[io] object NodeFSWatchModule:
+  def watch(
+      path: String,
+      options: js.Object,
+      listener: js.Function2[String, String, Unit]
+  ): NodeFSWatcher = NodeFSModule
+    .asInstanceOf[js.Dynamic]
+    .watch(path, options, listener)
+    .asInstanceOf[NodeFSWatcher]
+
+private[io] object IOWatchJS extends IOWatchBase:
+
+  private def isNodeEnv: Boolean =
+    js.typeOf(js.Dynamic.global.process) != "undefined" &&
+      !js.isUndefined(js.Dynamic.global.process.versions) &&
+      !js.isUndefined(js.Dynamic.global.process.versions.node)
+
+  override def watch(path: IOPath, options: WatchOptions)(handler: WatchEvent => Unit): IOWatcher =
+    if !isNodeEnv then
+      throw UnsupportedOperationException("IOWatch is not supported in browser environments")
+
+    if !NodeFSModule.existsSync(path.path) || !NodeFSModule.statSync(path.path).isDirectory() then
+      throw IOOperationException(s"Watch path is not a directory: ${path.path}")
+
+    val watchOptions = js.Dynamic.literal(recursive = options.recursive, persistent = false)
+
+    val listener: js.Function2[String, String, Unit] =
+      (eventType: String, filename: String) =>
+        if filename != null then
+          val fullPath       = IOPath.parse(NodePathModule.join(path.path, filename))
+          val watchEventType =
+            eventType match
+              case "rename" =>
+                if NodeFSModule.existsSync(fullPath.path) then
+                  WatchEventType.Created
+                else
+                  WatchEventType.Deleted
+              case "change" =>
+                WatchEventType.Modified
+              case _ =>
+                WatchEventType.Modified
+          handler(WatchEvent(watchEventType, fullPath))
+
+    val fsWatcher = NodeFSWatchModule.watch(path.path, watchOptions, listener)
+
+    new IOWatcher:
+      override def close(): Unit = fsWatcher.close()
+
+  end watch
+
+end IOWatchJS

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -14,7 +14,6 @@
 package wvlet.uni.io
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSImport
 
 /**
   * Node.js fs.watch facade.
@@ -35,20 +34,21 @@ private[io] object NodeFSWatchModule:
 
 private[io] object IOWatchJS extends IOWatchBase:
 
-  private def isNodeEnv: Boolean =
-    js.typeOf(js.Dynamic.global.process) != "undefined" &&
-      !js.isUndefined(js.Dynamic.global.process.versions) &&
-      !js.isUndefined(js.Dynamic.global.process.versions.node)
-
   private def supportsRecursiveWatch: Boolean =
     val platform = NodeOSModule.platform()
     platform == "darwin" || platform == "win32"
 
   override def watch(path: IOPath, options: WatchOptions)(handler: WatchEvent => Unit): IOWatcher =
-    if !isNodeEnv then
+    if !FileSystem.isNode then
       throw UnsupportedOperationException("IOWatch is not supported in browser environments")
 
-    if !NodeFSModule.existsSync(path.path) || !NodeFSModule.statSync(path.path).isDirectory() then
+    val isDir =
+      try
+        NodeFSModule.statSync(path.path).isDirectory()
+      catch
+        case _: Throwable =>
+          false
+    if !isDir then
       throw IOOperationException(s"Watch path is not a directory: ${path.path}")
 
     if options.recursive && !supportsRecursiveWatch then

--- a/uni-core/.jvm/src/main/scala/wvlet/uni/io/FileSystemImpl.scala
+++ b/uni-core/.jvm/src/main/scala/wvlet/uni/io/FileSystemImpl.scala
@@ -376,8 +376,9 @@ end FileSystemJvm
   * JVM FileSystem initialization. This object ensures the JVM implementation is registered.
   */
 object FileSystemInit:
-  // Register JVM implementation
+  // Register JVM implementations
   FileSystem.setImplementation(FileSystemJvm)
+  IOWatch.setImplementation(IOWatchJvm)
 
   /**
     * Ensures the FileSystem is initialized. Call this at application startup if needed.

--- a/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -35,6 +35,7 @@ private[io] object IOWatchJvm extends IOWatchBase:
 
     val watchService = FileSystems.getDefault.newWatchService()
     val keyToPath    = java.util.concurrent.ConcurrentHashMap[WatchKey, Path]()
+    val running      = AtomicBoolean(true)
 
     def registerDirectory(dir: Path): Unit =
       val key = dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE)
@@ -44,17 +45,20 @@ private[io] object IOWatchJvm extends IOWatchBase:
       root,
       new SimpleFileVisitor[Path]:
         override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult =
-          registerDirectory(dir)
+          if !running.get() then
+            FileVisitResult.TERMINATE
+          else
+            registerDirectory(dir)
+            FileVisitResult.CONTINUE
+
+        override def visitFileFailed(file: Path, exc: java.io.IOException): FileVisitResult =
           FileVisitResult.CONTINUE
     )
 
-    // Register the root directory (and all subdirectories if recursive)
     if options.recursive then
       registerTree(nioPath)
     else
       registerDirectory(nioPath)
-
-    val running = AtomicBoolean(true)
     val thread  = Thread(() =>
       while running.get() do
         try
@@ -80,13 +84,19 @@ private[io] object IOWatchJvm extends IOWatchBase:
                   handler(WatchEvent(eventType, ioPath))
 
                   // If recursive and a new directory was created, register its entire subtree
-                  if options.recursive && kind == ENTRY_CREATE && Files.isDirectory(fullPath) then
-                    registerTree(fullPath)
+                  if options.recursive && kind == ENTRY_CREATE then
+                    try
+                      if Files.isDirectory(fullPath) then
+                        registerTree(fullPath)
+                    catch
+                      case _: java.io.IOException => // Directory may have been removed
                 else
                   handler(WatchEvent(WatchEventType.Overflow, IOPath.parse(dir.toString)))
               }
               if !key.reset() then
                 keyToPath.remove(key)
+            end if
+          end if
         catch
           case _: java.nio.file.ClosedWatchServiceException =>
             running.set(false)

--- a/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -59,7 +59,7 @@ private[io] object IOWatchJvm extends IOWatchBase:
       registerTree(nioPath)
     else
       registerDirectory(nioPath)
-    val thread  = Thread(() =>
+    val thread = Thread(() =>
       while running.get() do
         try
           val key = watchService.poll(options.pollingIntervalMs, TimeUnit.MILLISECONDS)

--- a/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.FileVisitResult
+import java.nio.file.StandardWatchEventKinds.*
+import java.nio.file.WatchKey
+import java.nio.file.WatchService
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+private[io] object IOWatchJvm extends IOWatchBase:
+
+  override def watch(path: IOPath, options: WatchOptions)(handler: WatchEvent => Unit): IOWatcher =
+    val nioPath = Paths.get(path.path)
+    if !Files.isDirectory(nioPath) then
+      throw IOOperationException(s"Watch path is not a directory: ${path.path}")
+
+    val watchService = FileSystems.getDefault.newWatchService()
+    val keyToPath    = java.util.concurrent.ConcurrentHashMap[WatchKey, Path]()
+
+    def registerDirectory(dir: Path): Unit =
+      val key = dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE)
+      keyToPath.put(key, dir)
+
+    // Register the root directory
+    registerDirectory(nioPath)
+
+    // For recursive watching, register all subdirectories
+    if options.recursive then
+      Files.walkFileTree(
+        nioPath,
+        new SimpleFileVisitor[Path]:
+          override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult =
+            registerDirectory(dir)
+            FileVisitResult.CONTINUE
+      )
+
+    val running = AtomicBoolean(true)
+    val thread  = Thread(() =>
+      while running.get() do
+        try
+          val key = watchService.poll(options.pollingIntervalMs, TimeUnit.MILLISECONDS)
+          if key != null then
+            val dir = keyToPath.get(key)
+            if dir != null then
+              val events = key.pollEvents()
+              events.forEach { event =>
+                val kind = event.kind()
+                if kind != OVERFLOW then
+                  val context   = event.context().asInstanceOf[Path]
+                  val fullPath  = dir.resolve(context)
+                  val ioPath    = IOPath.parse(fullPath.toString)
+                  val eventType =
+                    if kind == ENTRY_CREATE then
+                      WatchEventType.Created
+                    else if kind == ENTRY_MODIFY then
+                      WatchEventType.Modified
+                    else
+                      WatchEventType.Deleted
+
+                  handler(WatchEvent(eventType, ioPath))
+
+                  // If recursive and a new directory was created, register it
+                  if options.recursive && kind == ENTRY_CREATE && Files.isDirectory(fullPath) then
+                    registerDirectory(fullPath)
+                else
+                  handler(WatchEvent(WatchEventType.Overflow, IOPath.parse(dir.toString)))
+              }
+              if !key.reset() then
+                keyToPath.remove(key)
+        catch
+          case _: java.nio.file.ClosedWatchServiceException =>
+            running.set(false)
+          case _: InterruptedException =>
+            running.set(false)
+    )
+    thread.setDaemon(true)
+    thread.setName(s"io-watch-${path.path}")
+    thread.start()
+
+    new IOWatcher:
+      override def close(): Unit =
+        running.set(false)
+        watchService.close()
+        thread.interrupt()
+        thread.join(1000)
+
+  end watch
+
+end IOWatchJvm

--- a/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -81,7 +81,11 @@ private[io] object IOWatchJvm extends IOWatchBase:
                     else
                       WatchEventType.Deleted
 
-                  handler(WatchEvent(eventType, ioPath))
+                  try
+                    handler(WatchEvent(eventType, ioPath))
+                  catch
+                    case _: Throwable =>
+                      ()
 
                   // If recursive and a new directory was created, register its entire subtree
                   if options.recursive && kind == ENTRY_CREATE then
@@ -89,9 +93,15 @@ private[io] object IOWatchJvm extends IOWatchBase:
                       if Files.isDirectory(fullPath) then
                         registerTree(fullPath)
                     catch
-                      case _: java.io.IOException => // Directory may have been removed
+                      case _: java.io.IOException =>
+                        ()
                 else
-                  handler(WatchEvent(WatchEventType.Overflow, IOPath.parse(dir.toString)))
+                  try
+                    handler(WatchEvent(WatchEventType.Overflow, IOPath.parse(dir.toString)))
+                  catch
+                    case _: Throwable =>
+                      ()
+                end if
               }
               if !key.reset() then
                 keyToPath.remove(key)

--- a/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -40,18 +40,19 @@ private[io] object IOWatchJvm extends IOWatchBase:
       val key = dir.register(watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE)
       keyToPath.put(key, dir)
 
-    // Register the root directory
-    registerDirectory(nioPath)
+    def registerTree(root: Path): Unit = Files.walkFileTree(
+      root,
+      new SimpleFileVisitor[Path]:
+        override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult =
+          registerDirectory(dir)
+          FileVisitResult.CONTINUE
+    )
 
-    // For recursive watching, register all subdirectories
+    // Register the root directory (and all subdirectories if recursive)
     if options.recursive then
-      Files.walkFileTree(
-        nioPath,
-        new SimpleFileVisitor[Path]:
-          override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult =
-            registerDirectory(dir)
-            FileVisitResult.CONTINUE
-      )
+      registerTree(nioPath)
+    else
+      registerDirectory(nioPath)
 
     val running = AtomicBoolean(true)
     val thread  = Thread(() =>
@@ -78,9 +79,9 @@ private[io] object IOWatchJvm extends IOWatchBase:
 
                   handler(WatchEvent(eventType, ioPath))
 
-                  // If recursive and a new directory was created, register it
+                  // If recursive and a new directory was created, register its entire subtree
                   if options.recursive && kind == ENTRY_CREATE && Files.isDirectory(fullPath) then
-                    registerDirectory(fullPath)
+                    registerTree(fullPath)
                 else
                   handler(WatchEvent(WatchEventType.Overflow, IOPath.parse(dir.toString)))
               }

--- a/uni-core/.native/src/main/scala/wvlet/uni/io/FileSystemImpl.scala
+++ b/uni-core/.native/src/main/scala/wvlet/uni/io/FileSystemImpl.scala
@@ -386,8 +386,9 @@ end FileSystemNative
   * Scala Native FileSystem initialization.
   */
 object FileSystemInit:
-  // Register Native implementation
+  // Register Native implementations
   FileSystem.setImplementation(FileSystemNative)
+  IOWatch.setImplementation(IOWatchNative)
 
   /**
     * Ensures the FileSystem is initialized.

--- a/uni-core/.native/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.native/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+  * Scala Native implementation of IOWatch using a polling-based approach. Periodically scans the
+  * directory and compares file modification times to detect changes.
+  */
+private[io] object IOWatchNative extends IOWatchBase:
+
+  override def watch(path: IOPath, options: WatchOptions)(handler: WatchEvent => Unit): IOWatcher =
+    val rootFile = File(path.path)
+    if !rootFile.isDirectory then
+      throw IOOperationException(s"Watch path is not a directory: ${path.path}")
+
+    val running = AtomicBoolean(true)
+
+    // Take an initial snapshot of the directory
+    var snapshot = scanDirectory(rootFile, options.recursive)
+
+    val thread = Thread(() =>
+      while running.get() do
+        try
+          Thread.sleep(options.pollingIntervalMs)
+          if running.get() then
+            val current = scanDirectory(rootFile, options.recursive)
+
+            // Detect created files
+            current.foreach { (filePath, modTime) =>
+              snapshot.get(filePath) match
+                case None =>
+                  handler(WatchEvent(WatchEventType.Created, IOPath.parse(filePath)))
+                case Some(oldModTime) if oldModTime != modTime =>
+                  handler(WatchEvent(WatchEventType.Modified, IOPath.parse(filePath)))
+                case _ => // No change
+            }
+
+            // Detect deleted files
+            snapshot.foreach { (filePath, _) =>
+              if !current.contains(filePath) then
+                handler(WatchEvent(WatchEventType.Deleted, IOPath.parse(filePath)))
+            }
+
+            snapshot = current
+        catch
+          case _: InterruptedException =>
+            running.set(false)
+    )
+    thread.setDaemon(true)
+    thread.setName(s"io-watch-${path.path}")
+    thread.start()
+
+    new IOWatcher:
+      override def close(): Unit =
+        running.set(false)
+        thread.interrupt()
+        thread.join(1000)
+
+  end watch
+
+  private def scanDirectory(dir: File, recursive: Boolean): Map[String, Long] =
+    val result = Map.newBuilder[String, Long]
+
+    def scan(d: File): Unit =
+      val children = d.listFiles()
+      if children != null then
+        children.foreach { child =>
+          result += (child.getAbsolutePath -> child.lastModified())
+          if recursive && child.isDirectory then
+            scan(child)
+        }
+
+    scan(dir)
+    result.result()
+
+end IOWatchNative

--- a/uni-core/.native/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.native/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -40,17 +40,26 @@ private[io] object IOWatchNative extends IOWatchBase:
             val current = scanDirectory(rootFile, options.recursive)
 
             current.foreach { (filePath, modTime) =>
-              snapshot.get(filePath) match
-                case None =>
-                  handler(WatchEvent(WatchEventType.Created, IOPath.parse(filePath)))
-                case Some(oldModTime) if oldModTime != modTime =>
-                  handler(WatchEvent(WatchEventType.Modified, IOPath.parse(filePath)))
-                case _ => // No change
+              try
+                snapshot.get(filePath) match
+                  case None =>
+                    handler(WatchEvent(WatchEventType.Created, IOPath.parse(filePath)))
+                  case Some(oldModTime) if oldModTime != modTime =>
+                    handler(WatchEvent(WatchEventType.Modified, IOPath.parse(filePath)))
+                  case _ =>
+                    ()
+              catch
+                case _: Throwable =>
+                  ()
             }
 
             snapshot.foreach { (filePath, _) =>
               if !current.contains(filePath) then
-                handler(WatchEvent(WatchEventType.Deleted, IOPath.parse(filePath)))
+                try
+                  handler(WatchEvent(WatchEventType.Deleted, IOPath.parse(filePath)))
+                catch
+                  case _: Throwable =>
+                    ()
             }
 
             snapshot = current

--- a/uni-core/.native/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
+++ b/uni-core/.native/src/main/scala/wvlet/uni/io/IOWatchImpl.scala
@@ -29,7 +29,7 @@ private[io] object IOWatchNative extends IOWatchBase:
 
     val running = AtomicBoolean(true)
 
-    // Take an initial snapshot of the directory
+    @volatile
     var snapshot = scanDirectory(rootFile, options.recursive)
 
     val thread = Thread(() =>
@@ -39,7 +39,6 @@ private[io] object IOWatchNative extends IOWatchBase:
           if running.get() then
             val current = scanDirectory(rootFile, options.recursive)
 
-            // Detect created files
             current.foreach { (filePath, modTime) =>
               snapshot.get(filePath) match
                 case None =>
@@ -49,7 +48,6 @@ private[io] object IOWatchNative extends IOWatchBase:
                 case _ => // No change
             }
 
-            // Detect deleted files
             snapshot.foreach { (filePath, _) =>
               if !current.contains(filePath) then
                 handler(WatchEvent(WatchEventType.Deleted, IOPath.parse(filePath)))

--- a/uni-core/src/main/scala/wvlet/uni/io/IO.scala
+++ b/uni-core/src/main/scala/wvlet/uni/io/IO.scala
@@ -265,4 +265,6 @@ object IO extends IOCompat:
     existsAsync
   }
 
+  export IOWatch.watch
+
 end IO

--- a/uni-core/src/main/scala/wvlet/uni/io/IOWatch.scala
+++ b/uni-core/src/main/scala/wvlet/uni/io/IOWatch.scala
@@ -49,27 +49,6 @@ trait IOWatcher extends AutoCloseable:
   def close(): Unit
 
 /**
-  * Cross-platform file system watcher. Watches a directory for file creation, modification, and
-  * deletion events.
-  *
-  * Usage:
-  * {{{
-  * import wvlet.uni.io.*
-  *
-  * val watcher = IOWatch.watch(IOPath("my-dir")) { event =>
-  *   println(s"${event.eventType}: ${event.path}")
-  * }
-  * // ... later
-  * watcher.close()
-  * }}}
-  *
-  * Platform implementations:
-  *   - JVM: Uses `java.nio.file.WatchService`
-  *   - Node.js: Uses `fs.watch`
-  *   - Native: Uses polling-based approach
-  *   - Browser: Not supported
-  */
-/**
   * Base trait for platform-specific watch implementations.
   */
 trait IOWatchBase:

--- a/uni-core/src/main/scala/wvlet/uni/io/IOWatch.scala
+++ b/uni-core/src/main/scala/wvlet/uni/io/IOWatch.scala
@@ -105,7 +105,8 @@ object IOWatch extends IOWatchBase:
       )
     _impl
 
-  override def watch(path: IOPath, options: WatchOptions)(handler: WatchEvent => Unit): IOWatcher =
-    impl.watch(path, options)(handler)
+  override def watch(path: IOPath, options: WatchOptions = WatchOptions.default)(
+      handler: WatchEvent => Unit
+  ): IOWatcher = impl.watch(path, options)(handler)
 
 end IOWatch

--- a/uni-core/src/main/scala/wvlet/uni/io/IOWatch.scala
+++ b/uni-core/src/main/scala/wvlet/uni/io/IOWatch.scala
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+/**
+  * Type of file system watch event.
+  */
+enum WatchEventType:
+  case Created
+  case Modified
+  case Deleted
+  case Overflow
+
+/**
+  * A file system watch event indicating a change to a file or directory.
+  */
+case class WatchEvent(eventType: WatchEventType, path: IOPath)
+
+/**
+  * Options for configuring file system watching.
+  */
+case class WatchOptions(
+    /** Watch subdirectories recursively */
+    recursive: Boolean = false,
+    /** Polling interval in milliseconds for platforms that use polling */
+    pollingIntervalMs: Long = 500
+):
+  def withRecursive(value: Boolean): WatchOptions   = copy(recursive = value)
+  def withPollingIntervalMs(ms: Long): WatchOptions = copy(pollingIntervalMs = ms)
+
+object WatchOptions:
+  val default: WatchOptions = WatchOptions()
+
+/**
+  * A handle to a running file system watcher. Call `close()` to stop watching.
+  */
+trait IOWatcher extends AutoCloseable:
+  def close(): Unit
+
+/**
+  * Cross-platform file system watcher. Watches a directory for file creation, modification, and
+  * deletion events.
+  *
+  * Usage:
+  * {{{
+  * import wvlet.uni.io.*
+  *
+  * val watcher = IOWatch.watch(IOPath("my-dir")) { event =>
+  *   println(s"${event.eventType}: ${event.path}")
+  * }
+  * // ... later
+  * watcher.close()
+  * }}}
+  *
+  * Platform implementations:
+  *   - JVM: Uses `java.nio.file.WatchService`
+  *   - Node.js: Uses `fs.watch`
+  *   - Native: Uses polling-based approach
+  *   - Browser: Not supported
+  */
+/**
+  * Base trait for platform-specific watch implementations.
+  */
+trait IOWatchBase:
+
+  /**
+    * Watch a directory for file system events.
+    *
+    * @param path
+    *   the directory to watch
+    * @param options
+    *   watch configuration
+    * @param handler
+    *   callback invoked for each watch event
+    * @return
+    *   an IOWatcher handle; call `close()` to stop watching
+    */
+  def watch(path: IOPath, options: WatchOptions = WatchOptions.default)(
+      handler: WatchEvent => Unit
+  ): IOWatcher
+
+/**
+  * Cross-platform file system watcher. Watches a directory for file creation, modification, and
+  * deletion events.
+  *
+  * Usage:
+  * {{{
+  * import wvlet.uni.io.*
+  *
+  * val watcher = IOWatch.watch(IOPath("my-dir")) { event =>
+  *   println(s"${event.eventType}: ${event.path}")
+  * }
+  * // ... later
+  * watcher.close()
+  * }}}
+  *
+  * Platform implementations:
+  *   - JVM: Uses `java.nio.file.WatchService`
+  *   - Node.js: Uses `fs.watch`
+  *   - Native: Uses polling-based approach
+  *   - Browser: Not supported
+  */
+object IOWatch extends IOWatchBase:
+  import scala.compiletime.uninitialized
+
+  @volatile
+  private var _impl: IOWatchBase = uninitialized
+
+  private[io] def setImplementation(impl: IOWatchBase): Unit = _impl = impl
+
+  private def impl: IOWatchBase =
+    if _impl == null then
+      throw IllegalStateException(
+        "IOWatch not initialized. Platform-specific initialization required."
+      )
+    _impl
+
+  override def watch(path: IOPath, options: WatchOptions)(handler: WatchEvent => Unit): IOWatcher =
+    impl.watch(path, options)(handler)
+
+end IOWatch

--- a/uni/.jvm/src/test/scala/wvlet/uni/io/IOWatchJvmTest.scala
+++ b/uni/.jvm/src/test/scala/wvlet/uni/io/IOWatchJvmTest.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+import wvlet.uni.test.UniTest
+
+import java.util.concurrent.CopyOnWriteArrayList
+import scala.jdk.CollectionConverters.*
+
+class IOWatchJvmTest extends UniTest:
+  FileSystemInit.init()
+
+  private def waitForEvents(
+      events: CopyOnWriteArrayList[WatchEvent],
+      expectedCount: Int,
+      timeoutMs: Long = 5000
+  ): Unit =
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while events.size() < expectedCount && System.currentTimeMillis() < deadline do
+      Thread.sleep(100)
+
+  test("detect file creation") {
+    val dir    = FileSystem.createTempDirectory("watch-create-test")
+    val events = CopyOnWriteArrayList[WatchEvent]()
+
+    val watcher =
+      IOWatch.watch(dir, WatchOptions.default.withPollingIntervalMs(100)) { event =>
+        events.add(event)
+      }
+    try
+      Thread.sleep(200)
+
+      val file = dir / "new-file.txt"
+      FileSystem.writeString(file, "hello")
+
+      waitForEvents(events, 1)
+
+      val createdEvents = events.asScala.filter(_.eventType == WatchEventType.Created)
+      (createdEvents.size >= 1) shouldBe true
+    finally
+      watcher.close()
+      FileSystem.deleteRecursively(dir)
+  }
+
+  test("detect file modification") {
+    val dir  = FileSystem.createTempDirectory("watch-modify-test")
+    val file = dir / "existing.txt"
+    FileSystem.writeString(file, "initial")
+
+    val events = CopyOnWriteArrayList[WatchEvent]()
+
+    val watcher =
+      IOWatch.watch(dir, WatchOptions.default.withPollingIntervalMs(100)) { event =>
+        events.add(event)
+      }
+    try
+      Thread.sleep(200)
+
+      FileSystem.writeString(file, "modified")
+
+      waitForEvents(events, 1)
+
+      val modifiedEvents = events.asScala.filter(_.eventType == WatchEventType.Modified)
+      (modifiedEvents.size >= 1) shouldBe true
+    finally
+      watcher.close()
+      FileSystem.deleteRecursively(dir)
+  }
+
+  test("detect file deletion") {
+    val dir  = FileSystem.createTempDirectory("watch-delete-test")
+    val file = dir / "to-delete.txt"
+    FileSystem.writeString(file, "delete me")
+
+    val events = CopyOnWriteArrayList[WatchEvent]()
+
+    val watcher =
+      IOWatch.watch(dir, WatchOptions.default.withPollingIntervalMs(100)) { event =>
+        events.add(event)
+      }
+    try
+      Thread.sleep(200)
+
+      FileSystem.delete(file)
+
+      waitForEvents(events, 1)
+
+      val deletedEvents = events.asScala.filter(_.eventType == WatchEventType.Deleted)
+      (deletedEvents.size >= 1) shouldBe true
+    finally
+      watcher.close()
+      FileSystem.deleteRecursively(dir)
+  }
+
+  test("watcher closes cleanly") {
+    val dir = FileSystem.createTempDirectory("watch-close-test")
+
+    val watcher =
+      IOWatch.watch(dir, WatchOptions.default.withPollingIntervalMs(100)) { _ =>
+        ()
+      }
+    watcher.close()
+
+    // Should not throw when closing again
+    watcher.close()
+
+    FileSystem.deleteRecursively(dir)
+  }
+
+  test("throw on non-directory path") {
+    val dir  = FileSystem.createTempDirectory("watch-nondir-test")
+    val file = dir / "a-file.txt"
+    FileSystem.writeString(file, "not a dir")
+
+    try
+      val ex = intercept[IOOperationException] {
+        IOWatch.watch(file) { _ =>
+          ()
+        }
+      }
+      ex.getMessage shouldContain "not a directory"
+    finally
+      FileSystem.deleteRecursively(dir)
+  }
+
+  test("IO.watch delegates to IOWatch") {
+    val dir    = FileSystem.createTempDirectory("io-watch-test")
+    val events = CopyOnWriteArrayList[WatchEvent]()
+
+    val watcher =
+      IO.watch(dir, WatchOptions.default.withPollingIntervalMs(100)) { event =>
+        events.add(event)
+      }
+    try
+      Thread.sleep(200)
+
+      val file = dir / "via-io.txt"
+      FileSystem.writeString(file, "test")
+
+      waitForEvents(events, 1)
+      (events.size() >= 1) shouldBe true
+    finally
+      watcher.close()
+      FileSystem.deleteRecursively(dir)
+  }
+
+end IOWatchJvmTest

--- a/uni/src/test/scala/wvlet/uni/io/IOWatchTest.scala
+++ b/uni/src/test/scala/wvlet/uni/io/IOWatchTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+import wvlet.uni.test.UniTest
+
+class IOWatchTest extends UniTest:
+  FileSystemInit.init()
+
+  test("WatchOptions default values") {
+    val opts = WatchOptions.default
+    opts.recursive shouldBe false
+    opts.pollingIntervalMs shouldBe 500L
+  }
+
+  test("WatchOptions builder") {
+    val opts = WatchOptions.default.withRecursive(true).withPollingIntervalMs(1000)
+    opts.recursive shouldBe true
+    opts.pollingIntervalMs shouldBe 1000L
+  }
+
+  test("WatchEventType values") {
+    val types = WatchEventType.values
+    types.length shouldBe 4
+    types shouldContain WatchEventType.Created
+    types shouldContain WatchEventType.Modified
+    types shouldContain WatchEventType.Deleted
+    types shouldContain WatchEventType.Overflow
+  }
+
+  test("WatchEvent construction") {
+    val event = WatchEvent(WatchEventType.Created, IOPath.parse("/tmp/test.txt"))
+    event.eventType shouldBe WatchEventType.Created
+    event.path.fileName shouldBe "test.txt"
+  }
+
+end IOWatchTest


### PR DESCRIPTION
## Summary

- Add `IOWatch` API to `wvlet.uni.io` for watching directories for file creation, modification, and deletion events
- JVM implementation uses `java.nio.file.WatchService` with daemon thread polling
- Node.js (Scala.js) implementation uses `fs.watch` API with recursive support
- Scala Native implementation uses polling-based approach (periodic directory scanning)
- Browser platform throws `UnsupportedOperationException` (not supported)
- Export `IOWatch.watch` through the `IO` facade object

## API

```scala
val watcher = IOWatch.watch(IOPath("my-dir"), WatchOptions(recursive = true)) { event =>
  println(s"${event.eventType}: ${event.path}")
}
watcher.close()  // Stop watching
```

## Test plan

- [x] Cross-platform unit tests (WatchOptions, WatchEventType, WatchEvent construction)
- [x] JVM integration tests: file creation, modification, deletion detection
- [x] JVM test: watcher close/cleanup
- [x] JVM test: error on non-directory path
- [x] JVM test: IO.watch delegation
- [x] Scala.js tests pass (shared API tests)
- [x] Scala Native tests pass (shared API tests)
- [x] `scalafmtAll` passes
- [x] Full compilation across all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)