### PR TITLE
feature: Add zip archive support (create/extract/list) to wvlet.uni.io

### DIFF
--- a/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -67,6 +67,7 @@ trait ZipCompat extends ZipApi:
   private val MethodStored   = 0
   private val MethodDeflated = 8
   private val VersionNeeded  = 20
+  private val MaxEOCDSearchOffset = 22 + 65535 // EOCD size + max comment length
 
   private def requireNode(): Unit =
     if FileSystem.isBrowser then
@@ -100,7 +101,9 @@ trait ZipCompat extends ZipApi:
     for (entryName, sourcePath) <- filesToAdd do
       val isDir = entryName.endsWith("/")
 
-      // Track uncompressed size and keep compressed data as Uint8Array to avoid extra copies
+      val stats = NodeFSModule.statSync(sourcePath)
+
+      // Keep compressed data as Uint8Array to avoid extra copies
       val (uncompressedSize, crc, compressedData, method) =
         if isDir then
           (0, 0.0, Uint8Array(0), MethodStored)
@@ -114,12 +117,7 @@ trait ZipCompat extends ZipApi:
             val deflated = NodeZlibRawModule.deflateRawSync(raw)
             (bytes.length, crcValue, deflated, MethodDeflated)
 
-      val (dosTime, dosDate) =
-        if isDir then
-          (0, 0)
-        else
-          val stats = NodeFSModule.statSync(sourcePath)
-          epochMillisToDosDateTime(stats.mtimeMs)
+      val (dosTime, dosDate) = epochMillisToDosDateTime(stats.mtimeMs)
 
       // Local file header
       val nameBytes = NodeBufferFactory.from(entryName, "utf8")
@@ -298,7 +296,7 @@ trait ZipCompat extends ZipApi:
 
   private def findEOCD(data: NodeBuffer): Int =
     var pos = data.length - 22
-    while pos >= math.max(0, data.length - 65557) do
+    while pos >= math.max(0, data.length - MaxEOCDSearchOffset) do
       if data.readUInt32LE(pos) == EndOfCentralDirSig then
         return pos
       pos -= 1

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -61,25 +61,27 @@ trait ZipCompat extends ZipApi:
   private val LocalFileHeaderSig = 0x04034b50.toDouble
   private val CentralDirSig      = 0x02014b50.toDouble
   private val EndOfCentralDirSig = 0x06054b50.toDouble
-  private val MethodStored       = 0
-  private val MethodDeflated     = 8
-  private val VersionNeeded      = 20
+  private val FlagUtf8       = 0x800 // General purpose bit flag: UTF-8 filename encoding (bit 11)
+  private val MethodStored   = 0
+  private val MethodDeflated = 8
+  private val VersionNeeded  = 20
 
-  override def create(target: IOPath, sources: Seq[IOPath]): Unit =
+  private def requireNode(): Unit =
     if FileSystem.isBrowser then
       throw UnsupportedOperationException(
         "Zip operations are not supported in browser environments"
       )
 
+  override def create(target: IOPath, sources: Seq[IOPath]): Unit =
+    requireNode()
+
     val resolvedTarget = NodePathModule.resolve(target.path)
     val targetDir      = NodePathModule.dirname(resolvedTarget)
-    if !NodeFSModule.existsSync(targetDir) then
-      NodeFSModule.mkdirSync(targetDir, js.Dynamic.literal(recursive = true))
+    NodeFSModule.mkdirSync(targetDir, js.Dynamic.literal(recursive = true))
 
     val filesToAdd = collectFiles(sources, resolvedTarget)
     val buffers    = js.Array[js.Any]()
 
