### PR TITLE
chore: Ignore .claude/settings.local.json and include plan drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ target
 metals.sbt
 
 .claude/settings.local.json
-plans/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ target
 .metals
 .vscode
 metals.sbt
+
+.claude/settings.local.json
+plans/

--- a/plans/magical-napping-sky.md
+++ b/plans/magical-napping-sky.md
@@ -1,0 +1,83 @@
+# Plan: Add Filesystem Watcher to wvlet.uni.io
+
+## Context
+
+The `wvlet.uni.io` package provides cross-platform file system operations (JVM, Scala.js, Scala Native). It currently lacks a file-watching capability — the `os.watch` equivalent from os-lib. This feature enables detecting file creation, modification, and deletion events in a directory, which is essential for dev tools, build systems, and reactive file processing.
+
+## API Design
+
+New standalone file `IOWatch.scala` in the shared source directory. Follows existing patterns: enum for event types, options case class with builder methods, `AutoCloseable` for resource cleanup, object-level factory.
+
+```scala
+// Shared API
+enum WatchEventType:
+  case Created, Modified, Deleted, Overflow
+
+case class WatchEvent(eventType: WatchEventType, path: IOPath)
+
+case class WatchOptions(
+    recursive: Boolean = false,
+    pollingIntervalMs: Long = 500
+):
+  def withRecursive(value: Boolean): WatchOptions = ...
+  def withPollingIntervalMs(ms: Long): WatchOptions = ...
+
+trait IOWatcher extends AutoCloseable:
+  def close(): Unit
+
+// Platform-delegating factory
+object IOWatch:
+  def watch(path: IOPath, options: WatchOptions = WatchOptions.default)(
+      handler: WatchEvent => Unit
+  ): IOWatcher
+```
+
+## Files to Create/Modify
+
+### New shared file
+- `uni-core/src/main/scala/wvlet/uni/io/IOWatch.scala` — `WatchEventType`, `WatchEvent`, `WatchOptions`, `IOWatcher` trait, `IOWatch` object (delegates to platform impl)
+
+### Platform implementations
+- `uni-core/.jvm/src/main/scala/wvlet/uni/io/IOWatchImpl.scala` — JVM impl using `java.nio.file.WatchService`, daemon thread for polling
+- `uni-core/.js/src/main/scala/wvlet/uni/io/IOWatchImpl.scala` — Node.js impl using `fs.watch`; browser throws `UnsupportedOperationException`
+- `uni-core/.native/src/main/scala/wvlet/uni/io/IOWatchImpl.scala` — Polling-based impl: periodically scan directory, compare modification times
+
+### Tests
+- `uni/src/test/scala/wvlet/uni/io/IOWatchTest.scala` — Cross-platform tests (create/modify/delete detection)
+- `uni/.jvm/src/test/scala/wvlet/uni/io/IOWatchTest.scala` — JVM-specific tests if needed
+
+### Facade export
+- `uni-core/src/main/scala/wvlet/uni/io/IO.scala` — Add `IOWatch.watch` to the `IO` object exports
+
+## Platform Implementation Details
+
+### JVM (`java.nio.file.WatchService`)
+- Create `WatchService` from `FileSystems.getDefault.newWatchService()`
+- Register directory for `ENTRY_CREATE`, `ENTRY_MODIFY`, `ENTRY_DELETE` events
+- For recursive: walk directory tree with `Files.walkFileTree`, register each subdir; also register newly created directories
+- Daemon thread polls `watchService.poll(pollingIntervalMs)` in a loop
+- `close()` stops the thread and closes the watch service
+
+### Node.js (`fs.watch`)
+- Use `NodeFSModule.watch(path, options)` which returns an `FSWatcher`
+- `recursive` option is natively supported on macOS/Windows
+- Convert `rename`/`change` events to Created/Modified/Deleted by checking file existence
+- `close()` calls `watcher.close()`
+- Browser: throw `UnsupportedOperationException`
+
+### Scala Native (polling)
+- Background thread periodically scans directory tree
+- Maintain `Map[IOPath, Long]` of last-modified timestamps
+- Compare snapshots to detect create/modify/delete
+- For recursive: include subdirectories in scan
+- `close()` stops the polling thread
+
+## Verification
+
+```bash
+./sbt "uniJVM/testOnly *IOWatchTest"     # JVM tests
+./sbt "uniJS/testOnly *IOWatchTest"      # JS tests
+./sbt "uniNative/testOnly *IOWatchTest"  # Native tests
+./sbt scalafmtAll                        # Format check
+./sbt compile                            # Full compile
+```

