### PR TITLE
docs: Add Book section with Rust-book style narrative guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,6 +7,9 @@ export default defineConfig({
   base: '/uni/',
   cleanUrls: true,
 
+  // Exclude contributor-only files from the rendered site.
+  srcExclude: ['**/CLAUDE.md'],
+
   markdown: {
     theme: {
       light: 'nord',
@@ -43,6 +46,7 @@ export default defineConfig({
     logo: '/uni-logo-1024x1024.png',
     nav: [
       { text: 'Guide', link: '/guide/' },
+      { text: 'Book', link: '/book/' },
       { text: 'Modules', link: '/core/' },
       {
         text: 'GitHub',
@@ -51,6 +55,77 @@ export default defineConfig({
     ],
 
     sidebar: {
+      '/book/': [
+        {
+          text: 'The Uni Book',
+          items: [
+            { text: 'Overview', link: '/book/' },
+            { text: 'Foreword', link: '/book/foreword' }
+          ]
+        },
+        {
+          text: 'Part I — Getting Started',
+          items: [
+            { text: '1. Getting Started', link: '/book/ch01-00-getting-started' },
+            { text: '1.1 Installation', link: '/book/ch01-01-installation' },
+            { text: '1.2 Hello, Uni!', link: '/book/ch01-02-hello-uni' }
+          ]
+        },
+        {
+          text: 'Part II — Building a CLI Application',
+          items: [
+            { text: '2. A URL Fetcher', link: '/book/ch02-00-cli-app' }
+          ]
+        },
+        {
+          text: 'Part III — Core Concepts',
+          items: [
+            { text: '3. Wiring with Design', link: '/book/ch03-00-design' },
+            { text: '4. Logging That Finds You', link: '/book/ch04-00-logging' },
+            { text: '5. JSON & MessagePack', link: '/book/ch05-00-data' }
+          ]
+        },
+        {
+          text: 'Part IV — Async & Control Flow',
+          items: [
+            { text: '6. Rx, the Composable Stream', link: '/book/ch06-00-rx' },
+            { text: '7. Retry, Circuit Breakers, Resources', link: '/book/ch07-00-control' }
+          ]
+        },
+        {
+          text: 'Part V — HTTP & RPC',
+          items: [
+            { text: '8. HTTP Clients and Servers', link: '/book/ch08-00-http' },
+            { text: '9. Typed RPC', link: '/book/ch09-00-rpc' }
+          ]
+        },
+        {
+          text: 'Part VI — Cross-Platform',
+          items: [
+            { text: '10. One Codebase, Three Runtimes', link: '/book/ch10-00-cross-platform' }
+          ]
+        },
+        {
+          text: 'Part VII — Agent Framework',
+          items: [
+            { text: '11. Building LLM Agents', link: '/book/ch11-00-agent' }
+          ]
+        },
+        {
+          text: 'Part VIII — Testing',
+          items: [
+            { text: '12. Testing with UniTest', link: '/book/ch12-00-testing' }
+          ]
+        },
+        {
+          text: 'Appendices',
+          items: [
+            { text: 'A. Scala 3 Syntax Notes', link: '/book/appendix-a-scala3' },
+            { text: 'B. Uni and Airframe', link: '/book/appendix-b-airframe' },
+            { text: 'C. Glossary', link: '/book/appendix-c-glossary' }
+          ]
+        }
+      ],
       '/guide/': [
         {
           text: 'Getting Started',

--- a/docs/book/CLAUDE.md
+++ b/docs/book/CLAUDE.md
@@ -1,0 +1,212 @@
+# Writing Guide — The Uni Book
+
+> This file is for contributors (humans and Claude) writing chapters of
+> `docs/book/`. It is **not** rendered as a book page. If you are reading
+> it inside the site, you took a wrong turn — see `/book/` instead.
+
+## What the Book is for
+
+The Book is a **narrative, mental-model-first guide** to building
+real applications with Scala 3 and Uni. It is modeled after
+*[The Rust Programming Language](https://doc.rust-lang.org/book/)* ("the
+Rust Book").
+
+- `/guide/`, `/core/`, `/http/`, `/agent/`, etc. are **reference**:
+  shaped around *APIs*.
+- `/book/` is **narrative**: shaped around *tasks, concepts, and
+  reasoning*.
+
+A reader should finish the Book able to say, in their own words:
+"I know how Uni organizes a Scala 3 application, and I know *why* it is
+organized that way." That sentence is the bar every chapter is written
+against.
+
+## Audience
+
+Pick one reader and write to them throughout:
+
+- **Has:** working Scala knowledge (reads case classes and traits
+  comfortably), sbt installed, a curious mind.
+- **Does not have:** experience with Uni, Airframe, or cross-platform
+  Scala (JVM / Scala.js / Scala Native).
+- **Wants:** to build something that runs, and to *understand why the
+  pieces fit the way they do*.
+
+If a sentence requires a reader who is more senior than that, rewrite it.
+If it requires a reader who is less, link out and keep moving.
+
+## Core pedagogical principles
+
+These are borrowed from the Rust Book, which is the benchmark.
+
+### 1. Show, then name
+
+Introduce a shape in code before naming the concept. The reader first
+sees `Design.newDesign.bindSingleton[Service]` doing something
+concrete, *then* we say "this is called a **design**, and here is why it
+is shaped that way." Named things land better when the reader has
+already seen them work.
+
+### 2. Small programs before big theory
+
+Every part opens with a working program, or extends a program the
+reader already has. The reader should never be more than one chapter
+away from something they have actually run. Chapter 2 of the Book is a
+full end-to-end CLI app built with Uni, on purpose — it is the Uni
+analogue of the Rust Book's Guessing Game.
+
+### 3. One new idea per section
+
+A section introduces exactly one concept on top of what the reader
+already has. If a section teaches both `Design` *and* `Rx`, split it.
+
+### 4. Say *why*, not just *how*
+
+Uni makes opinionated choices (constructor injection, avoiding
+`Try[A]`, `withXxx` config setters, Rx-first async, cross-platform
+code). For each one, the Book explains what problem the choice solves,
+with concrete failure modes it prevents. A reader who only memorizes
+the *how* cannot generalize; a reader who understands the *why* can.
+
+A quick sniff test: if a reader asked *"why not just pass it as a
+constructor arg?"*, does the surrounding text answer them? If not,
+answer it.
+
+### 5. Cross-platform by default
+
+Most Uni code runs unchanged on JVM, Scala.js, and Scala Native. Treat
+that as the default in examples; only call out the platform when it
+actually matters. Use callout blocks for platform detours:
+
+```markdown
+::: tip JVM-only
+This example uses `java.nio.file.Path`. On Scala.js / Native, use the
+[FileSystem](/core/filesystem) abstraction instead.
+:::
+```
+
+### 6. Runnable, not decorative
+
+Every non-illustrative code block must compile against the Uni version
+in the repo. Treat snippets as small programs, not wallpaper. If a
+snippet depends on earlier context, reference the file or section where
+that context was introduced — don't silently rely on it.
+
+For deliberately illustrative code (pseudocode, "here's what the API
+*looks like* at a distance"), mark it clearly:
+
+````markdown
+```scala
+// Sketch, not runnable — see ch02-00 for the real code.
+val server = uni.serve(routes)
+```
+````
+
+## Style
+
+### Prose
+
+- **Second person, active voice.** "You create a `Design`…", not "A
+  `Design` is created…".
+- **Present tense.** "`bindSingleton` registers…", not "`bindSingleton`
+  will register…".
+- **Short paragraphs.** Three sentences is a good median. If you hit
+  five, split.
+- **No filler.** Cut words like *simply*, *just*, *basically*, *of
+  course*. They condescend, and they are never the reason a sentence
+  worked.
+- **No emoji** unless the user explicitly requests it for a page.
+
+### Code
+
+- Scala 3 only. Indentation-based syntax, `new` omitted, `${...}` for
+  interpolation.
+- Imports at the top of each snippet, unless the snippet is a direct
+  continuation of the previous block (call that out).
+- Prefer meaningful names (`userService`) over type-mirrored ones
+  (`service`). The reader is learning concepts through examples — names
+  should carry weight.
+- Snippets should *show the output*. After a snippet that prints, show
+  what the reader will see in their terminal.
+
+### Structure of a chapter
+
+Every chapter (not every section) should follow this shape:
+
+1. **Opening question.** One or two lines framing what the reader is
+   about to figure out. Example: "Your app has three services that need
+   a database connection. How do you give it to them without passing it
+   through every call site?"
+2. **Minimal working example.** Something the reader can paste and run.
+3. **Walk the code.** Name and explain the parts. This is where *why*
+   lives.
+4. **Extend it.** One variation that introduces the next idea or shows
+   what changes under pressure (failure modes, alternate platform,
+   etc.).
+5. **"What you have, what comes next."** Two or three bullets. What
+   abilities the reader now has, and what the next chapter adds.
+
+The closing recap is load-bearing: it is what lets a reader navigate
+the book by skimming.
+
+## File conventions
+
+- All book files live under `docs/book/`.
+- File names: `chNN-MM-slug.md`.
+  - `NN` = part number (zero-padded: `01`, `02`, … `10`).
+  - `MM` = section within part (`00` = the part's intro page).
+  - `slug` = short kebab-case, ≤ 4 words.
+  - Example: `ch02-03-config-and-launchers.md`.
+- The part-intro page (`chNN-00-*.md`) introduces what the part is
+  about and lists its sections. It does not teach; it frames.
+- The book landing page is `docs/book/index.md`. Update it when adding
+  or renaming chapters.
+- `docs/book/CLAUDE.md` (this file) is the guide for authors — do **not**
+  link to it from the rendered book.
+
+## Sidebar
+
+When you add a chapter, also update the `'/book/'` sidebar in
+`docs/.vitepress/config.mts`. Order mirrors the file name order.
+
+## Linking
+
+- Link **into** reference docs liberally. The Book shows how to use the
+  pieces; the reference documents the pieces exhaustively. A sentence
+  like "see the full list of [retry
+  policies](/control/retry)" is ideal.
+- Reference docs should **not** link back to the Book. Reference stays
+  reference.
+- Use relative links inside `/book/` (`./ch02-00-cli-app`), absolute
+  links (`/core/design`) elsewhere.
+
+## Stubs
+
+It is fine — expected, even — to land a chapter as a stub while earlier
+chapters are still being written, so the ToC reads as an outline rather
+than as dead ends. A stub must include:
+
+- A one-paragraph "what this chapter will cover" summary.
+- A bulleted list of concepts it will introduce.
+- A VitePress warning block marking it as upcoming:
+
+```markdown
+::: warning Coming soon
+This chapter is an outline. Follow the
+[tracking issue](https://github.com/wvlet/uni/issues) for progress.
+:::
+```
+
+A chapter graduates out of stub state when it has a runnable example
+and matches the chapter-shape checklist above.
+
+## Review checklist before merging a chapter
+
+- [ ] Does the chapter open with a concrete question or problem?
+- [ ] Is there code the reader can run within the first screen?
+- [ ] Is each non-obvious design choice explained (the *why*)?
+- [ ] Are snippets Scala 3, valid against the current Uni version?
+- [ ] Is the "what you have, what comes next" recap present?
+- [ ] Are links into reference docs used instead of restating them?
+- [ ] Does the sidebar in `config.mts` include this file?
+- [ ] Does `npm run docs:build` succeed?

--- a/docs/book/CLAUDE.md
+++ b/docs/book/CLAUDE.md
@@ -153,12 +153,17 @@ the book by skimming.
 
 - All book files live under `docs/book/`.
 - File names: `chNN-MM-slug.md`.
-  - `NN` = part number (zero-padded: `01`, `02`, … `10`).
-  - `MM` = section within part (`00` = the part's intro page).
+  - `NN` = chapter number (zero-padded: `01`, `02`, … `12`).
+  - `MM` = section within the chapter (`00` = the chapter's intro or
+    main page).
   - `slug` = short kebab-case, ≤ 4 words.
-  - Example: `ch02-03-config-and-launchers.md`.
-- The part-intro page (`chNN-00-*.md`) introduces what the part is
-  about and lists its sections. It does not teach; it frames.
+  - Example: `ch01-02-hello-uni.md` is Chapter 1, Section 2.
+- The chapter-intro page (`chNN-00-*.md`) either frames what the
+  chapter is about and lists its sections (for multi-section chapters
+  like Chapter 1) or is itself the entire chapter (for single-section
+  chapters like Chapter 2).
+- "Parts" in the book's outline are a grouping in the ToC and sidebar,
+  not a file-naming concept.
 - The book landing page is `docs/book/index.md`. Update it when adding
   or renaming chapters.
 - `docs/book/CLAUDE.md` (this file) is the guide for authors — do **not**

--- a/docs/book/appendix-a-scala3.md
+++ b/docs/book/appendix-a-scala3.md
@@ -1,0 +1,22 @@
+# Appendix A: Scala 3 Syntax Notes for This Book
+
+::: warning Coming soon
+This appendix is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this appendix will cover
+
+A concise reference for the Scala 3 features this book relies on,
+aimed at readers coming from Scala 2, Java, or another
+strongly-typed language.
+
+Topics:
+
+- Indentation-based syntax (and when braces are still handy).
+- `@main` annotated entry points.
+- `given` / `using` for contextual parameters.
+- Enum types and pattern matching.
+- Extension methods.
+- Why `new` is almost never needed.
+
+[← 12. Testing with UniTest](./ch12-00-testing) | [Next → Appendix B: Uni and Airframe](./appendix-b-airframe)

--- a/docs/book/appendix-b-airframe.md
+++ b/docs/book/appendix-b-airframe.md
@@ -1,0 +1,21 @@
+# Appendix B: Uni and Airframe — History and Relationship
+
+::: warning Coming soon
+This appendix is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this appendix will cover
+
+Uni is a refinement of code that started life in the
+[Airframe](https://github.com/wvlet/airframe) project. This
+appendix explains what stayed, what changed, and how to think about
+the relationship if you have existing Airframe code.
+
+Topics:
+
+- The migration from Airframe to Uni: package renames, deprecations,
+  and what survives identically.
+- What Uni deliberately dropped from Airframe, and why.
+- Using Uni and Airframe in the same project during a migration.
+
+[← Appendix A: Scala 3 Syntax Notes](./appendix-a-scala3) | [Next → Appendix C: Glossary](./appendix-c-glossary)

--- a/docs/book/appendix-c-glossary.md
+++ b/docs/book/appendix-c-glossary.md
@@ -1,0 +1,26 @@
+# Appendix C: Glossary
+
+::: warning Coming soon
+This appendix is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this appendix will cover
+
+A short glossary of terms as this book uses them. The intent is to
+make cross-references precise, not to define every word in Scala.
+
+Terms to include (non-exhaustive):
+
+- **Design** — an immutable description of how types are wired.
+- **Session** — a runtime context built from a Design; owns
+  singletons and lifecycle hooks.
+- **Binding** — one entry in a Design (`bindSingleton`, `bindImpl`,
+  etc.).
+- **LogSupport** — the trait mixed in to give a class a `logger`.
+- **Rx** — Uni's asynchronous / streaming abstraction.
+- **Surface** — compile-time type reflection used by the codec layer.
+- **Launcher** — the annotation-driven CLI argument parser.
+- **Codec** — a bidirectional translator between bytes (JSON /
+  MessagePack) and Scala values.
+
+[← Appendix B: Uni and Airframe](./appendix-b-airframe) | [Back to the Book](./)

--- a/docs/book/ch01-00-getting-started.md
+++ b/docs/book/ch01-00-getting-started.md
@@ -1,0 +1,22 @@
+# 1. Getting Started
+
+Before you can write Uni code, your machine needs a JDK, an sbt that
+knows how to fetch Scala 3, and a project wired to pull Uni in. This
+part of the book gets you there, then writes enough of a program to
+prove everything is hooked up.
+
+Two chapters, in order:
+
+- [1.1 Installation](./ch01-01-installation) — prerequisites, a minimal
+  `build.sbt`, and how to pull Uni into JVM-only, Scala.js, and Scala
+  Native projects.
+- [1.2 Hello, Uni!](./ch01-02-hello-uni) — your first runnable Uni
+  program. It is only a dozen lines, but by the end of it you will
+  have met the two concepts that thread through the rest of the book:
+  **logging** and **Design** (object wiring).
+
+By the end of Part I, a fresh clone of your project should compile and
+run. Part II then turns that starting point into a real command-line
+application.
+
+[← Foreword](./foreword) | [Next → 1.1 Installation](./ch01-01-installation)

--- a/docs/book/ch01-01-installation.md
+++ b/docs/book/ch01-01-installation.md
@@ -112,7 +112,10 @@ addSbtPlugin("org.scala-native"   % "sbt-scala-native"               % "0.5.7")
 
 ```scala
 // build.sbt
+import sbtcrossproject.CrossPlugin.autoImport.CrossType
+
 lazy val hello = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
   .in(file("."))
   .settings(
     scalaVersion := "3.3.4",
@@ -120,13 +123,24 @@ lazy val hello = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
 ```
 
+Two parts of that snippet are worth a moment.
+
+`.crossType(CrossType.Pure)` says *"all of this project's sources are
+shared across platforms"*. The alternative, `CrossType.Full`, keeps
+per-platform `src/main/scala-jvm`, `src/main/scala-js`, and
+`src/main/scala-native` folders for code that has to differ. **Prefer
+`Pure`.** Reach for `Full` only when you actually have a chunk of code
+that cannot compile on every target — at which point a separate module
+is usually a cleaner split than per-platform source folders inside one
+module.
+
 The `%%%` operator tells sbt: *pick the version of `uni` that was built
 for whichever platform I am compiling for right now*. Your Scala source
 does not change between platforms; only the build setting does.
 
 We will build a real cross-platform codebase in Chapter 10. For now
-know that it is two characters of difference (`%%` → `%%%`) and one
-sbt plugin away.
+know that it is one cross-plugin, one `CrossType.Pure`, and a `%%%`
+away.
 
 ## IDE setup
 

--- a/docs/book/ch01-01-installation.md
+++ b/docs/book/ch01-01-installation.md
@@ -161,12 +161,6 @@ everyone shares lives at the module root under `src/main/scala` and
 > browser DOM API, a native syscall. You will see examples of that in
 > Chapter 10.
 
-The other alternative, `CrossType.Full`, uses a different layout with
-a `shared/` folder alongside `jvm/`, `js/`, and `native/` folders for
-per-platform sources. **Prefer `Pure`.** Reach for `Full` only when
-platform-specific code is a substantial part of the project, at which
-point splitting into separate modules is usually cleaner still.
-
 The `%%%` operator tells sbt: *pick the version of `uni` that was built
 for whichever platform I am compiling for right now*. Your Scala source
 does not change between platforms; only the build setting does.

--- a/docs/book/ch01-01-installation.md
+++ b/docs/book/ch01-01-installation.md
@@ -140,25 +140,26 @@ hello/
     └── test/scala/    ← shared tests
 ```
 
-The `.jvm`, `.js`, and `.native` directories are **not** where you put
-code. sbt-crossproject creates them as per-platform project roots
-(each is a distinct sbt subproject with its own `target/`), but your
-Scala lives at the module root under `src/main/scala` and
-`src/test/scala`. Compile once, run on three platforms.
+The `.jvm`, `.js`, and `.native` directories are per-platform project
+roots. Each is a distinct sbt subproject with its own `target/`, and
+each is where **platform-specific** code goes when you need it:
+`.jvm/src/main/scala` is seen only by the JVM build,
+`.js/src/main/scala` only by the Scala.js build, and
+`.native/src/main/scala` only by the Scala Native build. The code
+everyone shares lives at the module root under `src/main/scala` and
+`src/test/scala`.
 
-> **Why this works with Uni.** Uni's public API — `Design`, `Logger`,
-> `Http`, `Rx`, `JSON`, `MessagePack` — is the same on every platform.
-> Where a platform difference exists (filesystem access, timers,
-> threading), Uni exposes a single abstraction that resolves to the
+> **With Uni, you rarely have to.** Uni's public API — `Design`,
+> `Logger`, `Http`, `Rx`, `JSON`, `MessagePack` — is the same on every
+> platform. Where a platform difference exists (filesystem access,
+> timers, threading), Uni exposes one abstraction that resolves to the
 > right implementation under the covers. For a typical Uni
-> application, *all* of your code can live in the shared `src/main/scala`,
-> and that is usually the whole story.
->
-> If you do need truly platform-specific code — say, calling a
-> JVM-only Java library — sbt-crossproject lets you drop files into
-> `.jvm/src/main/scala`, `.js/src/main/scala`, or
-> `.native/src/main/scala`, and only the matching platform sees them.
-> You will see examples of this in Chapter 10.
+> application, *all* of your code can live in the shared
+> `src/main/scala`, and that is usually the whole story. The
+> `.<platform>/src/main/scala` folders stay empty unless you reach for
+> a genuinely platform-only dependency — a JVM-only Java library, a
+> browser DOM API, a native syscall. You will see examples of that in
+> Chapter 10.
 
 The other alternative, `CrossType.Full`, uses a different layout with
 a `shared/` folder alongside `jvm/`, `js/`, and `native/` folders for

--- a/docs/book/ch01-01-installation.md
+++ b/docs/book/ch01-01-installation.md
@@ -126,13 +126,45 @@ lazy val hello = crossProject(JVMPlatform, JSPlatform, NativePlatform)
 Two parts of that snippet are worth a moment.
 
 `.crossType(CrossType.Pure)` says *"all of this project's sources are
-shared across platforms"*. The alternative, `CrossType.Full`, keeps
-per-platform `src/main/scala-jvm`, `src/main/scala-js`, and
-`src/main/scala-native` folders for code that has to differ. **Prefer
-`Pure`.** Reach for `Full` only when you actually have a chunk of code
-that cannot compile on every target — at which point a separate module
-is usually a cleaner split than per-platform source folders inside one
-module.
+shared across platforms"*. With `Pure`, your project looks like this
+on disk:
+
+```
+hello/
+├── build.sbt
+├── .jvm/          ← auto-generated per-platform project root
+├── .js/           ← auto-generated per-platform project root
+├── .native/       ← auto-generated per-platform project root
+└── src/
+    ├── main/scala/    ← shared code, compiled for all three platforms
+    └── test/scala/    ← shared tests
+```
+
+The `.jvm`, `.js`, and `.native` directories are **not** where you put
+code. sbt-crossproject creates them as per-platform project roots
+(each is a distinct sbt subproject with its own `target/`), but your
+Scala lives at the module root under `src/main/scala` and
+`src/test/scala`. Compile once, run on three platforms.
+
+> **Why this works with Uni.** Uni's public API — `Design`, `Logger`,
+> `Http`, `Rx`, `JSON`, `MessagePack` — is the same on every platform.
+> Where a platform difference exists (filesystem access, timers,
+> threading), Uni exposes a single abstraction that resolves to the
+> right implementation under the covers. For a typical Uni
+> application, *all* of your code can live in the shared `src/main/scala`,
+> and that is usually the whole story.
+>
+> If you do need truly platform-specific code — say, calling a
+> JVM-only Java library — sbt-crossproject lets you drop files into
+> `.jvm/src/main/scala`, `.js/src/main/scala`, or
+> `.native/src/main/scala`, and only the matching platform sees them.
+> You will see examples of this in Chapter 10.
+
+The other alternative, `CrossType.Full`, uses a different layout with
+a `shared/` folder alongside `jvm/`, `js/`, and `native/` folders for
+per-platform sources. **Prefer `Pure`.** Reach for `Full` only when
+platform-specific code is a substantial part of the project, at which
+point splitting into separate modules is usually cleaner still.
 
 The `%%%` operator tells sbt: *pick the version of `uni` that was built
 for whichever platform I am compiling for right now*. Your Scala source
@@ -140,7 +172,7 @@ does not change between platforms; only the build setting does.
 
 We will build a real cross-platform codebase in Chapter 10. For now
 know that it is one cross-plugin, one `CrossType.Pure`, and a `%%%`
-away.
+away — and that everything you write goes in `src/main/scala`.
 
 ## IDE setup
 

--- a/docs/book/ch01-01-installation.md
+++ b/docs/book/ch01-01-installation.md
@@ -1,0 +1,155 @@
+# 1.1 Installation
+
+Uni is a library, not a framework. You add it to a Scala 3 project with
+a single line in `build.sbt` and you are done. This chapter walks you
+through getting the tools, creating a minimal project, and confirming
+the setup.
+
+If you already have Scala 3 and sbt installed, jump to [Adding Uni to a
+project](#adding-uni-to-a-project).
+
+## Prerequisites
+
+You need three things:
+
+| Tool | Minimum version | Why |
+|------|-----------------|-----|
+| JDK | 17 | Scala 3 targets modern JVMs. 17 is the LTS floor most of the ecosystem is on. |
+| sbt | 1.9 | The build tool. Anything older may not know about current Scala.js / Native plugins. |
+| Scala 3 | 3.3 or newer | Uni uses Scala 3 features (match types, given imports, `extends` with indentation). |
+
+A JDK 17+ and sbt 1.9+ will pull the right Scala 3 compiler on demand.
+
+### Installing the JDK and sbt
+
+The single easiest path on any OS is [Coursier](https://get-coursier.io/):
+
+```bash
+cs setup
+```
+
+That command installs a JDK, `sbt`, `scala`, and sets up your `PATH`. If
+you prefer native package managers:
+
+- **macOS:** `brew install sbt openjdk@21`
+- **Linux (Debian/Ubuntu):** install `sbt` from the [official APT
+  repo](https://www.scala-sbt.org/download.html) and `openjdk-21-jdk`
+  from your distribution.
+- **Windows:** use [Scoop](https://scoop.sh/) or the
+  [sbt MSI installer](https://www.scala-sbt.org/download.html).
+
+Confirm both tools:
+
+```bash
+$ java --version
+openjdk 21.0.4 2024-07-16 LTS
+$ sbt --version
+sbt script version: 1.9.8
+```
+
+## Adding Uni to a project
+
+Create a directory and drop two files in it.
+
+```
+hello-uni/
+├── build.sbt
+└── src/main/scala/Main.scala
+```
+
+`build.sbt`:
+
+```scala
+val scala3Version = "3.3.4"
+
+ThisBuild / scalaVersion := scala3Version
+
+lazy val hello = project
+  .in(file("."))
+  .settings(
+    name := "hello-uni",
+    libraryDependencies += "org.wvlet.uni" %% "uni" % "2026.1.0"
+  )
+```
+
+`src/main/scala/Main.scala`:
+
+```scala
+@main def main(): Unit =
+  println("hello")
+```
+
+Run it:
+
+```bash
+$ sbt run
+[info] running main
+hello
+```
+
+The first `sbt run` will download Scala 3 and Uni's transitive
+dependencies. Subsequent runs are fast.
+
+> **Why no "framework initialization" step?** Uni is deliberately a
+> library — a collection of small pieces you pull from. There is no
+> bootstrap ceremony, no annotation processor to wire up, no agent to
+> install. The moment sbt resolves the dependency, you can import and
+> use any of it.
+
+## Cross-platform projects
+
+Most Uni code works unchanged on **JVM**, **Scala.js**, and **Scala
+Native**. For a cross-build project, use
+[sbt-crossproject](https://github.com/portable-scala/sbt-crossproject)
+and reference Uni with `%%%` instead of `%%`:
+
+```scala
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"       % "1.3.2")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"                    % "1.16.0")
+addSbtPlugin("org.scala-native"   % "sbt-scala-native"               % "0.5.7")
+```
+
+```scala
+// build.sbt
+lazy val hello = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .in(file("."))
+  .settings(
+    scalaVersion := "3.3.4",
+    libraryDependencies += "org.wvlet.uni" %%% "uni" % "2026.1.0"
+  )
+```
+
+The `%%%` operator tells sbt: *pick the version of `uni` that was built
+for whichever platform I am compiling for right now*. Your Scala source
+does not change between platforms; only the build setting does.
+
+We will build a real cross-platform codebase in Chapter 10. For now
+know that it is two characters of difference (`%%` → `%%%`) and one
+sbt plugin away.
+
+## IDE setup
+
+Uni uses only standard Scala 3 features, so any Scala 3-aware IDE
+works. The common choices:
+
+- **IntelliJ IDEA** with the Scala plugin.
+- **VS Code** with [Metals](https://scalameta.org/metals/).
+- **Neovim** with Metals.
+
+Open the project directory, let the IDE import the build, and you are
+done.
+
+## What you have, what comes next
+
+You now have:
+
+- A JDK, sbt, and Scala 3 on your `PATH`.
+- A `build.sbt` that pulls Uni in as a dependency.
+- Proof that `sbt run` works on an empty program.
+
+The [next chapter](./ch01-02-hello-uni) replaces that `println` with
+actual Uni code — and in doing so meets the two ideas that thread
+through the rest of the book: **logging** and **object wiring**.
+
+[← 1. Getting Started](./ch01-00-getting-started) | [Next → 1.2 Hello, Uni!](./ch01-02-hello-uni)

--- a/docs/book/ch01-01-installation.md
+++ b/docs/book/ch01-01-installation.md
@@ -132,9 +132,9 @@ on disk:
 ```
 hello/
 ├── build.sbt
-├── .jvm/          ← auto-generated per-platform project root
-├── .js/           ← auto-generated per-platform project root
-├── .native/       ← auto-generated per-platform project root
+├── .jvm/          ← JVM-specific code (rarely needed with Uni)
+├── .js/           ← Scala.js-specific code (rarely needed with Uni)
+├── .native/       ← Scala Native-specific code (rarely needed with Uni)
 └── src/
     ├── main/scala/    ← shared code, compiled for all three platforms
     └── test/scala/    ← shared tests

--- a/docs/book/ch01-02-hello-uni.md
+++ b/docs/book/ch01-02-hello-uni.md
@@ -109,8 +109,7 @@ class Greeter extends LogSupport:
   val design = Design.newDesign
     .bindSingleton[Greeter]
 
-  design.withSession { session =>
-    val greeter = session.build[Greeter]
+  design.build[Greeter] { greeter =>
     greeter.greet("Uni")
   }
 ```
@@ -121,10 +120,11 @@ Run it again — same output, but now something structural has changed.
   configuration.
 - `.bindSingleton[Greeter]` says *"when someone asks for a `Greeter`,
   build one and share it."* No instance is created yet.
-- `design.withSession { session => ... }` opens a **session**. Inside
-  the block, `session.build[Greeter]` gets (or creates on first ask)
-  the `Greeter`. When the block ends, the session is shut down and any
-  resources attached to it are released.
+- `design.build[Greeter] { greeter => ... }` opens a **session**,
+  builds the `Greeter` (this is the moment it is actually constructed),
+  hands it to your block, and then shuts the session down when the
+  block returns. Any resources attached to the session are released
+  at that shutdown.
 
 You did not have to tell `Main` how `Greeter` is constructed. You did
 not have to thread a `Greeter` through intermediate functions. You
@@ -143,7 +143,7 @@ Fair question — this is exactly the point. With three lines of code,
   pool when the session ends). Design has a hook for that.
 
 We will meet all three of those in Part III. For now, treat
-`Design.newDesign.bindSingleton[X].withSession { ... }` as the shape
+`Design.newDesign.bindSingleton[X].build[X] { x => ... }` as the shape
 your `main` methods will have from here on.
 
 ## What you have, what comes next

--- a/docs/book/ch01-02-hello-uni.md
+++ b/docs/book/ch01-02-hello-uni.md
@@ -2,8 +2,8 @@
 
 With Uni on the classpath, the shortest useful program you can write is
 one that logs a line. That seems small, but it introduces two of Uni's
-core ideas — **structured logging** and the **LogSupport trait** — and
-sets up the next step, where we let **Design** wire objects together
+core ideas — the **LogSupport trait** and **source-location capture** —
+and sets up the next step, where we let **Design** wire objects together
 for us.
 
 ## The smallest Uni program

--- a/docs/book/ch01-02-hello-uni.md
+++ b/docs/book/ch01-02-hello-uni.md
@@ -1,0 +1,163 @@
+# 1.2 Hello, Uni!
+
+With Uni on the classpath, the shortest useful program you can write is
+one that logs a line. That seems small, but it introduces two of Uni's
+core ideas — **structured logging** and the **LogSupport trait** — and
+sets up the next step, where we let **Design** wire objects together
+for us.
+
+## The smallest Uni program
+
+Replace `src/main/scala/Main.scala` from the previous chapter with:
+
+```scala
+import wvlet.uni.log.LogSupport
+
+object Main extends LogSupport:
+  def main(args: Array[String]): Unit =
+    info("Hello, Uni!")
+```
+
+Run it:
+
+```bash
+$ sbt run
+2026-04-18 09:00:00.000-0700  info [Main] Hello, Uni!  - (Main.scala:5)
+```
+
+Four things are worth pausing on.
+
+### `LogSupport` is a trait, not a wrapper
+
+`LogSupport` mixes in two things: a `logger` bound to the enclosing
+class name, and methods (`info`, `warn`, `error`, `debug`, `trace`) that
+call it. You do not construct a `Logger`; you declare that this class
+*has* one. That is the whole of the logging API for day-to-day code.
+
+### The logger name is the class name
+
+The output starts with `[Main]`. That is the simple name of the class
+that mixed in `LogSupport`. When you search logs later, the grep is on a
+string you can see right here in the source file.
+
+### The source location is captured automatically
+
+The `(Main.scala:5)` at the end of the line is free. Uni captures it at
+compile time using Scala 3's `scala.quoted.Quotes` API, so there is no
+stack-walking cost at runtime. When a production incident makes you ask
+*"which line produced this?"*, the answer is already printed.
+
+### Scala 3 syntax is the default
+
+No `new`, no `class Main { ... }` braces, no `extends App`. The Scala 3
+indentation style is what Uni uses in its own code and what this book
+will use throughout. If you prefer braces, the compiler still accepts
+them — but the examples here will stay in the indented style.
+
+## Adding a collaborator: wire it by hand
+
+A real program has more than one class. Let's add a `Greeter` and have
+`Main` use it.
+
+```scala
+import wvlet.uni.log.LogSupport
+
+class Greeter extends LogSupport:
+  def greet(name: String): Unit =
+    info(s"Hello, ${name}!")
+
+object Main extends LogSupport:
+  def main(args: Array[String]): Unit =
+    val greeter = Greeter()
+    greeter.greet("Uni")
+```
+
+Output:
+
+```
+info [Greeter] Hello, Uni!  - (Main.scala:5)
+```
+
+Two things changed. The logger name shifted to `[Greeter]` (because the
+`info` call now happens inside the `Greeter` class), and `Main` now
+constructs the `Greeter` explicitly with `Greeter()`.
+
+In a three-line program, manual construction is fine. In a real
+application it is not:
+
+- Every caller needs to know how every callee is built.
+- When a collaborator grows a dependency ("now `Greeter` needs a
+  `Config`"), every caller changes.
+- Swapping an implementation in a test means passing a different
+  constructor argument in every call site.
+
+Uni offers a better tool.
+
+## Letting Design do the wiring
+
+The same program, this time wired by `Design`:
+
+```scala
+import wvlet.uni.design.Design
+import wvlet.uni.log.LogSupport
+
+class Greeter extends LogSupport:
+  def greet(name: String): Unit =
+    info(s"Hello, ${name}!")
+
+@main def main(): Unit =
+  val design = Design.newDesign
+    .bindSingleton[Greeter]
+
+  design.withSession { session =>
+    val greeter = session.build[Greeter]
+    greeter.greet("Uni")
+  }
+```
+
+Run it again — same output, but now something structural has changed.
+
+- `Design.newDesign` gives you an empty, immutable wiring
+  configuration.
+- `.bindSingleton[Greeter]` says *"when someone asks for a `Greeter`,
+  build one and share it."* No instance is created yet.
+- `design.withSession { session => ... }` opens a **session**. Inside
+  the block, `session.build[Greeter]` gets (or creates on first ask)
+  the `Greeter`. When the block ends, the session is shut down and any
+  resources attached to it are released.
+
+You did not have to tell `Main` how `Greeter` is constructed. You did
+not have to thread a `Greeter` through intermediate functions. You
+asked for one, and you got one.
+
+### Why this instead of `Greeter()`?
+
+Fair question — this is exactly the point. With three lines of code,
+`Greeter()` is less ceremony. What `Design` buys you shows up when:
+
+- `Greeter` gains a dependency (a `Config`, an `HttpClient`). You only
+  update the `Design`, not every call site.
+- You want a different `Greeter` in tests (say, one that captures
+  messages). You replace one line in a test-specific design.
+- You want to tie *shutdown behavior* to *construction* (close the HTTP
+  pool when the session ends). Design has a hook for that.
+
+We will meet all three of those in Part III. For now, treat
+`Design.newDesign.bindSingleton[X].withSession { ... }` as the shape
+your `main` methods will have from here on.
+
+## What you have, what comes next
+
+You can now:
+
+- Print log lines from a Scala 3 program with source locations.
+- Construct one object, then three, using `Design` instead of by hand.
+- Read a Uni-idiomatic `main` method and recognize its shape.
+
+The [next chapter](./ch02-00-cli-app) takes these primitives and
+builds something you would actually run: a small command-line tool
+that fetches a URL and prints what it gets back. That single program
+will introduce argument parsing, HTTP, and the first failure modes
+Uni helps you handle.
+
+[← 1.1 Installation](./ch01-01-installation) | [Next → 2. A URL Fetcher](./ch02-00-cli-app)

--- a/docs/book/ch02-00-cli-app.md
+++ b/docs/book/ch02-00-cli-app.md
@@ -1,0 +1,272 @@
+# 2. A URL Fetcher
+
+This chapter builds one complete program — a small command-line tool
+that fetches a URL, prints the status line, and optionally dumps the
+body. It is the first real Uni app we write, and the point is to meet
+four pieces together, in context:
+
+- **Launcher** — turn command-line arguments into a typed object.
+- **HttpClient** — make a request and inspect the response.
+- **Design** — wire the two together so they can be replaced
+  independently.
+- **UniTest** — write a fast, dependency-free test.
+
+You will not learn everything about any of these in this chapter;
+Parts III–V take each one apart. What you will get is a working mental
+shape: *what goes where, and why*.
+
+## What we are building
+
+A tool called `fetch` that behaves like this:
+
+```bash
+$ fetch https://httpbin.org/get
+200 OK  (https://httpbin.org/get)
+
+$ fetch --show-body https://httpbin.org/get
+200 OK  (https://httpbin.org/get)
+{
+  "args": {},
+  "headers": { ... },
+  ...
+}
+
+$ fetch
+Missing URL. Usage: fetch [--show-body] <url>
+```
+
+Small, but it has the three pieces every real CLI has: it parses args,
+does I/O, and reports success or failure.
+
+## Step 1: Parse arguments with Launcher
+
+Create `src/main/scala/Fetch.scala` and start with just the argument
+shape:
+
+```scala
+import wvlet.uni.cli.launcher.{Launcher, argument, option}
+
+case class FetchArgs(
+    @option(prefix = "--show-body", description = "Print response body")
+    showBody: Boolean = false,
+    @argument(name = "url", description = "URL to fetch")
+    url: String = ""
+)
+
+@main def fetch(args: String*): Unit =
+  val parsed = Launcher.execute[FetchArgs](args.toArray)
+  println(s"url='${parsed.url}', showBody=${parsed.showBody}")
+```
+
+Try it:
+
+```bash
+$ sbt "runMain fetch --show-body https://example.com"
+url='https://example.com', showBody=true
+```
+
+Three things to notice.
+
+**`FetchArgs` is a plain case class.** The `@option` and `@argument`
+annotations are metadata; the class itself is just data. This is a
+recurring Uni shape: configuration and input are ordinary Scala types,
+and a separate tool (`Launcher`) populates them.
+
+**Defaults live with the field.** `showBody = false` is how you say
+"this flag is optional". `url = ""` is a sentinel we will check below.
+
+**`Launcher.execute[FetchArgs](args)` does two things.** It parses, and
+it constructs — returning a `FetchArgs` ready to use. If you passed
+malformed flags, it prints help and exits; if the user passed `--help`
+it prints the description strings you wrote in the annotations.
+
+> **Why annotate the fields instead of calling a builder?**
+> The annotation form keeps the case class *the* source of truth for
+> what the CLI accepts. There is no second list to keep in sync, no
+> place for the "declared flag" and "consumed flag" to drift apart.
+
+## Step 2: Fetch the URL
+
+Add a service that does the actual HTTP call. The service takes its
+`HttpSyncClient` as a constructor parameter instead of creating one
+inside — so whoever builds `UrlFetcher` decides how long the client
+lives:
+
+```scala
+import wvlet.uni.http.{HttpSyncClient, Request}
+import wvlet.uni.log.LogSupport
+
+class UrlFetcher(client: HttpSyncClient) extends LogSupport:
+  def fetch(url: String, showBody: Boolean): Unit =
+    info(s"GET ${url}")
+    val response = client.send(Request.get(url))
+    println(s"${response.status}  (${url})")
+    if showBody then
+      println(response.contentAsString.getOrElse(""))
+```
+
+A few things to notice.
+
+`Http.client.newSyncClient` (which we will call in the next step)
+produces a client with sensible defaults: connection pooling, JSON
+content negotiation, and — importantly — a retry policy. If
+`httpbin.org` returns a 5xx or the TCP connection flakes, the client
+retries with exponential backoff before giving up. We lean on that in
+Chapter 7.
+
+`response.status` is a typed `HttpStatus` (not a number), so you can
+pattern-match on it without digging through strings.
+`response.contentAsString` returns `Option[String]` — some responses
+genuinely have no body (a `204 No Content`, for instance), and the
+type reflects that. We unwrap with `.getOrElse("")` at the print site.
+
+Because `UrlFetcher` no longer owns its client, we can tell `Design` to
+own it instead — and to close it cleanly when the session ends.
+
+## Step 3: Wire it with Design
+
+Now connect the pieces in `main`:
+
+```scala
+import wvlet.uni.cli.launcher.{Launcher, argument, option}
+import wvlet.uni.design.Design
+import wvlet.uni.http.{Http, HttpSyncClient, Request}
+import wvlet.uni.log.LogSupport
+
+case class FetchArgs(
+    @option(prefix = "--show-body", description = "Print response body")
+    showBody: Boolean = false,
+    @argument(name = "url", description = "URL to fetch")
+    url: String = ""
+)
+
+class UrlFetcher(client: HttpSyncClient) extends LogSupport:
+  def fetch(url: String, showBody: Boolean): Unit =
+    info(s"GET ${url}")
+    val response = client.send(Request.get(url))
+    println(s"${response.status}  (${url})")
+    if showBody then
+      println(response.contentAsString.getOrElse(""))
+
+@main def fetch(args: String*): Unit =
+  val parsed = Launcher.execute[FetchArgs](args.toArray)
+  if parsed.url.isEmpty then
+    println("Missing URL. Usage: fetch [--show-body] <url>")
+    sys.exit(1)
+
+  val design = Design.newDesign
+    .bindInstance[HttpSyncClient](Http.client.newSyncClient)
+    .onShutdown(_.close())
+    .bindSingleton[UrlFetcher]
+
+  design.withSession { session =>
+    val fetcher = session.build[UrlFetcher]
+    fetcher.fetch(parsed.url, parsed.showBody)
+  }
+```
+
+Run the real thing:
+
+```bash
+$ sbt "runMain fetch https://httpbin.org/get"
+info [UrlFetcher] GET https://httpbin.org/get  - (Fetch.scala:15)
+200 OK  (https://httpbin.org/get)
+```
+
+You now have the spine of every Uni application you will write:
+
+1. **Parse** (`Launcher.execute`).
+2. **Wire** (`Design.newDesign...withSession`).
+3. **Do** (build the services you need, call them).
+
+Everything else — more services, more wiring, more complex flows —
+slots into that spine.
+
+## Why the extra ceremony?
+
+Right now you could inline `UrlFetcher` into `main` and save six lines.
+So what does the indirection buy?
+
+**Replaceability.** In the next step we will test this without
+actually hitting the network. That means swapping the *real*
+`UrlFetcher` for a stand-in. If `main` constructed `UrlFetcher` directly,
+the test would have to call `main` with monkey-patched globals. With
+`Design`, the swap is one line.
+
+**Lifecycle.** You saw a small example of this already:
+`.bindInstance[HttpSyncClient](...).onShutdown(_.close())` attaches the
+client's cleanup to the session. When `withSession` ends — whether the
+block completed normally or threw — the client's `close()` runs. A real
+app might add a database connection, a server, and a scheduler, each
+with its own hook. `withSession` is the single place that controls
+when they all wind down.
+
+**Locality of wiring.** The entire dependency graph of your program is
+visible in one `Design.newDesign...` block. Growing from one service to
+ten does not scatter construction logic across the codebase.
+
+## Step 4: A test, without the network
+
+Add `src/test/scala/FetchTest.scala`:
+
+```scala
+import wvlet.uni.cli.launcher.Launcher
+import wvlet.uni.test.UniTest
+
+class FetchTest extends UniTest:
+  test("parses --show-body and URL") {
+    val args = Launcher.execute[FetchArgs](Array("--show-body", "https://example.com"))
+    args.showBody shouldBe true
+    args.url shouldBe "https://example.com"
+  }
+
+  test("defaults showBody to false") {
+    val args = Launcher.execute[FetchArgs](Array("https://example.com"))
+    args.showBody shouldBe false
+  }
+
+  test("treats missing URL as empty string") {
+    val args = Launcher.execute[FetchArgs](Array.empty)
+    args.url shouldBe ""
+  }
+```
+
+Run it:
+
+```bash
+$ sbt test
+[info] FetchTest:
+[info]  - parses --show-body and URL
+[info]  - defaults showBody to false
+[info]  - treats missing URL as empty string
+```
+
+No network, no mocks, no fixtures. The arg-parsing layer is a pure
+function from `Array[String]` to `FetchArgs`, and Uni keeps it that
+way.
+
+For testing `UrlFetcher` itself *without* the network, we would
+replace its HTTP client with a stand-in via a test-only `Design`. We
+will do exactly that in Chapter 12 once we have met `Design`'s
+override mechanism.
+
+## What you have, what comes next
+
+You have written a Scala 3 CLI tool end to end:
+
+- Typed CLI arguments with `@option` and `@argument`.
+- Real HTTP calls through `Http.client.newSyncClient`.
+- Object wiring and lifecycle through `Design.withSession`.
+- A test suite that runs in milliseconds and has no external
+  dependencies.
+
+You have also met the shape every Uni program shares: **parse, wire,
+do, clean up**. The rest of the book takes each of those layers apart
+in depth.
+
+Next, [Part III](./ch03-00-design) goes back to the beginning and
+explains **Design** properly — why constructor wiring beats the
+alternatives, how singletons and sessions interact, and how to
+override bindings for tests and environments.
+
+[← 1.2 Hello, Uni!](./ch01-02-hello-uni) | [Next → 3. Wiring with Design](./ch03-00-design)

--- a/docs/book/ch02-00-cli-app.md
+++ b/docs/book/ch02-00-cli-app.md
@@ -40,8 +40,7 @@ does I/O, and reports success or failure.
 
 ## Step 1: Parse arguments with Launcher
 
-Create `src/main/scala/Fetch.scala` and start with just the argument
-shape:
+Create `src/main/scala/Fetch.scala` and start with the argument shape:
 
 ```scala
 import wvlet.uni.cli.launcher.{Launcher, argument, option}
@@ -55,6 +54,7 @@ case class FetchArgs(
 
 @main def fetch(args: String*): Unit =
   val parsed = Launcher.execute[FetchArgs](args.toArray)
+  if parsed == null then return // user requested --help; Launcher already printed it
   println(s"url='${parsed.url}', showBody=${parsed.showBody}")
 ```
 
@@ -68,7 +68,7 @@ url='https://example.com', showBody=true
 Three things to notice.
 
 **`FetchArgs` is a plain case class.** The `@option` and `@argument`
-annotations are metadata; the class itself is just data. This is a
+annotations are metadata; the class itself is data. This is a
 recurring Uni shape: configuration and input are ordinary Scala types,
 and a separate tool (`Launcher`) populates them.
 
@@ -78,7 +78,10 @@ and a separate tool (`Launcher`) populates them.
 **`Launcher.execute[FetchArgs](args)` does two things.** It parses, and
 it constructs — returning a `FetchArgs` ready to use. If you passed
 malformed flags, it prints help and exits; if the user passed `--help`
-it prints the description strings you wrote in the annotations.
+(or invoked the program with no arguments, which is the default help
+trigger) `Launcher` prints the annotation-derived usage text and returns
+`null`. The `if parsed == null then return` line is how you let that
+help-message path out of your `main`.
 
 > **Why annotate the fields instead of calling a builder?**
 > The annotation form keeps the case class *the* source of truth for
@@ -150,6 +153,7 @@ class UrlFetcher(client: HttpSyncClient) extends LogSupport:
 
 @main def fetch(args: String*): Unit =
   val parsed = Launcher.execute[FetchArgs](args.toArray)
+  if parsed == null then return // --help was handled by Launcher
   if parsed.url.isEmpty then
     println("Missing URL. Usage: fetch [--show-body] <url>")
     sys.exit(1)

--- a/docs/book/ch02-00-cli-app.md
+++ b/docs/book/ch02-00-cli-app.md
@@ -163,8 +163,7 @@ class UrlFetcher(client: HttpSyncClient) extends LogSupport:
     .onShutdown(_.close())
     .bindSingleton[UrlFetcher]
 
-  design.withSession { session =>
-    val fetcher = session.build[UrlFetcher]
+  design.build[UrlFetcher] { fetcher =>
     fetcher.fetch(parsed.url, parsed.showBody)
   }
 ```
@@ -180,8 +179,8 @@ info [UrlFetcher] GET https://httpbin.org/get  - (Fetch.scala:15)
 You now have the spine of every Uni application you will write:
 
 1. **Parse** (`Launcher.execute`).
-2. **Wire** (`Design.newDesign...withSession`).
-3. **Do** (build the services you need, call them).
+2. **Wire** (`Design.newDesign...`).
+3. **Do** (`design.build[EntryPoint] { entry => ... }`).
 
 Everything else — more services, more wiring, more complex flows —
 slots into that spine.
@@ -199,11 +198,11 @@ the test would have to call `main` with monkey-patched globals. With
 
 **Lifecycle.** You saw a small example of this already:
 `.bindInstance[HttpSyncClient](...).onShutdown(_.close())` attaches the
-client's cleanup to the session. When `withSession` ends — whether the
-block completed normally or threw — the client's `close()` runs. A real
-app might add a database connection, a server, and a scheduler, each
-with its own hook. `withSession` is the single place that controls
-when they all wind down.
+client's cleanup to the session `design.build` opens. When the block
+returns — whether normally or by throwing — the session shuts down
+and the client's `close()` runs. A real app might add a database
+connection, a server, and a scheduler, each with its own hook. One
+block controls when they all wind down.
 
 **Locality of wiring.** The entire dependency graph of your program is
 visible in one `Design.newDesign...` block. Growing from one service to
@@ -260,7 +259,7 @@ You have written a Scala 3 CLI tool end to end:
 
 - Typed CLI arguments with `@option` and `@argument`.
 - Real HTTP calls through `Http.client.newSyncClient`.
-- Object wiring and lifecycle through `Design.withSession`.
+- Object wiring and lifecycle through `Design.build`.
 - A test suite that runs in milliseconds and has no external
   dependencies.
 

--- a/docs/book/ch03-00-design.md
+++ b/docs/book/ch03-00-design.md
@@ -1,0 +1,33 @@
+# 3. Wiring with Design
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+Part III goes back to the `Design` and `withSession` shape you already
+met in Parts I and II, and explains it properly. By the end of it you
+should be able to look at an unfamiliar `Design.newDesign...` block
+and know exactly what it is saying.
+
+Concepts introduced:
+
+- Why constructor injection is preferred over globals, service
+  locators, and runtime reflection.
+- `bindSingleton`, `bindImpl`, `bindInstance`, `bindProvider` — which
+  to reach for, and why.
+- Sessions, child sessions, and scoping: when one instance lives for
+  the whole process vs. per-request.
+- Lifecycle hooks (`onStart`, `onShutdown`) and how they compose with
+  `withSession`.
+- Overriding a design for tests (the foundation for Chapter 12).
+- Common mistakes and how to read the error messages Design produces.
+
+## Reference you can read now
+
+While this chapter is in progress, the reference page is complete:
+
+- [Design (module reference)](/core/design)
+
+[← 2. A URL Fetcher](./ch02-00-cli-app) | [Next → 4. Logging That Finds You](./ch04-00-logging)

--- a/docs/book/ch03-00-design.md
+++ b/docs/book/ch03-00-design.md
@@ -6,10 +6,10 @@ This chapter is an outline. The full draft ships in a follow-up PR.
 
 ## What this chapter will cover
 
-Part III goes back to the `Design` and `withSession` shape you already
-met in Parts I and II, and explains it properly. By the end of it you
-should be able to look at an unfamiliar `Design.newDesign...` block
-and know exactly what it is saying.
+Part III goes back to the `Design.build` shape you already met in
+Parts I and II, and explains it properly. By the end of it you should
+be able to look at an unfamiliar `Design.newDesign...` block and know
+exactly what it is saying.
 
 Concepts introduced:
 
@@ -17,10 +17,13 @@ Concepts introduced:
   locators, and runtime reflection.
 - `bindSingleton`, `bindImpl`, `bindInstance`, `bindProvider` — which
   to reach for, and why.
+- `design.build[A] { ... }` as the convenience entry point, and
+  `withSession` underneath it for cases where you need access to the
+  session itself.
 - Sessions, child sessions, and scoping: when one instance lives for
   the whole process vs. per-request.
 - Lifecycle hooks (`onStart`, `onShutdown`) and how they compose with
-  `withSession`.
+  sessions.
 - Overriding a design for tests (the foundation for Chapter 12).
 - Common mistakes and how to read the error messages Design produces.
 

--- a/docs/book/ch04-00-logging.md
+++ b/docs/book/ch04-00-logging.md
@@ -6,10 +6,10 @@ This chapter is an outline. The full draft ships in a follow-up PR.
 
 ## What this chapter will cover
 
-Logging is load-bearing infrastructure: the difference between a
-five-minute incident and a five-hour one is usually whether the right
-log line was in the right place, at the right level, with the right
-context.
+Logs in a Uni application are written for **a human reading output**,
+not for a log-aggregation pipeline to parse. That framing shapes what
+Uni's logger does, and — just as importantly — what it chooses not to
+do.
 
 Concepts introduced:
 
@@ -20,9 +20,11 @@ Concepts introduced:
 - Log levels and how to choose between them without lying to your
   future self.
 - Per-package log configuration at runtime.
-- Structured logging and how to attach context (request IDs,
-  user IDs) without string concatenation.
-- Formatting for humans (terminals) vs. machines (log aggregators).
+- Why Uni's logger intentionally has **no structured-logging API**:
+  logs are developer context, not machine-parsed records. When you
+  need fields, IDs, and correlation, reach for a telemetry tool
+  (metrics, traces) instead of encoding state into log lines.
+- Formatting choices for terminals and for log files.
 
 ## Reference you can read now
 

--- a/docs/book/ch04-00-logging.md
+++ b/docs/book/ch04-00-logging.md
@@ -1,0 +1,31 @@
+# 4. Logging That Finds You
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+Logging is load-bearing infrastructure: the difference between a
+five-minute incident and a five-hour one is usually whether the right
+log line was in the right place, at the right level, with the right
+context.
+
+Concepts introduced:
+
+- The `LogSupport` trait and why mixing it in beats passing a
+  `Logger` around.
+- Source-location capture: how Uni captures file and line at compile
+  time, and what that means at runtime.
+- Log levels and how to choose between them without lying to your
+  future self.
+- Per-package log configuration at runtime.
+- Structured logging and how to attach context (request IDs,
+  user IDs) without string concatenation.
+- Formatting for humans (terminals) vs. machines (log aggregators).
+
+## Reference you can read now
+
+- [Logging (module reference)](/core/logging)
+
+[← 3. Wiring with Design](./ch03-00-design) | [Next → 5. JSON & MessagePack](./ch05-00-data)

--- a/docs/book/ch05-00-data.md
+++ b/docs/book/ch05-00-data.md
@@ -1,0 +1,32 @@
+# 5. Data In, Data Out — JSON & MessagePack
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+Every service eats and produces data. This chapter covers how Uni
+turns bytes on the wire into Scala 3 case classes, and back, without
+per-type boilerplate.
+
+Concepts introduced:
+
+- `JSON` for parsing, mutation, and generation of JSON trees.
+- Case-class codecs via `Surface` — no annotation or companion
+  boilerplate required.
+- When to reach for MessagePack instead of JSON (size, performance,
+  binary-safe payloads).
+- Streaming: parsing documents larger than memory, and producing them
+  incrementally.
+- Error handling: what happens when the bytes do not match the type.
+- Interop with existing JSON libraries when you must speak someone
+  else's schema.
+
+## Reference you can read now
+
+- [JSON Processing](/core/json)
+- [MessagePack](/core/msgpack)
+- [Type Introspection (Surface)](/core/surface)
+
+[← 4. Logging That Finds You](./ch04-00-logging) | [Next → 6. Rx, the Composable Stream](./ch06-00-rx)

--- a/docs/book/ch06-00-rx.md
+++ b/docs/book/ch06-00-rx.md
@@ -1,0 +1,34 @@
+# 6. Rx, the Composable Stream
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+`Rx` is Uni's abstraction for anything that happens over time:
+asynchronous results, event streams, websockets, server-sent events,
+timers. It is a single type with a small set of operators, and it is
+the backbone of async code across the library.
+
+Concepts introduced:
+
+- `Rx[A]` as a description of "something that will produce zero or
+  more `A` values".
+- The four shapes: `single`, `stream`, `completable`, `never`, and
+  when each is the right pick.
+- The operator set: `map`, `flatMap`, `filter`, `take`,
+  `zip`, `merge`, `recover`.
+- How Rx composes with `Design` lifecycle: closing a session cancels
+  the streams it owns.
+- Backpressure, cancellation, and the common mistakes (`subscribe`
+  without a handle, unbounded buffering).
+
+## Reference you can read now
+
+- [Reactive Streams — Overview](/rx/)
+- [Rx Basics](/rx/basics)
+- [Rx Operators](/rx/operators)
+- [Rx Concurrency](/rx/concurrency)
+
+[← 5. JSON & MessagePack](./ch05-00-data) | [Next → 7. Retry, Circuit Breakers, Resources](./ch07-00-control)

--- a/docs/book/ch07-00-control.md
+++ b/docs/book/ch07-00-control.md
@@ -1,0 +1,35 @@
+# 7. Living With Failure — Retry, Circuit Breakers, Resources
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+Production code spends most of its time either failing or recovering
+from something that failed a moment ago. This chapter covers the three
+Uni primitives that let you write that gracefully: `Retry`,
+`CircuitBreaker`, and `Resource`.
+
+Concepts introduced:
+
+- Retry policies: exponential backoff, jitter, and which errors are
+  safe to retry (and which are dangerous to).
+- Circuit breakers: when a backend is clearly down, stop making it
+  worse. The state machine (closed → open → half-open) and how Uni
+  models it.
+- Idempotency as a precondition for retry — and how to tell whether
+  your call is idempotent.
+- `Resource` for scoped resource lifetimes that compose with `Design`
+  sessions.
+- Combining the three: the canonical "HTTP call with retry, circuit
+  breaker, and a bounded connection pool" pattern.
+
+## Reference you can read now
+
+- [Control Flow — Overview](/control/)
+- [Retry](/control/retry)
+- [Circuit Breaker](/control/circuit-breaker)
+- [Resource](/control/resource)
+
+[← 6. Rx, the Composable Stream](./ch06-00-rx) | [Next → 8. HTTP Clients and Servers](./ch08-00-http)

--- a/docs/book/ch08-00-http.md
+++ b/docs/book/ch08-00-http.md
@@ -1,0 +1,36 @@
+# 8. HTTP Clients and Servers
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+You met the HTTP client in Chapter 2. This chapter covers it
+properly, alongside the server that serves requests from the other
+side.
+
+Concepts introduced:
+
+- Sync vs. async clients: when to use each, and why most code should
+  start with sync.
+- Configuring the client: timeouts, retry, rate limiting, connection
+  pooling.
+- The REST server: defining endpoints, binding them to a Design, and
+  running them.
+- The Router: composing endpoints into a larger service, including
+  sub-routers.
+- Server-sent events and streaming responses.
+- Interop: how the client behaves identically on JVM, Scala.js, and
+  Scala Native.
+
+## Reference you can read now
+
+- [HTTP — Overview](/http/)
+- [HTTP Client](/http/client)
+- [REST Server](/http/server)
+- [Router](/http/router)
+- [Server-Sent Events](/http/sse)
+- [Retry Strategies](/http/retry)
+
+[← 7. Retry, Circuit Breakers, Resources](./ch07-00-control) | [Next → 9. Typed RPC](./ch09-00-rpc)

--- a/docs/book/ch09-00-rpc.md
+++ b/docs/book/ch09-00-rpc.md
@@ -1,0 +1,28 @@
+# 9. Typed RPC
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+Uni's RPC layer lets two services share a trait definition and get a
+working client + server pair, without per-endpoint glue code. This
+chapter walks through defining, implementing, and consuming an RPC
+service.
+
+Concepts introduced:
+
+- RPC traits: declaring an interface once, using it on both sides.
+- The wire format and why MessagePack is a sensible default.
+- Error handling across process boundaries: what your exception looks
+  like on the other side.
+- Evolving an RPC API without breaking existing clients.
+- When RPC is the right tool — and when to use plain HTTP / REST
+  instead.
+
+## Reference you can read now
+
+- [RPC](/http/rpc)
+
+[← 8. HTTP Clients and Servers](./ch08-00-http) | [Next → 10. Cross-Platform Development](./ch10-00-cross-platform)

--- a/docs/book/ch10-00-cross-platform.md
+++ b/docs/book/ch10-00-cross-platform.md
@@ -1,0 +1,32 @@
+# 10. One Codebase, Three Runtimes
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+Scala 3 can target the JVM, JavaScript (via Scala.js), and native
+binaries (via Scala Native). Uni is designed so that a single piece of
+business logic compiles to all three. This chapter takes a working
+JVM service and shows the minimum changes needed to also ship it as a
+browser app and as a native binary.
+
+Concepts introduced:
+
+- `sbt-crossproject`: one `build.sbt`, three platforms.
+- The `.jvm`, `.js`, and `.native` source folders and what belongs in
+  each.
+- Platform abstractions Uni gives you (HTTP, filesystem, timers) so
+  your code stays identical.
+- Things you *cannot* share: JVM-only file paths, browser-only DOM
+  access, native-only syscalls — and how to isolate them.
+- Building and distributing: a fat JAR, an optimized JS bundle, and a
+  stripped native binary.
+
+## Reference you can read now
+
+- [Design Principles — Cross-Platform First](/guide/principles#cross-platform-first)
+- [HTTP Client — platform notes](/http/client)
+
+[← 9. Typed RPC](./ch09-00-rpc) | [Next → 11. Building LLM Agents](./ch11-00-agent)

--- a/docs/book/ch11-00-agent.md
+++ b/docs/book/ch11-00-agent.md
@@ -1,0 +1,32 @@
+# 11. Building LLM Agents with uni-agent
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+`uni-agent` is Uni's LLM agent framework: a small set of abstractions
+for chat sessions, tool calling, and model orchestration. This
+chapter builds a working agent from the ground up.
+
+Concepts introduced:
+
+- What an "agent" is in this framework, as opposed to a raw chat
+  completion.
+- `ChatSession` for turn-taking conversations with persistent state.
+- Registering Scala functions as tools the model can call.
+- Switching between providers (AWS Bedrock, etc.) without changing
+  your business logic.
+- Testing agent code — what is deterministic, what is not, and how to
+  assert on either.
+
+## Reference you can read now
+
+- [Agent Framework — Overview](/agent/)
+- [LLM Agent](/agent/llm-agent)
+- [Chat Sessions](/agent/chat-session)
+- [Tool Integration](/agent/tools)
+- [AWS Bedrock](/agent/bedrock)
+
+[← 10. Cross-Platform Development](./ch10-00-cross-platform) | [Next → 12. Testing with UniTest](./ch12-00-testing)

--- a/docs/book/ch12-00-testing.md
+++ b/docs/book/ch12-00-testing.md
@@ -1,0 +1,29 @@
+# 12. Testing with UniTest
+
+::: warning Coming soon
+This chapter is an outline. The full draft ships in a follow-up PR.
+:::
+
+## What this chapter will cover
+
+Tests in a Uni codebase favor the real implementation with narrow
+substitutions, rather than deep mocking. This chapter covers the
+shape of a UniTest suite and how Design makes substitutions clean.
+
+Concepts introduced:
+
+- The `UniTest` base class and the assertion vocabulary (`shouldBe`,
+  `shouldContain`, `shouldMatch`).
+- Why the project avoids mocks, and what to do instead: narrow
+  overrides via `Design` and in-process fakes.
+- Property-based testing primitives.
+- Async tests with `Rx` and `Future`.
+- Cross-platform tests: writing one suite that runs under JVM,
+  Scala.js, and Scala Native.
+- Speed: keeping a Uni test suite under a second, and why that matters.
+
+## Reference you can read now
+
+- [UniTest (module reference)](/core/unitest)
+
+[← 11. Building LLM Agents](./ch11-00-agent) | [Next → Appendix A: Scala 3 Syntax Notes](./appendix-a-scala3)

--- a/docs/book/foreword.md
+++ b/docs/book/foreword.md
@@ -1,0 +1,46 @@
+# Foreword
+
+Scala 3 is a small, sharp language. The standard library is careful,
+the type system is expressive, and the compiler will happily tell you
+when your ideas do not fit together. Those are the good parts.
+
+The parts the standard library leaves to you are the ones every real
+application still has to answer:
+
+- How do my objects get wired together, and when are they cleaned up?
+- How do I structure logging so that when a request goes wrong, I find
+  the one line that mattered?
+- How do I ship an HTTP client that retries the right errors, and no
+  others?
+- How do I write one piece of business logic that runs in the JVM, in
+  a browser, and in a compiled binary?
+
+**Uni** is the collection of small, opinionated libraries that Scala
+applications reach for to answer those questions. It is a distillation
+of code from the [Airframe](https://github.com/wvlet/airframe) project,
+refined for Scala 3 and for a future where Scala.js and Scala Native
+are first-class targets, not afterthoughts.
+
+This book is the long-form counterpart to Uni's reference docs. The
+reference answers *"what does this API do?"*. This book answers *"how
+do I build real applications with these pieces, and why are the pieces
+shaped this way?"*. By the end of it, you should be able to open an
+empty directory and sketch, in your head, the file layout and the
+dependency graph of a reasonable Scala 3 service — and have opinions
+about each choice.
+
+You will build two things as you read:
+
+1. A small CLI application (Part II).
+2. A single codebase that compiles to the JVM, to JavaScript, and to a
+   native binary (Part VI).
+
+Along the way the book will explain, honestly, when Uni is the right
+tool and when a different tool would serve you better. No library
+earns trust by hiding its edges.
+
+Thank you for spending time with this. Let's start.
+
+— *The Uni team*
+
+[Next → Chapter 1: Getting Started](./ch01-00-getting-started)

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -1,0 +1,78 @@
+# The Uni Book
+
+*A guided tour of Scala 3 application development with Uni.*
+
+This book teaches you to build real applications with
+[Uni](https://github.com/wvlet/uni) on Scala 3, across the JVM,
+Scala.js, and Scala Native. It is written for developers who already
+read Scala comfortably and want to understand not only *how* Uni works
+but *why* its pieces are shaped the way they are.
+
+The Book is narrative. It is meant to be read front to back at first,
+and used as a jumping-off point afterwards. The short-form API
+documentation under [Guide](/guide/) and the module references
+(e.g. [Core](/core/), [HTTP](/http/), [Agent](/agent/)) stay where they
+are, and the Book links into them when you need depth.
+
+## How to read it
+
+- Work from Part I to the end of Part II in order. Everything that
+  follows assumes the mental model built in those two parts.
+- Each part opens with a short intro page; each chapter ends with a
+  *"what you have, what comes next"* recap. If the recap doesn't feel
+  true yet, re-read the chapter before moving on.
+- Type the examples. Reading them is not the same exercise.
+
+## Table of contents
+
+### [Foreword](./foreword)
+
+### Part I — Getting Started
+
+- [Chapter 1: Getting Started](./ch01-00-getting-started)
+  - [1.1 Installation](./ch01-01-installation)
+  - [1.2 Hello, Uni!](./ch01-02-hello-uni)
+
+### Part II — Building a CLI Application
+
+- [Chapter 2: A URL Fetcher](./ch02-00-cli-app)
+
+### Part III — Core Concepts
+
+- [Chapter 3: Wiring with Design](./ch03-00-design)
+- [Chapter 4: Logging That Finds You](./ch04-00-logging)
+- [Chapter 5: Data In, Data Out — JSON & MessagePack](./ch05-00-data)
+
+### Part IV — Async & Control Flow
+
+- [Chapter 6: Rx, the Composable Stream](./ch06-00-rx)
+- [Chapter 7: Living With Failure — Retry, Circuit Breakers, Resources](./ch07-00-control)
+
+### Part V — HTTP & RPC
+
+- [Chapter 8: HTTP Clients and Servers](./ch08-00-http)
+- [Chapter 9: Typed RPC](./ch09-00-rpc)
+
+### Part VI — Cross-Platform Development
+
+- [Chapter 10: One Codebase, Three Runtimes](./ch10-00-cross-platform)
+
+### Part VII — Agent Framework
+
+- [Chapter 11: Building LLM Agents with uni-agent](./ch11-00-agent)
+
+### Part VIII — Testing
+
+- [Chapter 12: Testing with UniTest](./ch12-00-testing)
+
+### Appendices
+
+- [Appendix A: Scala 3 Syntax Notes for This Book](./appendix-a-scala3)
+- [Appendix B: Uni and Airframe — History and Relationship](./appendix-b-airframe)
+- [Appendix C: Glossary](./appendix-c-glossary)
+
+## Status
+
+Parts I and II are drafted. Parts III through VIII are stubs with
+outlines; they will ship in follow-up pull requests. If a link leads to
+a "Coming soon" page, that is working as intended.

--- a/plans/2026-04-18-book-section.md
+++ b/plans/2026-04-18-book-section.md
@@ -1,0 +1,123 @@
+# The Uni Book — Documentation Section (Initial Scaffolding)
+
+Date: 2026-04-18
+Branch: `docs/book-section`
+
+## Goal
+
+Add a long-form, narrative **Book** section to the Uni documentation,
+modeled after *[The Rust Programming Language](https://doc.rust-lang.org/book/)*
+("The Rust Book"). Where the existing `/guide/` and module reference pages
+answer "what does this API do?", the Book answers "how do I build real
+applications with Scala 3 + Uni, and why?".
+
+The Book should gradually build a reader's mental model:
+
+1. **Set up tools** → 2. **Run a small program** → 3. **Explain the
+   concepts behind it** → 4. **Apply the concepts to a real project**.
+
+Each chapter should leave the reader with a concrete artifact (a file they
+ran) *and* an internal model (why it is shaped that way).
+
+## Why not extend `/guide/`?
+
+The existing `/guide/` is reference-oriented (module → APIs). The Book is
+task-oriented (goal → techniques). Keeping them separate avoids two
+failure modes:
+
+- Reference docs swelling into tutorials and becoming hard to scan.
+- Tutorials drifting into incomplete reference material.
+
+The Book links *into* reference pages. Reference pages do not need to link
+back.
+
+## Scope of this PR
+
+This PR establishes **scaffolding + writing guide**, not a completed
+book. Specifically:
+
+- `docs/book/CLAUDE.md` — a contributor guide (audience: future authors,
+  including Claude) describing tone, structure, and how each chapter
+  should be shaped.
+- `docs/book/index.md` — book landing page with the full table of
+  contents.
+- `docs/book/foreword.md` — short foreword explaining who the book is for
+  and how to read it.
+- **Part I — Getting Started** (drafted):
+  - `ch01-00-getting-started.md` (part intro)
+  - `ch01-01-installation.md` — prerequisites (JDK, sbt, Scala 3), adding
+    Uni to a project, and a minimal `build.sbt` for JVM/JS/Native.
+  - `ch01-02-hello-uni.md` — first program with Uni logging & `Design`.
+- **Part II — Building a CLI Application** (drafted skeleton):
+  - `ch02-00-cli-app.md` — a walkthrough building a small CLI tool
+    (e.g. a URL fetcher) that introduces `Design`, `Logger`, `HttpClient`,
+    `Launcher`, and `UniTest`. This mirrors the Rust book's Chapter 2
+    "Guessing Game" pattern: one end-to-end program before deep theory.
+- **Stubs for later parts** (short placeholder pages describing intent):
+  - Part III — Core Concepts (Design, Logging, Surface, JSON/MessagePack)
+  - Part IV — Async & Control Flow (Rx, Retry, Circuit Breaker, Resource)
+  - Part V — HTTP & RPC
+  - Part VI — Cross-Platform (JVM / Scala.js / Scala Native)
+  - Part VII — Agent Framework (uni-agent)
+  - Part VIII — Testing with UniTest
+  - Appendices (cheat sheets, interop, glossary)
+- VitePress sidebar + top-nav entry for `/book/`.
+
+Stubs carry a short "what this chapter will cover" paragraph and are
+explicitly marked *Coming soon* so the ToC reads as a real outline rather
+than dead links.
+
+## Writing philosophy (carried in `docs/book/CLAUDE.md`)
+
+Mirrors the Rust book's pedagogy:
+
+1. **Show, then name.** Introduce a shape in code before naming the
+   concept. Readers bind the name to something they have already seen
+   working.
+2. **Small programs before big concepts.** Chapter 2 is a full working
+   program using Uni primitives; theory comes after.
+3. **One new idea per section.** Each section adds exactly one concept on
+   top of what the reader already has.
+4. **Explain *why*, not just *how*.** Every non-obvious choice ("why
+   `Design` instead of passing constructor args?", "why avoid `Try[A]`?")
+   gets a short rationale paragraph.
+5. **Cross-platform by default.** Examples that work unchanged on JVM,
+   Scala.js, and Scala Native use a single snippet. Platform-specific
+   detours are called out with a box.
+6. **Runnable, not decorative.** Every code block is meant to actually
+   compile against the current Uni version. Snippets use Scala 3 syntax
+   (indentation-based, `new` omitted, `${...}` interpolation).
+
+## Structure conventions
+
+- File names: `chNN-MM-slug.md`. `NN` = part number, `MM` = section
+  within part. `00` is reserved for the part's intro page.
+- Each chapter ends with a short *"What you have, what comes next"*
+  recap.
+- Deep-dive reference links go in the body (inline), not as a footer
+  dump.
+- Snippets are full enough to run. If a snippet depends on earlier
+  context, it references the file/section where that context was
+  introduced.
+
+## Non-goals for this PR
+
+- Writing the full body of Parts III–VIII. Those are stubs here and will
+  be expanded in follow-up PRs, one part per PR, to keep reviews
+  tractable.
+- Restructuring `/guide/`, `/core/`, etc. — they stay as reference docs.
+- Automated snippet testing. A future PR can wire `mdoc`-style
+  verification; for now snippets are reviewed by hand.
+
+## Rollout
+
+1. Land this PR with scaffolding + Parts I & II drafted.
+2. Open a tracking issue listing remaining parts.
+3. Each subsequent part ships as its own PR referencing that issue, so
+   reviewers see one narrative at a time.
+
+## Validation
+
+- `npm run docs:build` succeeds (no broken links within the book).
+- `npm run docs:dev` renders the new section in the sidebar.
+- Sample snippets compile against the current Uni version (manual check).


### PR DESCRIPTION
## Summary

- Introduces `docs/book/` — a long-form, mental-model-first guide modeled after *[The Rust Programming Language](https://doc.rust-lang.org/book/)* — as a companion to the existing reference docs.
- Adds `docs/book/CLAUDE.md` (contributor writing guide) describing the book's pedagogy, style, and chapter shape. Excluded from the rendered site via `srcExclude`.
- Lands **Part I — Getting Started** (installation + Hello Uni) and **Part II — A URL Fetcher** end-to-end CLI walkthrough that introduces Launcher, HttpClient, Design, and UniTest together.
- Outlines Parts III–VIII plus appendices as *Coming soon* stubs so the ToC reads as a real outline; subsequent parts ship as their own PRs.
- Wires `/book/` into the top nav and adds a dedicated sidebar.

## Why

The existing `/guide/` and module pages answer *"what does this API do?"* but not *"how do I structure a real Scala 3 application with Uni, and why is it shaped this way?"*. The Book fills that gap so newcomers can build working intuition before diving into the reference.

Design notes and rationale live in `plans/2026-04-18-book-section.md`.

## Test plan

- [x] `npm run docs:build` succeeds with no broken links.
- [x] `/book/CLAUDE.html` is **not** emitted in the built site (`srcExclude` excludes it).
- [x] `codex review --uncommitted` feedback addressed: contributor-only page excluded from build; `contentAsString` unwrapped via `.getOrElse("")`; `HttpSyncClient` moved onto Design with `onShutdown(_.close())` for proper lifecycle.
- [ ] Manually skim the rendered site via `npm run docs:dev` to confirm sidebar/nav appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)