-    // Track entries for central directory
     case class EntryRecord(
         name: String,
         localOffset: Int,
@@ -96,18 +98,19 @@ trait ZipCompat extends ZipApi:
     for (entryName, sourcePath) <- filesToAdd do
       val isDir = entryName.endsWith("/")
 
-      val (fileData, crc, compressed, method) =
+      // Track uncompressed size and keep compressed data as Uint8Array to avoid extra copies
+      val (uncompressedSize, crc, compressedData, method) =
         if isDir then
-          (Array.emptyByteArray, 0.0, Array.emptyByteArray, MethodStored)
+          (0, 0.0, Uint8Array(0), MethodStored)
         else
           val raw      = NodeFSModule.readFileSync(sourcePath)
           val bytes    = uint8ArrayToByteArray(raw)
           val crcValue = toUnsigned(CRC32.compute(bytes))
           if bytes.isEmpty then
-            (bytes, crcValue, bytes, MethodStored)
+            (0, crcValue, Uint8Array(0), MethodStored)
           else
-            val deflated = uint8ArrayToByteArray(NodeZlibRawModule.deflateRawSync(raw))
-            (bytes, crcValue, deflated, MethodDeflated)
+            val deflated = NodeZlibRawModule.deflateRawSync(raw)
+            (bytes.length, crcValue, deflated, MethodDeflated)
 
       val (dosTime, dosDate) =
         if isDir then
@@ -121,38 +124,32 @@ trait ZipCompat extends ZipApi:
       val header    = NodeBufferFactory.alloc(30)
       header.writeUInt32LE(LocalFileHeaderSig, 0)
       header.writeUInt16LE(VersionNeeded, 4)
-      header.writeUInt16LE(0x800, 6) // flags: UTF-8 filename encoding (bit 11)
+      header.writeUInt16LE(FlagUtf8, 6)
       header.writeUInt16LE(method, 8)
       header.writeUInt16LE(dosTime, 10)
       header.writeUInt16LE(dosDate, 12)
       header.writeUInt32LE(crc, 14)
-      header.writeUInt32LE(compressed.length.toDouble, 18)
-      header.writeUInt32LE(fileData.length.toDouble, 22)
+      header.writeUInt32LE(compressedData.length.toDouble, 18)
+      header.writeUInt32LE(uncompressedSize.toDouble, 22)
       header.writeUInt16LE(nameBytes.length, 26)
-      header.writeUInt16LE(0, 28) // extra field length
+      header.writeUInt16LE(0, 28)
 
       buffers.push(header)
       buffers.push(nameBytes)
-
-      val dataBuf =
-        if compressed.isEmpty then
-          NodeBufferFactory.alloc(0)
-        else
-          NodeBufferFactory.from(byteArrayToUint8Array(compressed))
-      buffers.push(dataBuf)
+      buffers.push(NodeBufferFactory.from(compressedData))
 
       entries +=
         EntryRecord(
           name = entryName,
           localOffset = offset,
           crc = crc,
-          compressedSize = compressed.length,
-          uncompressedSize = fileData.length,
+          compressedSize = compressedData.length,
+          uncompressedSize = uncompressedSize,
           method = method,
           dosTime = dosTime,
           dosDate = dosDate
         )
-      offset += 30 + nameBytes.length + compressed.length
+      offset += 30 + nameBytes.length + compressedData.length
     end for
 
     // Central directory
@@ -161,9 +158,9 @@ trait ZipCompat extends ZipApi:
       val nameBytes = NodeBufferFactory.from(entry.name, "utf8")
       val cdEntry   = NodeBufferFactory.alloc(46)
       cdEntry.writeUInt32LE(CentralDirSig, 0)
-      cdEntry.writeUInt16LE(VersionNeeded, 4) // version made by
-      cdEntry.writeUInt16LE(VersionNeeded, 6) // version needed
-      cdEntry.writeUInt16LE(0x800, 8)         // flags: UTF-8 filename encoding (bit 11)
+      cdEntry.writeUInt16LE(VersionNeeded, 4)
+      cdEntry.writeUInt16LE(VersionNeeded, 6)
+      cdEntry.writeUInt16LE(FlagUtf8, 8)
       cdEntry.writeUInt16LE(entry.method, 10)
       cdEntry.writeUInt16LE(entry.dosTime, 12)
       cdEntry.writeUInt16LE(entry.dosDate, 14)
@@ -171,11 +168,11 @@ trait ZipCompat extends ZipApi:
       cdEntry.writeUInt32LE(entry.compressedSize.toDouble, 20)
       cdEntry.writeUInt32LE(entry.uncompressedSize.toDouble, 24)
       cdEntry.writeUInt16LE(nameBytes.length, 28)
-      cdEntry.writeUInt16LE(0, 30) // extra field length
-      cdEntry.writeUInt16LE(0, 32) // comment length
-      cdEntry.writeUInt16LE(0, 34) // disk number start
-      cdEntry.writeUInt16LE(0, 36) // internal attrs
-      cdEntry.writeUInt32LE(0, 38) // external attrs
+      cdEntry.writeUInt16LE(0, 30)
+      cdEntry.writeUInt16LE(0, 32)
+      cdEntry.writeUInt16LE(0, 34)
+      cdEntry.writeUInt16LE(0, 36)
+      cdEntry.writeUInt32LE(0, 38)
       cdEntry.writeUInt32LE(entry.localOffset.toDouble, 42)
 
       buffers.push(cdEntry)
@@ -187,13 +184,13 @@ trait ZipCompat extends ZipApi:
     // End of central directory
     val eocd = NodeBufferFactory.alloc(22)
     eocd.writeUInt32LE(EndOfCentralDirSig, 0)
-    eocd.writeUInt16LE(0, 4)             // disk number
-    eocd.writeUInt16LE(0, 6)             // disk with CD
-    eocd.writeUInt16LE(entries.size, 8)  // entries this disk
-    eocd.writeUInt16LE(entries.size, 10) // total entries
+    eocd.writeUInt16LE(0, 4)
+    eocd.writeUInt16LE(0, 6)
+    eocd.writeUInt16LE(entries.size, 8)
+    eocd.writeUInt16LE(entries.size, 10)
     eocd.writeUInt32LE(cdSize.toDouble, 12)
     eocd.writeUInt32LE(cdStart.toDouble, 16)
-    eocd.writeUInt16LE(0, 20) // comment length
+    eocd.writeUInt16LE(0, 20)
     buffers.push(eocd)
 
     val result = NodeBufferFactory.concat(buffers)
@@ -202,13 +199,8 @@ trait ZipCompat extends ZipApi:
   end create
 
   override def extract(archive: IOPath, destination: IOPath): Unit =
-    if FileSystem.isBrowser then
-      throw UnsupportedOperationException(
-        "Zip operations are not supported in browser environments"
-      )
-
-    if !NodeFSModule.existsSync(destination.path) then
-      NodeFSModule.mkdirSync(destination.path, js.Dynamic.literal(recursive = true))
+    requireNode()
+    NodeFSModule.mkdirSync(destination.path, js.Dynamic.literal(recursive = true))
 
     val data         = NodeBufferFactory.from(NodeFSModule.readFileSync(archive.path))
     val eocdOffset   = findEOCD(data)
@@ -226,7 +218,6 @@ trait ZipCompat extends ZipApi:
       val localOffset    = data.readUInt32LE(pos + 42).toInt
       val name           = data.toString("utf8", pos + 46, pos + 46 + nameLength)
 
-      // Read local file header to find actual data offset
       val localNameLen  = data.readUInt16LE(localOffset + 26)
       val localExtraLen = data.readUInt16LE(localOffset + 28)
       val dataOffset    = localOffset + 30 + localNameLen + localExtraLen
@@ -234,8 +225,7 @@ trait ZipCompat extends ZipApi:
       val entryPath       = NodePathModule.join(destination.path, name)
       val normalizedDest  = NodePathModule.resolve(destination.path) + NodePathModule.sep
       val normalizedEntry = NodePathModule.resolve(entryPath)
-      // Guard against zip slip attack — append separator to prevent prefix false positives
-      // e.g. "/tmp/out-evil".startsWith("/tmp/out") would be a false positive
+      // Guard against zip slip — append separator to prevent prefix false positives
       if !normalizedEntry.startsWith(normalizedDest) then
         throw IOOperationException(s"Zip entry outside target directory: ${name}")
 
@@ -243,8 +233,7 @@ trait ZipCompat extends ZipApi:
         NodeFSModule.mkdirSync(entryPath, js.Dynamic.literal(recursive = true))
       else
         val parentDir = NodePathModule.dirname(entryPath)
-        if !NodeFSModule.existsSync(parentDir) then
-          NodeFSModule.mkdirSync(parentDir, js.Dynamic.literal(recursive = true))
+        NodeFSModule.mkdirSync(parentDir, js.Dynamic.literal(recursive = true))
 
         val compressedData = data.subarray(dataOffset, dataOffset + compressedSize)
         val fileData       =
@@ -268,10 +257,7 @@ trait ZipCompat extends ZipApi:
   end extract
 
   override def list(archive: IOPath): Seq[ZipEntry] =
-    if FileSystem.isBrowser then
-      throw UnsupportedOperationException(
-        "Zip operations are not supported in browser environments"
-      )
+    requireNode()
 
     val data         = NodeBufferFactory.from(NodeFSModule.readFileSync(archive.path))
     val eocdOffset   = findEOCD(data)
@@ -310,7 +296,7 @@ trait ZipCompat extends ZipApi:
 
   private def findEOCD(data: NodeBuffer): Int =
     var pos = data.length - 22
-    while pos >= 0 do
+    while pos >= math.max(0, data.length - 65557) do
       if data.readUInt32LE(pos) == EndOfCentralDirSig then
         return pos
       pos -= 1

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -225,7 +225,7 @@ trait ZipCompat extends ZipApi:
       val dataOffset    = localOffset + 30 + localNameLen + localExtraLen
 
       // Guard against zip slip — use IOPath segment-based startsWith
-      val destIOPath  = IOPath.parse(destination.path).normalize
+      val destIOPath  = destination.normalize
       val entryIOPath = destIOPath.resolve(name).normalize
       if !entryIOPath.startsWith(destIOPath) then
         throw IOOperationException(s"Zip entry outside target directory: ${name}")
@@ -351,14 +351,6 @@ trait ZipCompat extends ZipApi:
     d.getTime().toLong
 
   private def toUnsigned(value: Int): Double = (value.toLong & 0xffffffffL).toDouble
-
-  private def byteArrayToUint8Array(bytes: Array[Byte]): Uint8Array =
-    val uint8 = Uint8Array(bytes.length)
-    var i     = 0
-    while i < bytes.length do
-      uint8(i) = (bytes(i) & 0xff).toShort
-      i += 1
-    uint8
 
   private def uint8ArrayToByteArray(uint8: Uint8Array): Array[Byte] =
     Int8Array(uint8.buffer, uint8.byteOffset, uint8.length).toArray

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -53,7 +53,9 @@ private[io] object NodeBufferFactory extends js.Object:
   * Scala.js (Node.js) implementation of zip archive operations.
   *
   * Uses Node's zlib module for raw deflate/inflate compression and Buffer for binary data
-  * manipulation to implement the ZIP file format directly.
+  * manipulation to implement the ZIP file format directly. Archives and individual entries are
+  * loaded into memory, so this implementation is limited to archives that fit in available heap
+  * (typically under 2GB). For streaming support, use the JVM or Native platforms.
   *
   * Browser environments throw UnsupportedOperationException.
   */
@@ -222,12 +224,12 @@ trait ZipCompat extends ZipApi:
       val localExtraLen = data.readUInt16LE(localOffset + 28)
       val dataOffset    = localOffset + 30 + localNameLen + localExtraLen
 
-      val entryPath       = NodePathModule.join(destination.path, name)
-      val normalizedDest  = NodePathModule.resolve(destination.path) + NodePathModule.sep
-      val normalizedEntry = NodePathModule.resolve(entryPath)
-      // Guard against zip slip — append separator to prevent prefix false positives
-      if !normalizedEntry.startsWith(normalizedDest) then
+      // Guard against zip slip — use IOPath segment-based startsWith
+      val destIOPath  = IOPath.parse(destination.path).normalize
+      val entryIOPath = destIOPath.resolve(name).normalize
+      if !entryIOPath.startsWith(destIOPath) then
         throw IOOperationException(s"Zip entry outside target directory: ${name}")
+      val entryPath = entryIOPath.path
 
       if name.endsWith("/") then
         NodeFSModule.mkdirSync(entryPath, js.Dynamic.literal(recursive = true))

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -1,0 +1,375 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.typedarray.Int8Array
+import scala.scalajs.js.typedarray.Uint8Array
+
+/**
+  * Node.js zlib facade for raw deflate/inflate (used by ZIP format).
+  */
+@js.native
+@JSImport("zlib", JSImport.Namespace)
+private[io] object NodeZlibRawModule extends js.Object:
+  def deflateRawSync(buffer: Uint8Array): Uint8Array = js.native
+  def inflateRawSync(buffer: Uint8Array): Uint8Array = js.native
+
+/**
+  * Node.js Buffer facade for binary data manipulation.
+  */
+@js.native
+private[io] trait NodeBuffer extends js.Object:
+  val length: Int                                              = js.native
+  def writeUInt32LE(value: Double, offset: Int): Int           = js.native
+  def writeUInt16LE(value: Int, offset: Int): Int              = js.native
+  def readUInt32LE(offset: Int): Double                        = js.native
+  def readUInt16LE(offset: Int): Int                           = js.native
+  def subarray(start: Int, end: Int): NodeBuffer               = js.native
+  def toString(encoding: String, start: Int, end: Int): String = js.native
+
+@js.native
+@JSGlobal("Buffer")
+private[io] object NodeBufferFactory extends js.Object:
+  def alloc(size: Int): NodeBuffer                    = js.native
+  def concat(list: js.Array[js.Any]): NodeBuffer      = js.native
+  def from(data: Uint8Array): NodeBuffer              = js.native
+  def from(str: String, encoding: String): NodeBuffer = js.native
+
+/**
+  * Scala.js (Node.js) implementation of zip archive operations.
+  *
+  * Uses Node's zlib module for raw deflate/inflate compression and Buffer for binary data
+  * manipulation to implement the ZIP file format directly.
+  *
+  * Browser environments throw UnsupportedOperationException.
+  */
+trait ZipCompat extends ZipApi:
+  private val LocalFileHeaderSig = 0x04034b50.toDouble
+  private val CentralDirSig      = 0x02014b50.toDouble
+  private val EndOfCentralDirSig = 0x06054b50.toDouble
+  private val MethodStored       = 0
+  private val MethodDeflated     = 8
+  private val VersionNeeded      = 20
+
+  override def create(target: IOPath, sources: Seq[IOPath]): Unit =
+    if FileSystem.isBrowser then
+      throw UnsupportedOperationException(
+        "Zip operations are not supported in browser environments"
+      )
+
+    val targetDir = NodePathModule.dirname(target.path)
+    if !NodeFSModule.existsSync(targetDir) then
+      NodeFSModule.mkdirSync(targetDir, js.Dynamic.literal(recursive = true))
+
+    val filesToAdd = collectFiles(sources)
+    val buffers    = js.Array[js.Any]()
+
+    // Track entries for central directory
+    case class EntryRecord(
+        name: String,
+        localOffset: Int,
+        crc: Double,
+        compressedSize: Int,
+        uncompressedSize: Int,
+        method: Int,
+        dosTime: Int,
+        dosDate: Int
+    )
+    val entries = scala.collection.mutable.ArrayBuffer[EntryRecord]()
+    var offset  = 0
+
+    for (entryName, sourcePath) <- filesToAdd do
+      val isDir = entryName.endsWith("/")
+
+      val (fileData, crc, compressed, method) =
+        if isDir then
+          (Array.emptyByteArray, 0.0, Array.emptyByteArray, MethodStored)
+        else
+          val raw      = NodeFSModule.readFileSync(sourcePath)
+          val bytes    = uint8ArrayToByteArray(raw)
+          val crcValue = toUnsigned(CRC32.compute(bytes))
+          if bytes.isEmpty then
+            (bytes, crcValue, bytes, MethodStored)
+          else
+            val deflated = uint8ArrayToByteArray(NodeZlibRawModule.deflateRawSync(raw))
+            (bytes, crcValue, deflated, MethodDeflated)
+
+      val (dosTime, dosDate) =
+        if isDir then
+          (0, 0)
+        else
+          val stats = NodeFSModule.statSync(sourcePath)
+          epochMillisToDosDateTime(stats.mtimeMs)
+
+      // Local file header
+      val nameBytes = NodeBufferFactory.from(entryName, "utf8")
+      val header    = NodeBufferFactory.alloc(30)
+      header.writeUInt32LE(LocalFileHeaderSig, 0)
+      header.writeUInt16LE(VersionNeeded, 4)
+      header.writeUInt16LE(0, 6) // flags
+      header.writeUInt16LE(method, 8)
+      header.writeUInt16LE(dosTime, 10)
+      header.writeUInt16LE(dosDate, 12)
+      header.writeUInt32LE(crc, 14)
+      header.writeUInt32LE(compressed.length.toDouble, 18)
+      header.writeUInt32LE(fileData.length.toDouble, 22)
+      header.writeUInt16LE(nameBytes.length, 26)
+      header.writeUInt16LE(0, 28) // extra field length
+
+      buffers.push(header)
+      buffers.push(nameBytes)
+
+      val dataBuf =
+        if compressed.isEmpty then
+          NodeBufferFactory.alloc(0)
+        else
+          NodeBufferFactory.from(byteArrayToUint8Array(compressed))
+      buffers.push(dataBuf)
+
+      entries +=
+        EntryRecord(
+          name = entryName,
+          localOffset = offset,
+          crc = crc,
+          compressedSize = compressed.length,
+          uncompressedSize = fileData.length,
+          method = method,
+          dosTime = dosTime,
+          dosDate = dosDate
+        )
+      offset += 30 + nameBytes.length + compressed.length
+    end for
+
+    // Central directory
+    val cdStart = offset
+    for entry <- entries do
+      val nameBytes = NodeBufferFactory.from(entry.name, "utf8")
+      val cdEntry   = NodeBufferFactory.alloc(46)
+      cdEntry.writeUInt32LE(CentralDirSig, 0)
+      cdEntry.writeUInt16LE(VersionNeeded, 4) // version made by
+      cdEntry.writeUInt16LE(VersionNeeded, 6) // version needed
+      cdEntry.writeUInt16LE(0, 8)             // flags
+      cdEntry.writeUInt16LE(entry.method, 10)
+      cdEntry.writeUInt16LE(entry.dosTime, 12)
+      cdEntry.writeUInt16LE(entry.dosDate, 14)
+      cdEntry.writeUInt32LE(entry.crc, 16)
+      cdEntry.writeUInt32LE(entry.compressedSize.toDouble, 20)
+      cdEntry.writeUInt32LE(entry.uncompressedSize.toDouble, 24)
+      cdEntry.writeUInt16LE(nameBytes.length, 28)
+      cdEntry.writeUInt16LE(0, 30) // extra field length
+      cdEntry.writeUInt16LE(0, 32) // comment length
+      cdEntry.writeUInt16LE(0, 34) // disk number start
+      cdEntry.writeUInt16LE(0, 36) // internal attrs
+      cdEntry.writeUInt32LE(0, 38) // external attrs
+      cdEntry.writeUInt32LE(entry.localOffset.toDouble, 42)
+
+      buffers.push(cdEntry)
+      buffers.push(nameBytes)
+      offset += 46 + nameBytes.length
+
+    val cdSize = offset - cdStart
+
+    // End of central directory
+    val eocd = NodeBufferFactory.alloc(22)
+    eocd.writeUInt32LE(EndOfCentralDirSig, 0)
+    eocd.writeUInt16LE(0, 4)             // disk number
+    eocd.writeUInt16LE(0, 6)             // disk with CD
+    eocd.writeUInt16LE(entries.size, 8)  // entries this disk
+    eocd.writeUInt16LE(entries.size, 10) // total entries
+    eocd.writeUInt32LE(cdSize.toDouble, 12)
+    eocd.writeUInt32LE(cdStart.toDouble, 16)
+    eocd.writeUInt16LE(0, 20) // comment length
+    buffers.push(eocd)
+
+    val result = NodeBufferFactory.concat(buffers)
+    NodeFSModule.writeFileSync(target.path, result.asInstanceOf[Uint8Array], js.Dynamic.literal())
+
+  end create
+
+  override def extract(archive: IOPath, destination: IOPath): Unit =
+    if FileSystem.isBrowser then
+      throw UnsupportedOperationException(
+        "Zip operations are not supported in browser environments"
+      )
+
+    if !NodeFSModule.existsSync(destination.path) then
+      NodeFSModule.mkdirSync(destination.path, js.Dynamic.literal(recursive = true))
+
+    val data         = NodeBufferFactory.from(NodeFSModule.readFileSync(archive.path))
+    val eocdOffset   = findEOCD(data)
+    val totalEntries = data.readUInt16LE(eocdOffset + 10)
+    val cdOffset     = data.readUInt32LE(eocdOffset + 16).toInt
+
+    var pos = cdOffset
+    var i   = 0
+    while i < totalEntries do
+      val method         = data.readUInt16LE(pos + 10)
+      val compressedSize = data.readUInt32LE(pos + 20).toInt
+      val nameLength     = data.readUInt16LE(pos + 28)
+      val extraLength    = data.readUInt16LE(pos + 30)
+      val commentLength  = data.readUInt16LE(pos + 32)
+      val localOffset    = data.readUInt32LE(pos + 42).toInt
+      val name           = data.toString("utf8", pos + 46, pos + 46 + nameLength)
+
+      // Read local file header to find actual data offset
+      val localNameLen  = data.readUInt16LE(localOffset + 26)
+      val localExtraLen = data.readUInt16LE(localOffset + 28)
+      val dataOffset    = localOffset + 30 + localNameLen + localExtraLen
+
+      val entryPath       = NodePathModule.join(destination.path, name)
+      val normalizedDest  = NodePathModule.resolve(destination.path)
+      val normalizedEntry = NodePathModule.resolve(entryPath)
+      // Guard against zip slip attack
+      if !normalizedEntry.startsWith(normalizedDest) then
+        throw IOOperationException(s"Zip entry outside target directory: ${name}")
+
+      if name.endsWith("/") then
+        NodeFSModule.mkdirSync(entryPath, js.Dynamic.literal(recursive = true))
+      else
+        val parentDir = NodePathModule.dirname(entryPath)
+        if !NodeFSModule.existsSync(parentDir) then
+          NodeFSModule.mkdirSync(parentDir, js.Dynamic.literal(recursive = true))
+
+        val compressedData = data.subarray(dataOffset, dataOffset + compressedSize)
+        val fileData       =
+          if method == MethodStored then
+            compressedData
+          else if method == MethodDeflated then
+            NodeZlibRawModule.inflateRawSync(compressedData.asInstanceOf[Uint8Array])
+          else
+            throw IOOperationException(s"Unsupported compression method: ${method}")
+
+        NodeFSModule.writeFileSync(
+          entryPath,
+          fileData.asInstanceOf[Uint8Array],
+          js.Dynamic.literal()
+        )
+
+      pos += 46 + nameLength + extraLength + commentLength
+      i += 1
+    end while
+
+  end extract
+
+  override def list(archive: IOPath): Seq[ZipEntry] =
+    if FileSystem.isBrowser then
+      throw UnsupportedOperationException(
+        "Zip operations are not supported in browser environments"
+      )
+
+    val data         = NodeBufferFactory.from(NodeFSModule.readFileSync(archive.path))
+    val eocdOffset   = findEOCD(data)
+    val totalEntries = data.readUInt16LE(eocdOffset + 10)
+    val cdOffset     = data.readUInt32LE(eocdOffset + 16).toInt
+
+    val result = scala.collection.mutable.ArrayBuffer[ZipEntry]()
+    var pos    = cdOffset
+    var i      = 0
+    while i < totalEntries do
+      val compressedSize   = data.readUInt32LE(pos + 20).toLong
+      val uncompressedSize = data.readUInt32LE(pos + 24).toLong
+      val nameLength       = data.readUInt16LE(pos + 28)
+      val extraLength      = data.readUInt16LE(pos + 30)
+      val commentLength    = data.readUInt16LE(pos + 32)
+      val name             = data.toString("utf8", pos + 46, pos + 46 + nameLength)
+      val dosTime          = data.readUInt16LE(pos + 12)
+      val dosDate          = data.readUInt16LE(pos + 14)
+      val lastModified     = dosDateTimeToEpochMillis(dosTime, dosDate)
+
+      result +=
+        ZipEntry(
+          name = name,
+          size = uncompressedSize,
+          compressedSize = compressedSize,
+          isDirectory = name.endsWith("/"),
+          lastModified = lastModified
+        )
+
+      pos += 46 + nameLength + extraLength + commentLength
+      i += 1
+
+    result.toSeq
+
+  end list
+
+  private def findEOCD(data: NodeBuffer): Int =
+    var pos = data.length - 22
+    while pos >= 0 do
+      if data.readUInt32LE(pos) == EndOfCentralDirSig then
+        return pos
+      pos -= 1
+    throw IOOperationException("Invalid zip archive: end of central directory not found")
+
+  private def collectFiles(sources: Seq[IOPath]): Seq[(String, String)] =
+    val files = scala.collection.mutable.ArrayBuffer[(String, String)]()
+    for source <- sources do
+      val path = source.path
+      if NodeFSModule.statSync(path).isDirectory() then
+        val baseName = NodePathModule.basename(path)
+        collectDirectory(files, path, baseName)
+      else
+        files += ((NodePathModule.basename(path), path))
+    files.toSeq
+
+  private def collectDirectory(
+      files: scala.collection.mutable.ArrayBuffer[(String, String)],
+      dirPath: String,
+      prefix: String
+  ): Unit =
+    files += ((s"${prefix}/", dirPath))
+    val entries = NodeFSModule.readdirSync(dirPath, js.Dynamic.literal(withFileTypes = true))
+    for entry <- entries do
+      val dirent    = entry.asInstanceOf[NodeDirent]
+      val childPath = NodePathModule.join(dirPath, dirent.name)
+      val childName = s"${prefix}/${dirent.name}"
+      if dirent.isDirectory() then
+        collectDirectory(files, childPath, childName)
+      else
+        files += ((childName, childPath))
+
+  private def epochMillisToDosDateTime(millis: Double): (Int, Int) =
+    val d    = new js.Date(millis)
+    val time =
+      ((d.getHours().toInt << 11) | (d.getMinutes().toInt << 5) | (d.getSeconds().toInt / 2))
+    val date =
+      (((d.getFullYear().toInt - 1980) << 9) | ((d.getMonth().toInt + 1) << 5) | d.getDate().toInt)
+    (time, date)
+
+  private def dosDateTimeToEpochMillis(dosTime: Int, dosDate: Int): Long =
+    val year    = ((dosDate >> 9) & 0x7f) + 1980
+    val month   = ((dosDate >> 5) & 0x0f) - 1 // JS Date months are 0-based
+    val day     = dosDate & 0x1f
+    val hours   = (dosTime >> 11) & 0x1f
+    val minutes = (dosTime >> 5) & 0x3f
+    val seconds = (dosTime & 0x1f) * 2
+    val d       = new js.Date(year, month, day, hours, minutes, seconds)
+    d.getTime().toLong
+
+  private def toUnsigned(value: Int): Double = (value.toLong & 0xffffffffL).toDouble
+
+  private def byteArrayToUint8Array(bytes: Array[Byte]): Uint8Array =
+    val uint8 = Uint8Array(bytes.length)
+    var i     = 0
+    while i < bytes.length do
+      uint8(i) = (bytes(i) & 0xff).toShort
+      i += 1
+    uint8
+
+  private def uint8ArrayToByteArray(uint8: Uint8Array): Array[Byte] =
+    Int8Array(uint8.buffer, uint8.byteOffset, uint8.length).toArray
+
+end ZipCompat

--- a/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -71,11 +71,12 @@ trait ZipCompat extends ZipApi:
         "Zip operations are not supported in browser environments"
       )
 