--- a/plans/shimmying-cooking-torvalds.md
+++ b/plans/shimmying-cooking-torvalds.md
@@ -1,0 +1,67 @@
+# JSONC Support for uni JSON Parser
+
+## Context
+
+Add JSONC (JSON with Comments) support per [jsonc.org](https://jsonc.org/). JSONC extends JSON with `//` line comments, `/* */` block comments, and trailing commas. Comments are attached as mutable metadata on nearby `JSONValue` nodes for round-tripping. Following the pattern of Jackson and Microsoft's jsonc-parser, comments are enabled directly in the existing `JSON.parse` — no separate entry point.
+
+## Design
+
+### Comment attachment rules
+
+1. **New-line comments** → `leadingComments` on the **next** value node
+2. **Inline (same-line) comments** → `trailingComment` on the **previous** value node
+3. **End-of-container with no next sibling** → trailing on the last element
+
+### JSONComment
+
+```scala
+case class JSONComment(text: String):
+  def commentBody: String      // Strip delimiters: "// x" → "x", "/* x */" → "x"
+  def isLineComment: Boolean   // starts with //
+  def isBlockComment: Boolean  // starts with /*
+```
+
+### Mutable comment fields on JSONValue
+
+```scala
+sealed trait JSONValue:
+  def toJSON: String           // Valid JSON (no comments)
+  def toJSONC: String          // JSONC with comments from mutable fields
+  var leadingComments: Seq[JSONComment] = Nil
+  var trailingComment: Option[JSONComment] = None
+```
+
+**JSONNull**: Change from `case object` to `case class JSONNull()`.
+
+### Scanner changes
+
+- Scanner always handles `//` and `/* */` comments (no mode flag)
+- Reports comments to handler via callback
+- Supports trailing commas in objects and arrays
+
+### API (no new entry point)
+
+- `JSON.parse(s)` → accepts JSONC, preserves comments on nodes
+- `v.toJSON` → compact valid JSON (no comments)
+- `v.toJSONC` → compact JSONC with comments
+- `JSON.format(v)` → pretty-printed JSONC (includes comments when present)
+
+### Files
+
+| File | Change |
+|---|---|
+| `uni/.../json/JSON.scala` | Add `JSONComment`, mutable comment vars, `JSONNull` → case class, update `format` to output comments |
+| `uni/.../json/JSONScanner.scala` | Comment scanning, trailing commas, comment callback |
+| `uni/.../json/JSONValueBuilder.scala` | Capture comments, attach to nodes, use `JSONNull()` |
+| `uni/.../json/JSONEventHandler.scala` | Add comment callback to handler trait |
+| `uni/.../json/JSONTraverser.scala` | Update `case JSONNull` pattern |
+| `uni/.../json/package.scala` | Update `JSONNull` usage |
+| `uni/.../json/YAMLFormatter.scala` | Use `JSONNull()` |
+| `uni/.../weaver/codec/JSONWeaver.scala` | Use `JSONNull()` |
+| `uni/src/test/.../json/JSONCTest.scala` (new) | 18 comprehensive tests |
+
+### Design Learnings
+
+1. **Scala `self =>` in anonymous inner classes**: `private` methods resolve to the outer instance, not inner. Use `protected` for methods shared with inner builders.
+2. **`markValueLine()` placement**: Moved into scan methods (not `scanString` since it's used for keys and values).
+3. **Orphaned comments**: Merge multiple end-of-container comments and merge with existing trailing comments.

--- a/plans/ticklish-skipping-dream.md
+++ b/plans/ticklish-skipping-dream.md
@@ -1,0 +1,124 @@
+# Plan: Add Zip Archive Support to wvlet.uni.io
+
+## Context
+
+The uni IO module already has cross-platform Gzip compression (`Gzip.scala` + platform `GzipCompat` traits). Zip archive support (create/extract/list) is needed to complete the compression story. This follows the exact same cross-platform pattern as Gzip.
+
+## API Design
+
+```scala
+// Shared: uni-core/src/main/scala/wvlet/uni/io/Zip.scala
+case class ZipEntry(
+  name: String,
+  size: Long,
+  compressedSize: Long,
+  isDirectory: Boolean,
+  lastModified: Long  // epoch millis
+)
+
+trait ZipApi:
+  def create(target: IOPath, sources: Seq[IOPath]): Unit
+  def extract(archive: IOPath, destination: IOPath): Unit
+  def list(archive: IOPath): Seq[ZipEntry]
+
+object Zip extends ZipCompat
+```
+
+## Platform Implementations
+
+### JVM (`uni-core/.jvm/src/main/scala/wvlet/uni/io/ZipImpl.scala`)
+- Use `java.util.zip.ZipOutputStream` for create
+- Use `java.util.zip.ZipInputStream` for extract
+- Use `java.util.zip.ZipFile` for list (efficient — reads central directory)
+- Handles nested directories, preserves relative paths
+
+### Native (`uni-core/.native/src/main/scala/wvlet/uni/io/ZipImpl.scala`)
+- Same code as JVM — Scala Native supports `java.util.zip.*` when linked with `-lz`
+- The existing Native GzipImpl already uses `java.util.zip.GZIP*` classes successfully
+
+### JS/Node.js (`uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala`)
+- Implement ZIP format handling using Node.js `zlib` (deflateRawSync/inflateRawSync) + `Buffer` for binary data
+- Implement CRC32 in pure Scala (shared or JS-local utility, ~20 lines)
+- ZIP format structures: local file headers, central directory, EOCD — straightforward binary format
+- Browser: throw `UnsupportedOperationException` (same pattern as Gzip)
+
+### Key Node.js facades needed:
+- `zlib.deflateRawSync(buffer)` / `zlib.inflateRawSync(buffer)` — already partially in GzipImpl
+- `Buffer` — for binary data construction/parsing (read/write UInt32LE, UInt16LE, etc.)
+
+## Files to Create/Modify
+
+### New Files
+1. `uni-core/src/main/scala/wvlet/uni/io/Zip.scala` — shared API trait + ZipEntry + CRC32 utility
+2. `uni-core/.jvm/src/main/scala/wvlet/uni/io/ZipImpl.scala` — JVM ZipCompat
+3. `uni-core/.native/src/main/scala/wvlet/uni/io/ZipImpl.scala` — Native ZipCompat (same as JVM)
+4. `uni-core/.js/src/main/scala/wvlet/uni/io/ZipImpl.scala` — JS ZipCompat (Node.js zlib-based)
+5. `uni/src/test/scala/wvlet/uni/io/ZipTest.scala` — cross-platform tests
+
+### Reference Files (patterns to follow)
+- `uni-core/src/main/scala/wvlet/uni/io/Gzip.scala` — API trait pattern
+- `uni-core/.jvm/src/main/scala/wvlet/uni/io/GzipImpl.scala` — JVM impl pattern
+- `uni-core/.js/src/main/scala/wvlet/uni/io/GzipImpl.scala` — JS impl + browser detection
+- `uni-core/.native/src/main/scala/wvlet/uni/io/GzipImpl.scala` — Native impl pattern
+- `uni/src/test/scala/wvlet/uni/io/GzipTest.scala` — test pattern
+
+## Implementation Details
+
+### create(target, sources)
+- Walk each source: if file, add as entry; if directory, recursively add all files
+- Entry names use relative POSIX paths (forward slashes)
+- Create parent directories of target if needed
+
+### extract(archive, destination)
+- Read each entry from the archive
+- Create intermediate directories as needed
+- Write file contents to destination/entryName
+- Skip directory entries (just create directories)
+
+### list(archive)
+- Return all entries with metadata (name, size, compressedSize, isDirectory, lastModified)
+- JVM: use ZipFile for efficient central directory reading
+- JS: parse the ZIP end-of-central-directory and central directory records
+
+### CRC32 (for JS implementation)
+- Pure Scala CRC32 implementation using standard polynomial (0xEDB88320)
+- Needed for ZIP local file headers and central directory entries
+- ~20 lines using lookup table
+
+## Tests
+
+```scala
+class ZipTest extends UniTest:
+  FileSystemInit.init()
+  private lazy val tempDir = FileSystem.createTempDirectory("zip-test")
+
+  test("create and extract files") { ... }
+  test("create and extract nested directories") { ... }
+  test("list entries") { ... }
+  test("handle empty archive") { ... }
+  test("round-trip preserves file content") { ... }
+```
+
+## Verification
+
+1. `./sbt coreJVM/compile coreJS/compile coreNative/compile` — all platforms compile
+2. `./sbt "uniJVM/testOnly *ZipTest"` — JVM tests pass
+3. `./sbt "uniJS/testOnly *ZipTest"` — JS/Node.js tests pass
+4. `./sbt "uniNative/testOnly *ZipTest"` — Native tests pass
+5. `./sbt scalafmtAll` — formatting
+
+## Implementation Notes
+
+### Scala Native Quirks
+- `ZipFile` throws `ZipException` for empty archives (unlike JVM). Used try-catch to return `Seq.empty`.
+- `ZipInputStream.getNextEntry` returns `-1` for size/compressedSize when reading sequentially. Must use `ZipFile` for accurate metadata.
+
+### JS Implementation
+- `js.Date(millis)` resolves to companion object `apply(): String`, not constructor. Must use `new js.Date(millis)`.
+- `js.Date` constructor takes `Int` parameters, not `Double`.
+- Zip slip protection needs `path + separator` for string prefix checks to avoid false positives (e.g., `/tmp/out-evil` vs `/tmp/out`).
+- ZIP format requires UTF-8 flag (bit 11 = 0x800) in general purpose bit flags for non-ASCII filename interoperability.
+- Keep compressed data as `Uint8Array` throughout to avoid triple byte array conversion.
+- `InputStream.read` returns -1 at EOF; use `while len >= 0` not `while len > 0`.
+
+### PR: wvlet/uni#476


### PR DESCRIPTION
## Summary
- Ignore `.claude/settings.local.json` so local Claude Code settings stay out of the repo
- Add three pending plan drafts under `plans/` so they are tracked alongside the existing dated plans

## Test plan
- [x] `git check-ignore` confirms `.claude/settings.local.json` is ignored
- [x] New `plans/*.md` files are tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)