-    val targetDir = NodePathModule.dirname(target.path)
+    val resolvedTarget = NodePathModule.resolve(target.path)
+    val targetDir      = NodePathModule.dirname(resolvedTarget)
     if !NodeFSModule.existsSync(targetDir) then
       NodeFSModule.mkdirSync(targetDir, js.Dynamic.literal(recursive = true))
 
-    val filesToAdd = collectFiles(sources)
+    val filesToAdd = collectFiles(sources, resolvedTarget)
     val buffers    = js.Array[js.Any]()
 
     // Track entries for central directory
@@ -120,7 +121,7 @@ trait ZipCompat extends ZipApi:
       val header    = NodeBufferFactory.alloc(30)
       header.writeUInt32LE(LocalFileHeaderSig, 0)
       header.writeUInt16LE(VersionNeeded, 4)
-      header.writeUInt16LE(0, 6) // flags
+      header.writeUInt16LE(0x800, 6) // flags: UTF-8 filename encoding (bit 11)
       header.writeUInt16LE(method, 8)
       header.writeUInt16LE(dosTime, 10)
       header.writeUInt16LE(dosDate, 12)
@@ -162,7 +163,7 @@ trait ZipCompat extends ZipApi:
       cdEntry.writeUInt32LE(CentralDirSig, 0)
       cdEntry.writeUInt16LE(VersionNeeded, 4) // version made by
       cdEntry.writeUInt16LE(VersionNeeded, 6) // version needed
-      cdEntry.writeUInt16LE(0, 8)             // flags
+      cdEntry.writeUInt16LE(0x800, 8)         // flags: UTF-8 filename encoding (bit 11)
       cdEntry.writeUInt16LE(entry.method, 10)
       cdEntry.writeUInt16LE(entry.dosTime, 12)
       cdEntry.writeUInt16LE(entry.dosDate, 14)
@@ -231,9 +232,10 @@ trait ZipCompat extends ZipApi:
       val dataOffset    = localOffset + 30 + localNameLen + localExtraLen
 
       val entryPath       = NodePathModule.join(destination.path, name)
-      val normalizedDest  = NodePathModule.resolve(destination.path)
+      val normalizedDest  = NodePathModule.resolve(destination.path) + NodePathModule.sep
       val normalizedEntry = NodePathModule.resolve(entryPath)
-      // Guard against zip slip attack
+      // Guard against zip slip attack — append separator to prevent prefix false positives
+      // e.g. "/tmp/out-evil".startsWith("/tmp/out") would be a false positive
       if !normalizedEntry.startsWith(normalizedDest) then
         throw IOOperationException(s"Zip entry outside target directory: ${name}")
 
@@ -314,21 +316,22 @@ trait ZipCompat extends ZipApi:
       pos -= 1
     throw IOOperationException("Invalid zip archive: end of central directory not found")
 
-  private def collectFiles(sources: Seq[IOPath]): Seq[(String, String)] =
+  private def collectFiles(sources: Seq[IOPath], excludePath: String): Seq[(String, String)] =
     val files = scala.collection.mutable.ArrayBuffer[(String, String)]()
     for source <- sources do
       val path = source.path
       if NodeFSModule.statSync(path).isDirectory() then
         val baseName = NodePathModule.basename(path)
-        collectDirectory(files, path, baseName)
-      else
+        collectDirectory(files, path, baseName, excludePath)
+      else if NodePathModule.resolve(path) != excludePath then
         files += ((NodePathModule.basename(path), path))
     files.toSeq
 
   private def collectDirectory(
       files: scala.collection.mutable.ArrayBuffer[(String, String)],
       dirPath: String,
-      prefix: String
+      prefix: String,
+      excludePath: String
   ): Unit =
     files += ((s"${prefix}/", dirPath))
     val entries = NodeFSModule.readdirSync(dirPath, js.Dynamic.literal(withFileTypes = true))
@@ -337,8 +340,8 @@ trait ZipCompat extends ZipApi:
       val childPath = NodePathModule.join(dirPath, dirent.name)
       val childName = s"${prefix}/${dirent.name}"
       if dirent.isDirectory() then
-        collectDirectory(files, childPath, childName)
-      else
+        collectDirectory(files, childPath, childName, excludePath)
+      else if NodePathModule.resolve(childPath) != excludePath then
         files += ((childName, childPath))
 
   private def epochMillisToDosDateTime(millis: Double): (Int, Int) =

--- a/uni-core/.jvm/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.jvm/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import java.util.zip.ZipEntry as JZipEntry
+
+/**
+  * JVM implementation of zip archive operations using java.util.zip.
+  */
+trait ZipCompat extends ZipApi:
+  private val BufferSize = 8192
+
+  override def create(target: IOPath, sources: Seq[IOPath]): Unit =
+    val targetPath = Path.of(target.path)
+    val parent     = targetPath.getParent
+    if parent != null && !Files.exists(parent) then
+      Files.createDirectories(parent)
+
+    val fos = FileOutputStream(target.path)
+    val zos = ZipOutputStream(BufferedOutputStream(fos))
+    try sources.foreach { source =>
+        val sourcePath = Path.of(source.path)
+        if Files.isDirectory(sourcePath) then
+          addDirectory(zos, sourcePath, sourcePath.getFileName.toString)
+        else
+          addFile(zos, sourcePath, sourcePath.getFileName.toString)
+      }
+    finally zos.close()
+
+  override def extract(archive: IOPath, destination: IOPath): Unit =
+    val destPath = Path.of(destination.path)
+    if !Files.exists(destPath) then
+      Files.createDirectories(destPath)
+
+    val fis = FileInputStream(archive.path)
+    val zis = ZipInputStream(BufferedInputStream(fis))
+    try
+      var entry = zis.getNextEntry
+      while entry != null do
+        val entryPath = destPath.resolve(entry.getName)
+        // Guard against zip slip attack
+        if !entryPath.normalize().startsWith(destPath.normalize()) then
+          throw IOOperationException(s"Zip entry outside target directory: ${entry.getName}")
+        if entry.isDirectory then
+          Files.createDirectories(entryPath)
+        else
+          val parent = entryPath.getParent
+          if parent != null && !Files.exists(parent) then
+            Files.createDirectories(parent)
+          val fos    = FileOutputStream(entryPath.toFile)
+          val buffer = Array.ofDim[Byte](BufferSize)
+          try
+            var len = zis.read(buffer)
+            while len > 0 do
+              fos.write(buffer, 0, len)
+              len = zis.read(buffer)
+          finally
+            fos.close()
+        zis.closeEntry()
+        entry = zis.getNextEntry
+    finally
+      zis.close()
+
+  end extract
+
+  override def list(archive: IOPath): Seq[ZipEntry] =
+    val zipFile = ZipFile(archive.path)
+    try
+      val entries = scala.collection.mutable.ArrayBuffer[ZipEntry]()
+      val it      = zipFile.entries()
+      while it.hasMoreElements do
+        val entry = it.nextElement()
+        entries +=
+          ZipEntry(
+            name = entry.getName,
+            size = entry.getSize,
+            compressedSize = entry.getCompressedSize,
+            isDirectory = entry.isDirectory,
+            lastModified = entry.getTime
+          )
+      entries.toSeq
+    finally
+      zipFile.close()
+
+  private def addFile(zos: ZipOutputStream, file: Path, entryName: String): Unit =
+    val entry = JZipEntry(entryName)
+    entry.setTime(Files.getLastModifiedTime(file).toMillis)
+    zos.putNextEntry(entry)
+    val fis    = FileInputStream(file.toFile)
+    val buffer = Array.ofDim[Byte](BufferSize)
+    try
+      var len = fis.read(buffer)
+      while len > 0 do
+        zos.write(buffer, 0, len)
+        len = fis.read(buffer)
+    finally
+      fis.close()
+    zos.closeEntry()
+
+  private def addDirectory(zos: ZipOutputStream, dir: Path, prefix: String): Unit =
+    // Add directory entry
+    val dirEntry = JZipEntry(s"${prefix}/")
+    dirEntry.setTime(Files.getLastModifiedTime(dir).toMillis)
+    zos.putNextEntry(dirEntry)
+    zos.closeEntry()
+
+    // Add files and subdirectories
+    val stream = Files.list(dir)
+    try stream.forEach { child =>
+        val childName = s"${prefix}/${child.getFileName}"
+        if Files.isDirectory(child) then
+          addDirectory(zos, child, childName)
+        else
+          addFile(zos, child, childName)
+      }
+    finally stream.close()
+
+end ZipCompat

--- a/uni-core/.jvm/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.jvm/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -33,7 +33,7 @@ trait ZipCompat extends ZipApi:
   override def create(target: IOPath, sources: Seq[IOPath]): Unit =
     val targetPath = Path.of(target.path).toAbsolutePath.normalize()
     val parent     = targetPath.getParent
-    if parent != null && !Files.exists(parent) then
+    if parent != null then
       Files.createDirectories(parent)
 
     val fos = FileOutputStream(targetPath.toString)
@@ -49,11 +49,11 @@ trait ZipCompat extends ZipApi:
 
   override def extract(archive: IOPath, destination: IOPath): Unit =
     val destPath = Path.of(destination.path)
-    if !Files.exists(destPath) then
-      Files.createDirectories(destPath)
+    Files.createDirectories(destPath)
 
-    val fis = FileInputStream(archive.path)
-    val zis = ZipInputStream(BufferedInputStream(fis))
+    val fis    = FileInputStream(archive.path)
+    val zis    = ZipInputStream(BufferedInputStream(fis))
+    val buffer = Array.ofDim[Byte](BufferSize)
     try
       var entry = zis.getNextEntry
       while entry != null do
@@ -65,13 +65,12 @@ trait ZipCompat extends ZipApi:
           Files.createDirectories(entryPath)
         else
           val parent = entryPath.getParent
-          if parent != null && !Files.exists(parent) then
+          if parent != null then
             Files.createDirectories(parent)
-          val fos    = FileOutputStream(entryPath.toFile)
-          val buffer = Array.ofDim[Byte](BufferSize)
+          val fos = BufferedOutputStream(FileOutputStream(entryPath.toFile))
           try
             var len = zis.read(buffer)
-            while len > 0 do
+            while len >= 0 do
               fos.write(buffer, 0, len)
               len = zis.read(buffer)
           finally
@@ -108,22 +107,23 @@ trait ZipCompat extends ZipApi:
       entryName: String,
       excludePath: Path
   ): Unit =
-    // Skip the output archive itself to prevent self-referential zip
     if file.toAbsolutePath.normalize() == excludePath then
       return
     val entry = JZipEntry(entryName)
     entry.setTime(Files.getLastModifiedTime(file).toMillis)
     zos.putNextEntry(entry)
-    val fis    = FileInputStream(file.toFile)
-    val buffer = Array.ofDim[Byte](BufferSize)
     try
-      var len = fis.read(buffer)
-      while len > 0 do
-        zos.write(buffer, 0, len)
-        len = fis.read(buffer)
+      val fis    = BufferedInputStream(FileInputStream(file.toFile))
+      val buffer = Array.ofDim[Byte](BufferSize)
+      try
+        var len = fis.read(buffer)
+        while len >= 0 do
+          zos.write(buffer, 0, len)
+          len = fis.read(buffer)
+      finally
+        fis.close()
     finally
-      fis.close()
-    zos.closeEntry()
+      zos.closeEntry()
 
   private def addDirectory(
       zos: ZipOutputStream,
@@ -131,13 +131,11 @@ trait ZipCompat extends ZipApi:
       prefix: String,
       excludePath: Path
   ): Unit =
-    // Add directory entry
     val dirEntry = JZipEntry(s"${prefix}/")
     dirEntry.setTime(Files.getLastModifiedTime(dir).toMillis)
     zos.putNextEntry(dirEntry)
     zos.closeEntry()
 
-    // Add files and subdirectories
     val stream = Files.list(dir)
     try stream.forEach { child =>
         val childName = s"${prefix}/${child.getFileName}"

--- a/uni-core/.jvm/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.jvm/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -31,19 +31,19 @@ trait ZipCompat extends ZipApi:
   private val BufferSize = 8192
 
   override def create(target: IOPath, sources: Seq[IOPath]): Unit =
-    val targetPath = Path.of(target.path)
+    val targetPath = Path.of(target.path).toAbsolutePath.normalize()
     val parent     = targetPath.getParent
     if parent != null && !Files.exists(parent) then
       Files.createDirectories(parent)
 
-    val fos = FileOutputStream(target.path)
+    val fos = FileOutputStream(targetPath.toString)
     val zos = ZipOutputStream(BufferedOutputStream(fos))
     try sources.foreach { source =>
         val sourcePath = Path.of(source.path)
         if Files.isDirectory(sourcePath) then
-          addDirectory(zos, sourcePath, sourcePath.getFileName.toString)
+          addDirectory(zos, sourcePath, sourcePath.getFileName.toString, targetPath)
         else
-          addFile(zos, sourcePath, sourcePath.getFileName.toString)
+          addFile(zos, sourcePath, sourcePath.getFileName.toString, targetPath)
       }
     finally zos.close()
 
@@ -102,7 +102,15 @@ trait ZipCompat extends ZipApi:
     finally
       zipFile.close()
 
-  private def addFile(zos: ZipOutputStream, file: Path, entryName: String): Unit =
+  private def addFile(
+      zos: ZipOutputStream,
+      file: Path,
+      entryName: String,
+      excludePath: Path
+  ): Unit =
+    // Skip the output archive itself to prevent self-referential zip
+    if file.toAbsolutePath.normalize() == excludePath then
+      return
     val entry = JZipEntry(entryName)
     entry.setTime(Files.getLastModifiedTime(file).toMillis)
     zos.putNextEntry(entry)
@@ -117,7 +125,12 @@ trait ZipCompat extends ZipApi:
       fis.close()
     zos.closeEntry()
 
-  private def addDirectory(zos: ZipOutputStream, dir: Path, prefix: String): Unit =
+  private def addDirectory(
+      zos: ZipOutputStream,
+      dir: Path,
+      prefix: String,
+      excludePath: Path
+  ): Unit =
     // Add directory entry
     val dirEntry = JZipEntry(s"${prefix}/")
     dirEntry.setTime(Files.getLastModifiedTime(dir).toMillis)
@@ -129,9 +142,9 @@ trait ZipCompat extends ZipApi:
     try stream.forEach { child =>
         val childName = s"${prefix}/${child.getFileName}"
         if Files.isDirectory(child) then
-          addDirectory(zos, child, childName)
+          addDirectory(zos, child, childName, excludePath)
         else
-          addFile(zos, child, childName)
+          addFile(zos, child, childName, excludePath)
       }
     finally stream.close()
 

--- a/uni-core/.native/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.native/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -34,7 +34,7 @@ trait ZipCompat extends ZipApi:
   override def create(target: IOPath, sources: Seq[IOPath]): Unit =
     val targetPath = Path.of(target.path).toAbsolutePath.normalize()
     val parent     = targetPath.getParent
-    if parent != null && !Files.exists(parent) then
+    if parent != null then
       Files.createDirectories(parent)
 
     val fos = FileOutputStream(targetPath.toString)
@@ -50,11 +50,11 @@ trait ZipCompat extends ZipApi:
 
   override def extract(archive: IOPath, destination: IOPath): Unit =
     val destPath = Path.of(destination.path)
-    if !Files.exists(destPath) then
-      Files.createDirectories(destPath)
+    Files.createDirectories(destPath)
 
-    val fis = FileInputStream(archive.path)
-    val zis = ZipInputStream(BufferedInputStream(fis))
+    val fis    = FileInputStream(archive.path)
+    val zis    = ZipInputStream(BufferedInputStream(fis))
+    val buffer = Array.ofDim[Byte](BufferSize)
     try
       var entry = zis.getNextEntry
       while entry != null do
@@ -66,13 +66,12 @@ trait ZipCompat extends ZipApi:
           Files.createDirectories(entryPath)
         else
           val parent = entryPath.getParent
-          if parent != null && !Files.exists(parent) then
+          if parent != null then
             Files.createDirectories(parent)
-          val fos    = FileOutputStream(entryPath.toFile)
-          val buffer = Array.ofDim[Byte](BufferSize)
+          val fos = BufferedOutputStream(FileOutputStream(entryPath.toFile))
           try
             var len = zis.read(buffer)
-            while len > 0 do
+            while len >= 0 do
               fos.write(buffer, 0, len)
               len = zis.read(buffer)
           finally
@@ -115,22 +114,23 @@ trait ZipCompat extends ZipApi:
       entryName: String,
       excludePath: Path
   ): Unit =
-    // Skip the output archive itself to prevent self-referential zip
     if file.toAbsolutePath.normalize() == excludePath then
       return
     val entry = JZipEntry(entryName)
     entry.setTime(Files.getLastModifiedTime(file).toMillis)
     zos.putNextEntry(entry)
-    val fis    = FileInputStream(file.toFile)
-    val buffer = Array.ofDim[Byte](BufferSize)
     try
-      var len = fis.read(buffer)
-      while len > 0 do
-        zos.write(buffer, 0, len)
-        len = fis.read(buffer)
+      val fis    = BufferedInputStream(FileInputStream(file.toFile))
+      val buffer = Array.ofDim[Byte](BufferSize)
+      try
+        var len = fis.read(buffer)
+        while len >= 0 do
+          zos.write(buffer, 0, len)
+          len = fis.read(buffer)
+      finally
+        fis.close()
     finally
-      fis.close()
-    zos.closeEntry()
+      zos.closeEntry()
 
   private def addDirectory(
       zos: ZipOutputStream,
@@ -138,13 +138,11 @@ trait ZipCompat extends ZipApi:
       prefix: String,
       excludePath: Path
   ): Unit =
-    // Add directory entry
     val dirEntry = JZipEntry(s"${prefix}/")
     dirEntry.setTime(Files.getLastModifiedTime(dir).toMillis)
     zos.putNextEntry(dirEntry)
     zos.closeEntry()
 
-    // Add files and subdirectories
     val stream = Files.list(dir)
     try stream.forEach { child =>
         val childName = s"${prefix}/${child.getFileName}"

--- a/uni-core/.native/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.native/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipFile
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import java.util.zip.ZipEntry as JZipEntry
+
+/**
+  * Scala Native implementation of zip archive operations using java.util.zip. Requires linking to
+  * zlib (-lz).
+  */
+trait ZipCompat extends ZipApi:
+  private val BufferSize = 8192
+
+  override def create(target: IOPath, sources: Seq[IOPath]): Unit =
+    val targetPath = Path.of(target.path)
+    val parent     = targetPath.getParent
+    if parent != null && !Files.exists(parent) then
+      Files.createDirectories(parent)
+
+    val fos = FileOutputStream(target.path)
+    val zos = ZipOutputStream(BufferedOutputStream(fos))
+    try sources.foreach { source =>
+        val sourcePath = Path.of(source.path)
+        if Files.isDirectory(sourcePath) then
+          addDirectory(zos, sourcePath, sourcePath.getFileName.toString)
+        else
+          addFile(zos, sourcePath, sourcePath.getFileName.toString)
+      }
+    finally zos.close()
+
+  override def extract(archive: IOPath, destination: IOPath): Unit =
+    val destPath = Path.of(destination.path)
+    if !Files.exists(destPath) then
+      Files.createDirectories(destPath)
+
+    val fis = FileInputStream(archive.path)
+    val zis = ZipInputStream(BufferedInputStream(fis))
+    try
+      var entry = zis.getNextEntry
+      while entry != null do
+        val entryPath = destPath.resolve(entry.getName)
+        // Guard against zip slip attack
+        if !entryPath.normalize().startsWith(destPath.normalize()) then
+          throw IOOperationException(s"Zip entry outside target directory: ${entry.getName}")
+        if entry.isDirectory then
+          Files.createDirectories(entryPath)
+        else
+          val parent = entryPath.getParent
+          if parent != null && !Files.exists(parent) then
+            Files.createDirectories(parent)
+          val fos    = FileOutputStream(entryPath.toFile)
+          val buffer = Array.ofDim[Byte](BufferSize)
+          try
+            var len = zis.read(buffer)
+            while len > 0 do
+              fos.write(buffer, 0, len)
+              len = zis.read(buffer)
+          finally
+            fos.close()
+        zis.closeEntry()
+        entry = zis.getNextEntry
+    finally
+      zis.close()
+
+  end extract
+
+  override def list(archive: IOPath): Seq[ZipEntry] =
+    val zipFile =
+      try
+        ZipFile(archive.path)
+      catch
+        // Scala Native's ZipFile throws ZipException for archives with no entries
+        case _: java.util.zip.ZipException =>
+          return Seq.empty
+    try
+      val entries = scala.collection.mutable.ArrayBuffer[ZipEntry]()
+      val it      = zipFile.entries()
+      while it.hasMoreElements do
+        val entry = it.nextElement()
+        entries +=
+          ZipEntry(
+            name = entry.getName,
+            size = entry.getSize,
+            compressedSize = entry.getCompressedSize,
+            isDirectory = entry.isDirectory,
+            lastModified = entry.getTime
+          )
+      entries.toSeq
+    finally
+      zipFile.close()
+
+  private def addFile(zos: ZipOutputStream, file: Path, entryName: String): Unit =
+    val entry = JZipEntry(entryName)
+    entry.setTime(Files.getLastModifiedTime(file).toMillis)
+    zos.putNextEntry(entry)
+    val fis    = FileInputStream(file.toFile)
+    val buffer = Array.ofDim[Byte](BufferSize)
+    try
+      var len = fis.read(buffer)
+      while len > 0 do
+        zos.write(buffer, 0, len)
+        len = fis.read(buffer)
+    finally
+      fis.close()
+    zos.closeEntry()
+
+  private def addDirectory(zos: ZipOutputStream, dir: Path, prefix: String): Unit =
+    // Add directory entry
+    val dirEntry = JZipEntry(s"${prefix}/")
+    dirEntry.setTime(Files.getLastModifiedTime(dir).toMillis)
+    zos.putNextEntry(dirEntry)
+    zos.closeEntry()
+
+    // Add files and subdirectories
+    val stream = Files.list(dir)
+    try stream.forEach { child =>
+        val childName = s"${prefix}/${child.getFileName}"
+        if Files.isDirectory(child) then
+          addDirectory(zos, child, childName)
+        else
+          addFile(zos, child, childName)
+      }
+    finally stream.close()
+
+end ZipCompat

--- a/uni-core/.native/src/main/scala/wvlet/uni/io/ZipImpl.scala
+++ b/uni-core/.native/src/main/scala/wvlet/uni/io/ZipImpl.scala
@@ -32,19 +32,19 @@ trait ZipCompat extends ZipApi:
   private val BufferSize = 8192
 
   override def create(target: IOPath, sources: Seq[IOPath]): Unit =
-    val targetPath = Path.of(target.path)
+    val targetPath = Path.of(target.path).toAbsolutePath.normalize()
     val parent     = targetPath.getParent
     if parent != null && !Files.exists(parent) then
       Files.createDirectories(parent)
 
-    val fos = FileOutputStream(target.path)
+    val fos = FileOutputStream(targetPath.toString)
     val zos = ZipOutputStream(BufferedOutputStream(fos))
     try sources.foreach { source =>
         val sourcePath = Path.of(source.path)
         if Files.isDirectory(sourcePath) then
-          addDirectory(zos, sourcePath, sourcePath.getFileName.toString)
+          addDirectory(zos, sourcePath, sourcePath.getFileName.toString, targetPath)
         else
-          addFile(zos, sourcePath, sourcePath.getFileName.toString)
+          addFile(zos, sourcePath, sourcePath.getFileName.toString, targetPath)
       }
     finally zos.close()
 
@@ -109,7 +109,15 @@ trait ZipCompat extends ZipApi:
     finally
       zipFile.close()
 
-  private def addFile(zos: ZipOutputStream, file: Path, entryName: String): Unit =
+  private def addFile(
+      zos: ZipOutputStream,
+      file: Path,
+      entryName: String,
+      excludePath: Path
+  ): Unit =
+    // Skip the output archive itself to prevent self-referential zip
+    if file.toAbsolutePath.normalize() == excludePath then
+      return
     val entry = JZipEntry(entryName)
     entry.setTime(Files.getLastModifiedTime(file).toMillis)
     zos.putNextEntry(entry)
@@ -124,7 +132,12 @@ trait ZipCompat extends ZipApi:
       fis.close()
     zos.closeEntry()
 
-  private def addDirectory(zos: ZipOutputStream, dir: Path, prefix: String): Unit =
+  private def addDirectory(
+      zos: ZipOutputStream,
+      dir: Path,
+      prefix: String,
+      excludePath: Path
+  ): Unit =
     // Add directory entry
     val dirEntry = JZipEntry(s"${prefix}/")
     dirEntry.setTime(Files.getLastModifiedTime(dir).toMillis)
@@ -136,9 +149,9 @@ trait ZipCompat extends ZipApi:
     try stream.forEach { child =>
         val childName = s"${prefix}/${child.getFileName}"
         if Files.isDirectory(child) then
-          addDirectory(zos, child, childName)
+          addDirectory(zos, child, childName, excludePath)
         else
-          addFile(zos, child, childName)
+          addFile(zos, child, childName, excludePath)
       }
     finally stream.close()
 

--- a/uni-core/src/main/scala/wvlet/uni/io/Zip.scala
+++ b/uni-core/src/main/scala/wvlet/uni/io/Zip.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+/**
+  * Metadata for a single entry in a zip archive.
+  *
+  * @param name
+  *   The entry name (path within the archive, using forward slashes)
+  * @param size
+  *   The uncompressed size in bytes
+  * @param compressedSize
+  *   The compressed size in bytes
+  * @param isDirectory
+  *   Whether this entry represents a directory
+  * @param lastModified
+  *   The last modification time in epoch milliseconds
+  */
+case class ZipEntry(
+    name: String,
+    size: Long,
+    compressedSize: Long,
+    isDirectory: Boolean,
+    lastModified: Long
+)
+
+/**
+  * Cross-platform zip archive utilities.
+  *
+  * Platform implementations:
+  *   - JVM: Uses java.util.zip (ZipOutputStream, ZipInputStream, ZipFile)
+  *   - Scala.js (Node.js): Uses Node's zlib module with manual ZIP format handling
+  *   - Scala Native: Uses java.util.zip (requires linking to zlib)
+  */
+object Zip extends ZipCompat
+
+/**
+  * Base trait for zip operations. Platform-specific implementations extend this trait.
+  */
+trait ZipApi:
+  /**
+    * Creates a zip archive from the given source files and directories.
+    *
+    * If a source is a directory, all files within it are added recursively. Entry names use forward
+    * slashes and are relative to each source's parent directory.
+    *
+    * @param target
+    *   The target zip file path
+    * @param sources
+    *   The source files and directories to include
+    */
+  def create(target: IOPath, sources: Seq[IOPath]): Unit
+
+  /**
+    * Extracts all entries from a zip archive to the given destination directory.
+    *
+    * Intermediate directories are created as needed.
+    *
+    * @param archive
+    *   The zip archive file path
+    * @param destination
+    *   The destination directory
+    */
+  def extract(archive: IOPath, destination: IOPath): Unit
+
+  /**
+    * Lists all entries in a zip archive without extracting.
+    *
+    * @param archive
+    *   The zip archive file path
+    * @return
+    *   The list of zip entries
+    */
+  def list(archive: IOPath): Seq[ZipEntry]
+
+end ZipApi
+
+/**
+  * CRC32 checksum implementation using the standard polynomial. Used by the Scala.js ZIP
+  * implementation which cannot rely on java.util.zip.CRC32.
+  */
+object CRC32:
+  private val Polynomial = 0xedb88320
+
+  private val Table: Array[Int] =
+    val t = Array.ofDim[Int](256)
+    var i = 0
+    while i < 256 do
+      var crc = i
+      var j   = 0
+      while j < 8 do
+        if (crc & 1) != 0 then
+          crc = (crc >>> 1) ^ Polynomial
+        else
+          crc = crc >>> 1
+        j += 1
+      t(i) = crc
+      i += 1
+    t
+
+  def compute(data: Array[Byte]): Int = compute(data, 0, data.length)
+
+  def compute(data: Array[Byte], offset: Int, length: Int): Int =
+    var crc = 0xffffffff
+    var i   = offset
+    val end = offset + length
+    while i < end do
+      crc = (crc >>> 8) ^ Table((crc ^ (data(i) & 0xff)) & 0xff)
+      i += 1
+    crc ^ 0xffffffff
+
+end CRC32

--- a/uni/src/test/scala/wvlet/uni/io/ZipTest.scala
+++ b/uni/src/test/scala/wvlet/uni/io/ZipTest.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.io
+
+import wvlet.uni.test.UniTest
+
+class ZipTest extends UniTest:
+  FileSystemInit.init()
+  private lazy val tempDir = FileSystem.createTempDirectory("zip-test")
+
+  test("create and extract single file") {
+    val sourceDir = tempDir / "single-src"
+    FileSystem.createDirectory(sourceDir)
+    FileSystem.writeString(sourceDir / "hello.txt", "Hello, World!")
+
+    val archivePath = tempDir / "single.zip"
+    Zip.create(archivePath, Seq(sourceDir / "hello.txt"))
+    FileSystem.exists(archivePath) shouldBe true
+
+    val extractDir = tempDir / "single-out"
+    Zip.extract(archivePath, extractDir)
+    FileSystem.readString(extractDir / "hello.txt") shouldBe "Hello, World!"
+  }
+
+  test("create and extract multiple files") {
+    val sourceDir = tempDir / "multi-src"
+    FileSystem.createDirectory(sourceDir)
+    FileSystem.writeString(sourceDir / "a.txt", "File A content")
+    FileSystem.writeString(sourceDir / "b.txt", "File B content")
+
+    val archivePath = tempDir / "multi.zip"
+    Zip.create(archivePath, Seq(sourceDir / "a.txt", sourceDir / "b.txt"))
+
+    val extractDir = tempDir / "multi-out"
+    Zip.extract(archivePath, extractDir)
+    FileSystem.readString(extractDir / "a.txt") shouldBe "File A content"
+    FileSystem.readString(extractDir / "b.txt") shouldBe "File B content"
+  }
+
+  test("create and extract nested directories") {
+    val sourceDir = tempDir / "nested-src"
+    FileSystem.createDirectory(sourceDir / "subdir")
+    FileSystem.writeString(sourceDir / "root.txt", "Root file")
+    FileSystem.writeString(sourceDir / "subdir" / "nested.txt", "Nested file")
+
+    val archivePath = tempDir / "nested.zip"
+    Zip.create(archivePath, Seq(sourceDir))
+
+    val extractDir = tempDir / "nested-out"
+    Zip.extract(archivePath, extractDir)
+    FileSystem.readString(extractDir / "nested-src" / "root.txt") shouldBe "Root file"
+    FileSystem.readString(extractDir / "nested-src" / "subdir" / "nested.txt") shouldBe
+      "Nested file"
+  }
+
+  test("list entries") {
+    val sourceDir = tempDir / "list-src"
+    FileSystem.createDirectory(sourceDir / "sub")
+    FileSystem.writeString(sourceDir / "file.txt", "content")
+    FileSystem.writeString(sourceDir / "sub" / "nested.txt", "nested content")
+
+    val archivePath = tempDir / "list.zip"
+    Zip.create(archivePath, Seq(sourceDir))
+
+    val entries = Zip.list(archivePath)
+    val names   = entries.map(_.name).toSet
+    names shouldContain "list-src/"
+    names shouldContain "list-src/file.txt"
+    names shouldContain "list-src/sub/"
+    names shouldContain "list-src/sub/nested.txt"
+
+    val fileEntry = entries.find(_.name == "list-src/file.txt").get
+    fileEntry.isDirectory shouldBe false
+    fileEntry.size shouldBe 7L // "content".length
+
+    val dirEntry = entries.find(_.name == "list-src/").get
+    dirEntry.isDirectory shouldBe true
+  }
+
+  test("handle empty archive") {
+    val archivePath = tempDir / "empty.zip"
+    Zip.create(archivePath, Seq.empty)
+    FileSystem.exists(archivePath) shouldBe true
+
+    val entries = Zip.list(archivePath)
+    entries.isEmpty shouldBe true
+
+    val extractDir = tempDir / "empty-out"
+    Zip.extract(archivePath, extractDir)
+    FileSystem.exists(extractDir) shouldBe true
+  }
+
+  test("round-trip preserves file content") {
+    val sourceDir = tempDir / "roundtrip-src"
+    FileSystem.createDirectory(sourceDir)
+
+    // Test various content types
+    FileSystem.writeString(sourceDir / "text.txt", "Hello\nWorld\n")
+    FileSystem.writeBytes(sourceDir / "binary.bin", Array[Byte](0, 1, 2, 127, -128, -1))
+    FileSystem.writeString(sourceDir / "large.txt", "A" * 10000)
+
+    val archivePath = tempDir / "roundtrip.zip"
+    Zip.create(
+      archivePath,
+      Seq(sourceDir / "text.txt", sourceDir / "binary.bin", sourceDir / "large.txt")
+    )
+
+    val extractDir = tempDir / "roundtrip-out"
+    Zip.extract(archivePath, extractDir)
+
+    FileSystem.readString(extractDir / "text.txt") shouldBe "Hello\nWorld\n"
+    FileSystem.readBytes(extractDir / "binary.bin") shouldBe Array[Byte](0, 1, 2, 127, -128, -1)
+    FileSystem.readString(extractDir / "large.txt") shouldBe ("A" * 10000)
+  }
+
+end ZipTest

--- a/uni/src/test/scala/wvlet/uni/io/ZipTest.scala
+++ b/uni/src/test/scala/wvlet/uni/io/ZipTest.scala
@@ -101,6 +101,23 @@ class ZipTest extends UniTest:
     FileSystem.exists(extractDir) shouldBe true
   }
 
+  test("handle empty file content") {
+    val sourceDir = tempDir / "emptyfile-src"
+    FileSystem.createDirectory(sourceDir)
+    FileSystem.writeBytes(sourceDir / "empty.txt", Array.emptyByteArray)
+
+    val archivePath = tempDir / "emptyfile.zip"
+    Zip.create(archivePath, Seq(sourceDir / "empty.txt"))
+
+    val entries = Zip.list(archivePath)
+    val entry   = entries.find(_.name == "empty.txt").get
+    entry.size shouldBe 0L
+
+    val extractDir = tempDir / "emptyfile-out"
+    Zip.extract(archivePath, extractDir)
+    FileSystem.readBytes(extractDir / "empty.txt") shouldBe Array.emptyByteArray
+  }
+
   test("round-trip preserves file content") {
     val sourceDir = tempDir / "roundtrip-src"
     FileSystem.createDirectory(sourceDir)


### PR DESCRIPTION
## Summary

- Add cross-platform `Zip.create`, `Zip.extract`, and `Zip.list` operations for zip archive handling
- JVM and Scala Native implementations use `java.util.zip` (ZipOutputStream, ZipInputStream, ZipFile)
- Scala.js (Node.js) implementation handles the ZIP binary format directly using Node's `zlib` module for raw deflate/inflate, with no external dependencies
- Includes `ZipEntry` metadata class (name, size, compressedSize, isDirectory, lastModified) and `CRC32` checksum utility
- All implementations include zip slip attack prevention

## API

```scala
Zip.create(target: IOPath, sources: Seq[IOPath])   // Create archive from files/directories
Zip.extract(archive: IOPath, destination: IOPath)   // Extract all entries
Zip.list(archive: IOPath): Seq[ZipEntry]            // List entries without extracting
```

## Test plan

- [x] JVM: 6 tests pass (single file, multiple files, nested dirs, list entries, empty archive, round-trip)
- [x] Scala.js (Node.js): 6 tests pass
- [x] Scala Native: 6 tests pass
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)