### PR TITLE
feature: Surface FileSystem and make IO the single entry point

### DIFF
--- a/docs/core/filesystem.md
+++ b/docs/core/filesystem.md
@@ -2,74 +2,79 @@
 
 Cross-platform file I/O abstraction for JVM, Scala.js (Node.js and browser), and Scala Native.
 
+Uni's `IO` object is the single entry point for file operations — it exposes path
+construction, reads, writes, directory listings, metadata, and async variants
+uniformly across platforms.
+
 ```scala
-import wvlet.uni.io.*
+import wvlet.uni.io.IO
 
 // Read and write files
-val content = FileSystem.readString(IOPath("config.json"))
-FileSystem.writeString(IOPath("output.txt"), "hello")
+val content = IO.readString(IO.path("config.json"))
+IO.writeString(IO.path("output.txt"), "hello")
 
 // Path operations
-val path = IOPath("/home/user") / "documents" / "file.txt"
+val path = IO.path("/home/user") / "documents" / "file.txt"
 println(path.fileName)   // "file.txt"
 println(path.extension)  // "txt"
 ```
 
-## IOPath
+## Paths
 
-`IOPath` is a cross-platform path abstraction that works consistently across all platforms.
+`IOPath` is uni's cross-platform path abstraction. Construct one through
+`IO.path(...)` and use it as the path type everywhere in the API.
 
 ### Creating Paths
 
 ```scala
-import wvlet.uni.io.IOPath
+import wvlet.uni.io.IO
 
 // From string
-val path = IOPath("/home/user/file.txt")
+val path = IO.path("/home/user/file.txt")
 
 // Join segments
-val joined = IOPath.of("home", "user", "file.txt")
+val joined = IO.path("home", "user", "file.txt")
 
 // Using / operator
-val composed = IOPath("/home") / "user" / "file.txt"
+val composed = IO.path("/home") / "user" / "file.txt"
 
 // Well-known directories
-val cwd  = IOPath.currentDir
-val home = IOPath.homeDir
-val tmp  = IOPath.tempDir
+val cwd  = IO.currentDirectory
+val home = IO.homeDirectory
+val tmp  = IO.tempDirectory
 ```
 
 ### Path Properties
 
 ```scala
-val path = IOPath("/home/user/project/README.md")
+val path = IO.path("/home/user/project/README.md")
 
 path.fileName    // "README.md"
 path.baseName    // "README"
 path.extension   // "md"
 path.isAbsolute  // true
 path.segments    // Seq("home", "user", "project", "README.md")
-path.parent      // Some(IOPath("/home/user/project"))
+path.parent      // Some(IO.path("/home/user/project"))
 ```
 
 ### Path Operations
 
 ```scala
 // Normalize . and ..
-IOPath("/home/user/../admin/./config").normalize
-// IOPath("/home/admin/config")
+IO.path("/home/user/../admin/./config").normalize
+// IO.path("/home/admin/config")
 
 // Relative path
-val base = IOPath("/home/user")
-val file = IOPath("/home/user/project/src/Main.scala")
-file.relativeTo(base)  // IOPath("project/src/Main.scala")
+val base = IO.path("/home/user")
+val file = IO.path("/home/user/project/src/Main.scala")
+file.relativeTo(base)  // IO.path("project/src/Main.scala")
 
 // POSIX format (always forward slashes)
 path.posixPath  // "/home/user/project/README.md"
 
 // Checks
-path.startsWith(IOPath("/home"))  // true
-path.endsWith(IOPath("README.md"))  // true
+path.startsWith(IO.path("/home"))  // true
+path.endsWith(IO.path("README.md"))  // true
 ```
 
 ## Reading and Writing Files
@@ -77,41 +82,41 @@ path.endsWith(IOPath("README.md"))  // true
 ### Reading Files
 
 ```scala
-import wvlet.uni.io.{FileSystem, IOPath}
+import wvlet.uni.io.IO
 
-val path = IOPath("data.txt")
+val path = IO.path("data.txt")
 
 // Read as string (UTF-8)
-val text: String = FileSystem.readString(path)
+val text: String = IO.readString(path)
 
 // Read as bytes
-val bytes: Array[Byte] = FileSystem.readBytes(path)
+val bytes: Array[Byte] = IO.readBytes(path)
 
 // Read line by line
-val lines: Seq[String] = FileSystem.readLines(path)
+val lines: Seq[String] = IO.readLines(path)
 ```
 
 ### Writing Files
 
 ```scala
-import wvlet.uni.io.{FileSystem, IOPath, WriteMode}
+import wvlet.uni.io.{IO, WriteMode}
 
-val path = IOPath("output.txt")
+val path = IO.path("output.txt")
 
 // Create or overwrite (default)
-FileSystem.writeString(path, "hello world")
+IO.writeString(path, "hello world")
 
 // Create new file, fail if exists
-FileSystem.writeString(path, "content", WriteMode.CreateNew)
+IO.writeString(path, "content", WriteMode.CreateNew)
 
 // Append to file
-FileSystem.writeString(path, "more content", WriteMode.Append)
+IO.writeString(path, "more content", WriteMode.Append)
 
 // Write bytes
-FileSystem.writeBytes(path, Array[Byte](1, 2, 3))
+IO.writeBytes(path, Array[Byte](1, 2, 3))
 
 // Append shorthand
-FileSystem.appendString(path, "\nnew line")
+IO.appendString(path, "\nnew line")
 ```
 
 ### WriteMode
@@ -127,93 +132,95 @@ FileSystem.appendString(path, "\nnew line")
 ### Listing Files
 
 ```scala
-import wvlet.uni.io.{FileSystem, IOPath, ListOptions}
+import wvlet.uni.io.{IO, ListOptions}
 
-val dir = IOPath("src")
+val dir = IO.path("src")
 
 // List immediate children
-val files = FileSystem.list(dir)
+val files = IO.list(dir)
 
 // Recursive listing
-val allFiles = FileSystem.list(dir, ListOptions().withRecursive(true))
+val allFiles = IO.list(dir, ListOptions().withRecursive(true))
 
 // Filter by extension
-val scalaFiles = FileSystem.list(dir,
+val scalaFiles = IO.list(dir,
   ListOptions()
     .withRecursive(true)
     .withExtensions("scala")
 )
 
 // Filter by glob pattern
-val testFiles = FileSystem.list(dir,
+val testFiles = IO.list(dir,
   ListOptions()
     .withRecursive(true)
     .withGlob("**/*Test.scala")
 )
 
 // Limit depth
-val shallow = FileSystem.list(dir,
+val shallow = IO.list(dir,
   ListOptions()
     .withRecursive(true)
     .withMaxDepth(2)
 )
 
 // Include hidden files
-val withHidden = FileSystem.list(dir, ListOptions().withIncludeHidden(true))
+val withHidden = IO.list(dir, ListOptions().withIncludeHidden(true))
 ```
 
 ### Creating, Deleting, Copying, Moving
 
 ```scala
+import wvlet.uni.io.{IO, CopyOptions}
+
 // Create directory (including parents)
-FileSystem.createDirectory(IOPath("a/b/c"))
+IO.createDirectory(IO.path("a/b/c"))
 
 // Create only if it doesn't exist
-FileSystem.createDirectoryIfNotExists(IOPath("output"))
+IO.createDirectoryIfNotExists(IO.path("output"))
 
 // Delete file or empty directory
-FileSystem.delete(IOPath("temp.txt"))
+IO.delete(IO.path("temp.txt"))
 
 // Delete recursively
-FileSystem.deleteRecursively(IOPath("build"))
+IO.deleteRecursively(IO.path("build"))
 
 // Delete if exists (no error if missing)
-FileSystem.deleteIfExists(IOPath("maybe.txt"))
+IO.deleteIfExists(IO.path("maybe.txt"))
 
 // Copy
-FileSystem.copy(IOPath("src.txt"), IOPath("dst.txt"))
-FileSystem.copy(IOPath("srcDir"), IOPath("dstDir"),
+IO.copy(IO.path("src.txt"), IO.path("dst.txt"))
+IO.copy(IO.path("srcDir"), IO.path("dstDir"),
   CopyOptions().withOverwrite(true).withPreserveAttributes(true)
 )
 
 // Move / rename
-FileSystem.move(IOPath("old.txt"), IOPath("new.txt"))
-FileSystem.move(IOPath("old.txt"), IOPath("new.txt"), overwrite = true)
+IO.move(IO.path("old.txt"), IO.path("new.txt"))
+IO.move(IO.path("old.txt"), IO.path("new.txt"), overwrite = true)
 ```
 
 ### Temporary Files
 
 ```scala
 // Temporary file
-val tmpFile = FileSystem.createTempFile(prefix = "data", suffix = ".json")
+val tmpFile = IO.createTempFile(prefix = "data", suffix = ".json")
 
 // Temporary directory
-val tmpDir = FileSystem.createTempDirectory(prefix = "work")
+val tmpDir = IO.createTempDirectory(prefix = "work")
 
 // In a specific directory
-val custom = FileSystem.createTempFile(
+val custom = IO.createTempFile(
   prefix = "report",
   suffix = ".csv",
-  directory = Some(IOPath("output"))
+  directory = Some(IO.path("output"))
 )
 ```
 
 ## File Metadata
 
 ```scala
-import wvlet.uni.io.{FileSystem, IOPath, FileType}
+import wvlet.uni.io.{IO, FileType}
 
-val info = FileSystem.info(IOPath("README.md"))
+val info = IO.info(IO.path("README.md"))
 
 info.fileType      // FileType.File
 info.size          // file size in bytes
@@ -227,9 +234,9 @@ info.isExecutable  // false
 info.isHidden      // false
 
 // Existence checks
-FileSystem.exists(IOPath("README.md"))       // true
-FileSystem.isFile(IOPath("README.md"))       // true
-FileSystem.isDirectory(IOPath("src"))        // true
+IO.exists(IO.path("README.md"))       // true
+IO.isFile(IO.path("README.md"))       // true
+IO.isDirectory(IO.path("src"))        // true
 ```
 
 ### FileType
@@ -247,31 +254,34 @@ FileSystem.isDirectory(IOPath("src"))        // true
 All async operations return `Future[...]` and work on every platform, including browsers.
 
 ```scala
-import wvlet.uni.io.{FileSystem, IOPath}
+import wvlet.uni.io.{IO, IOPath, FileInfo}
 import scala.concurrent.Future
 
 // Async read/write
-val content: Future[String] = FileSystem.readStringAsync(IOPath("data.txt"))
-val bytes: Future[Array[Byte]] = FileSystem.readBytesAsync(IOPath("image.png"))
+val content: Future[String] = IO.readStringAsync(IO.path("data.txt"))
+val bytes: Future[Array[Byte]] = IO.readBytesAsync(IO.path("image.png"))
 
-val written: Future[Unit] = FileSystem.writeStringAsync(
-  IOPath("output.txt"), "hello"
+val written: Future[Unit] = IO.writeStringAsync(
+  IO.path("output.txt"), "hello"
 )
 
 // Async directory listing
-val files: Future[Seq[IOPath]] = FileSystem.listAsync(IOPath("src"))
+val files: Future[Seq[IOPath]] = IO.listAsync(IO.path("src"))
 
 // Async metadata
-val info: Future[FileInfo] = FileSystem.infoAsync(IOPath("file.txt"))
-val exists: Future[Boolean] = FileSystem.existsAsync(IOPath("file.txt"))
+val info: Future[FileInfo] = IO.infoAsync(IO.path("file.txt"))
+val exists: Future[Boolean] = IO.existsAsync(IO.path("file.txt"))
 ```
+
+`IOPath` and `FileInfo` are the underlying types — import them when you need
+explicit type annotations.
 
 ## Gzip Compression
 
 Cross-platform gzip utilities for compressing and decompressing data.
 
 ```scala
-import wvlet.uni.io.{Gzip, IOPath}
+import wvlet.uni.io.{IO, Gzip}
 
 // In-memory compression
 val data = "hello world".getBytes("UTF-8")
@@ -279,8 +289,8 @@ val compressed = Gzip.compress(data)
 val decompressed = Gzip.decompress(compressed)
 
 // File-based compression (streaming)
-Gzip.compressFile(IOPath("large.txt"), IOPath("large.txt.gz"))
-Gzip.decompressFile(IOPath("large.txt.gz"), IOPath("large.txt"))
+Gzip.compressFile(IO.path("large.txt"), IO.path("large.txt.gz"))
+Gzip.decompressFile(IO.path("large.txt.gz"), IO.path("large.txt"))
 ```
 
 ## Cross-Platform Support
@@ -298,7 +308,7 @@ Sync operations throw `UnsupportedOperationException` in browser environments. U
 
 ## Best Practices
 
-1. **Use `IOPath`** instead of raw strings for file paths
+1. **Use `IO` as the single entry point** — `IO.path(...)`, `IO.readString(...)`, `IO.list(...)`, etc.
 2. **Prefer async operations** for code that must run on all platforms
 3. **Use `ListOptions`** with glob or extension filters instead of filtering results manually
 4. **Use `WriteMode.CreateNew`** when you want to avoid overwriting existing files

--- a/docs/core/io.md
+++ b/docs/core/io.md
@@ -11,6 +11,10 @@ import wvlet.uni.io.IO
 `IO` exposes all cross-platform file system operations from `FileSystem`:
 
 ```scala
+// Construct paths
+val path = IO.path("file.txt")
+val dir  = IO.path("some", "nested", "dir")
+
 // Read and write files
 val content = IO.readString(path)
 IO.writeString(path, "hello", WriteMode.Create)
@@ -136,10 +140,10 @@ else
 All three methods accept a `ProcessConfig` for advanced options:
 
 ```scala
-import wvlet.uni.io.{IO, ProcessConfig, IOPath}
+import wvlet.uni.io.{IO, ProcessConfig}
 
 val config = ProcessConfig.default
-  .withWorkingDirectory(IOPath("/tmp"))
+  .withWorkingDirectory(IO.path("/tmp"))
   .withEnv("MY_VAR", "value")
   .withRedirectErrorToOutput(true)
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -11,6 +11,7 @@ Uni provides:
 - **Design** - Object wiring with lifecycle management
 - **Logging** - Structured logging with source code location tracking
 - **Serialization** - JSON parsing/generation and MessagePack binary format
+- **FileSystem** - Cross-platform file I/O and path handling for JVM, Scala.js (Node and browser), and Scala Native — a capability that the standard Scala ecosystem historically lacked
 - **HTTP Client** - Cross-platform client with retry and streaming support
 - **Reactive Streams** - Rx-based operators for async data flows
 - **Control Flow** - Retry logic, circuit breakers, and resource management
@@ -38,6 +39,7 @@ uni follows these principles:
 | [JSON](/core/json) | JSON parsing and generation |
 | [MessagePack](/core/msgpack) | Binary serialization format |
 | [Surface](/core/surface) | Compile-time type introspection |
+| [FileSystem](/core/filesystem) | Cross-platform file I/O with `IOPath` for JVM, Scala.js, and Scala Native |
 | [HTTP](/http/) | HTTP client with retry and streaming support |
 | [Rx](/rx/) | Reactive streams and async data flows |
 | [Control](/control/) | Retry logic, circuit breakers, and caching |

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -11,7 +11,7 @@ Uni provides:
 - **Design** - Object wiring with lifecycle management
 - **Logging** - Structured logging with source code location tracking
 - **Serialization** - JSON parsing/generation and MessagePack binary format
-- **FileSystem** - Cross-platform file I/O and path handling for JVM, Scala.js (Node and browser), and Scala Native — a capability that the standard Scala ecosystem historically lacked
+- **FileSystem** - Cross-platform file I/O and path handling for JVM, Scala.js, and Scala Native
 - **HTTP Client** - Cross-platform client with retry and streaming support
 - **Reactive Streams** - Rx-based operators for async data flows
 - **Control Flow** - Retry logic, circuit breakers, and resource management

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,8 @@ hero:
 
 features:
   - title: Core Primitives
-    details: Logging, Design (object wiring), Rx (async programming), and unified serialization through JSON and MessagePack.
+    details: Logging, Design (object wiring), Rx (async programming), unified JSON/MessagePack serialization, and a cross-platform FileSystem that works on JVM, Scala.js, and Scala Native.
     link: /core/
-  - title: Cross-Platform FileSystem
-    details: Uniform file I/O and path handling across JVM, Scala.js (Node and browser), and Scala Native — a gap in the standard Scala ecosystem.
-    link: /core/filesystem
   - title: HTTP Client & Server
     details: Full-featured HTTP with automatic retry, circuit breaker, rate limiting, and streaming support.
     link: /http/

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,9 @@ features:
   - title: Core Primitives
     details: Logging, Design (object wiring), Rx (async programming), and unified serialization through JSON and MessagePack.
     link: /core/
+  - title: Cross-Platform FileSystem
+    details: Uniform file I/O and path handling across JVM, Scala.js (Node and browser), and Scala Native — a gap in the standard Scala ecosystem.
+    link: /core/filesystem
   - title: HTTP Client & Server
     details: Full-featured HTTP with automatic retry, circuit breaker, rate limiting, and streaming support.
     link: /http/

--- a/docs/uni-walkthrough.md
+++ b/docs/uni-walkthrough.md
@@ -9,6 +9,7 @@ This walkthrough provides a comprehensive guide to using `uni`, the foundational
 - [Logging](#logging)
 - [JSON Processing](#json-processing)
 - [MessagePack Serialization](#messagepack-serialization)
+- [FileSystem](#filesystem)
 - [Reactive Streams (Rx)](#reactive-streams-rx)
 - [Control Flow Utilities](#control-flow-utilities)
 - [Surface (Type Reflection)](#surface-type-reflection)
@@ -224,6 +225,72 @@ val age = unpacker.unpackInt()
 
 // For complex objects, use Weaver (see Object Weaving section)
 ```
+
+## FileSystem
+
+Scala historically lacked a cross-platform file I/O abstraction that works
+uniformly on JVM, Scala.js (Node and browser), and Scala Native. Uni's
+`wvlet.uni.io` package fills that gap with `IOPath` and `FileSystem`, so
+the same code handles paths, reads, writes, and directory listings on
+every supported platform.
+
+### Paths with IOPath
+
+```scala
+import wvlet.uni.io.IOPath
+
+val path = IOPath("/home/user") / "project" / "README.md"
+path.fileName    // "README.md"
+path.extension   // "md"
+path.parent      // Some(IOPath("/home/user/project"))
+
+// Well-known directories
+val cwd  = IOPath.currentDir
+val home = IOPath.homeDir
+val tmp  = IOPath.tempDir
+```
+
+### Reading and Writing
+
+```scala
+import wvlet.uni.io.{FileSystem, IOPath, WriteMode}
+
+val path = IOPath("data.txt")
+
+// Synchronous read/write (JVM, Node.js, Native)
+val text: String = FileSystem.readString(path)
+FileSystem.writeString(path, "hello")
+
+// Create-new and append modes
+FileSystem.writeString(path, "content", WriteMode.CreateNew)
+FileSystem.writeString(path, "more", WriteMode.Append)
+```
+
+### Directory Listing
+
+```scala
+import wvlet.uni.io.{FileSystem, IOPath, ListOptions}
+
+val scalaSources = FileSystem.list(
+  IOPath("src"),
+  ListOptions().withRecursive(true).withExtensions("scala")
+)
+```
+
+### Async for Every Platform
+
+Browser Scala.js cannot run the synchronous APIs; use the `Async` variants
+for code that must work everywhere, including in a browser.
+
+```scala
+import wvlet.uni.io.{FileSystem, IOPath}
+import scala.concurrent.Future
+
+val content: Future[String] = FileSystem.readStringAsync(IOPath("data.txt"))
+```
+
+See [FileSystem](/core/filesystem) for the full reference, including
+copy/move, metadata, temporary files, and gzip utilities.
 
 ## Reactive Streams (Rx)
 

--- a/docs/uni-walkthrough.md
+++ b/docs/uni-walkthrough.md
@@ -230,63 +230,65 @@ val age = unpacker.unpackInt()
 
 Scala historically lacked a cross-platform file I/O abstraction that works
 uniformly on JVM, Scala.js (Node and browser), and Scala Native. Uni's
-`wvlet.uni.io` package fills that gap with `IOPath` and `FileSystem`, so
-the same code handles paths, reads, writes, and directory listings on
-every supported platform.
+`wvlet.uni.io.IO` object is the single entry point that fills that gap —
+path construction, reads, writes, directory listings, and async variants
+all live on `IO`, working the same way on every supported platform.
 
-### Paths with IOPath
+### Paths
 
 ```scala
-import wvlet.uni.io.IOPath
+import wvlet.uni.io.IO
 
-val path = IOPath("/home/user") / "project" / "README.md"
+val path = IO.path("/home/user") / "project" / "README.md"
 path.fileName    // "README.md"
 path.extension   // "md"
-path.parent      // Some(IOPath("/home/user/project"))
+
+// Join segments directly
+val nested = IO.path("home", "user", "file.txt")
 
 // Well-known directories
-val cwd  = IOPath.currentDir
-val home = IOPath.homeDir
-val tmp  = IOPath.tempDir
+val cwd  = IO.currentDirectory
+val home = IO.homeDirectory
+val tmp  = IO.tempDirectory
 ```
 
 ### Reading and Writing
 
 ```scala
-import wvlet.uni.io.{FileSystem, IOPath, WriteMode}
+import wvlet.uni.io.{IO, WriteMode}
 
-val path = IOPath("data.txt")
+val path = IO.path("data.txt")
 
 // Synchronous read/write (JVM, Node.js, Native)
-val text: String = FileSystem.readString(path)
-FileSystem.writeString(path, "hello")
+val text: String = IO.readString(path)
+IO.writeString(path, "hello")
 
 // Create-new and append modes
-FileSystem.writeString(path, "content", WriteMode.CreateNew)
-FileSystem.writeString(path, "more", WriteMode.Append)
+IO.writeString(path, "content", WriteMode.CreateNew)
+IO.writeString(path, "more", WriteMode.Append)
 ```
 
 ### Directory Listing
 
 ```scala
-import wvlet.uni.io.{FileSystem, IOPath, ListOptions}
+import wvlet.uni.io.{IO, ListOptions}
 
-val scalaSources = FileSystem.list(
-  IOPath("src"),
+val scalaSources = IO.list(
+  IO.path("src"),
   ListOptions().withRecursive(true).withExtensions("scala")
 )
 ```
 
 ### Async for Every Platform
 
-Browser Scala.js cannot run the synchronous APIs; use the `Async` variants
-for code that must work everywhere, including in a browser.
+Scala.js in the browser cannot run the synchronous APIs; use the `Async`
+variants for code that must work everywhere, including in a browser.
 
 ```scala
-import wvlet.uni.io.{FileSystem, IOPath}
+import wvlet.uni.io.IO
 import scala.concurrent.Future
 
-val content: Future[String] = FileSystem.readStringAsync(IOPath("data.txt"))
+val content: Future[String] = IO.readStringAsync(IO.path("data.txt"))
 ```
 
 See [FileSystem](/core/filesystem) for the full reference, including

--- a/plans/2026-04-18-filesystem-docs-visibility.md
+++ b/plans/2026-04-18-filesystem-docs-visibility.md
@@ -43,3 +43,27 @@ new surfaces should be brief with links into it.
 - FileSystem appears in `/guide/` intro list and module table.
 - Walkthrough has a FileSystem section with working examples.
 - `npm run docs:build` succeeds (no broken links, no markdown errors).
+
+## PR-cycle follow-ups (added during review)
+
+After the first review, the FileSystem mention was folded into the existing
+"Core Primitives" feature card on the landing page rather than introduced as
+a fifth card — keeps the hero section focused on four categories.
+
+Scope was then expanded to make `IO` a true single entry point for file
+operations:
+
+- Added `IO.path(first: String, rest: String*): IOPath` (delegates to
+  `IOPath.of`) so users can construct paths, read, write, list, and
+  execute subprocesses all through one `IO` name.
+- Swept `docs/core/filesystem.md`, `docs/core/io.md`, and the walkthrough
+  FileSystem section to use `IO.*` consistently instead of mixing
+  `FileSystem.*` and `IOPath(...)`. `IOPath` remains the underlying type
+  and is still imported when explicit type annotations are needed.
+- 3 new tests in `IOFileSystemTest` cover parse, segment-join, and an
+  `IO.writeString` / `IO.readString` round-trip through `IO.path`.
+
+Rationale: the existing `IO` doc page already pitched `IO` as the unified
+facade, but `FileSystem.*` and `IOPath(...)` were still the default names
+in examples. Adding `IO.path` closes the gap and makes the "one entry
+point" promise real.

--- a/plans/2026-04-18-filesystem-docs-visibility.md
+++ b/plans/2026-04-18-filesystem-docs-visibility.md
@@ -1,0 +1,45 @@
+# Raise FileSystem visibility in docs
+
+## Problem
+
+Scala historically lacked a cross-platform file I/O abstraction that works
+uniformly on JVM, Scala.js (Node and browser), and Scala Native. `uni.io`
+fills that gap with `FileSystem` and `IOPath`, and this is one of uni's
+more distinguishing features.
+
+Currently, `FileSystem` is documented at `/core/filesystem` and listed in
+the sidebar, but it is missing from the higher-traffic discovery surfaces:
+
+- `docs/index.md` — landing page `features` block (shown on the home page).
+- `docs/guide/index.md` — "What is Uni?" bullet list and module table.
+- `docs/uni-walkthrough.md` — full walkthrough of the main APIs.
+
+A reader who lands on the home page or the intro guide would not learn
+that uni provides cross-platform filesystem support at all.
+
+## Changes
+
+1. **`docs/index.md`** — add a FileSystem feature card to the `features`
+   list on the hero section, with copy that highlights the cross-platform
+   gap uni fills.
+2. **`docs/guide/index.md`** — add a FileSystem bullet to the "What is
+   Uni?" list and a row in the module table pointing to `/core/filesystem`.
+3. **`docs/uni-walkthrough.md`** — add a "FileSystem" section with a brief
+   cross-platform framing and minimal examples (path composition,
+   sync/async read-write, directory listing). Update the Table of Contents.
+
+Keep existing `docs/core/filesystem.md` as the canonical reference; the
+new surfaces should be brief with links into it.
+
+## Out of scope
+
+- Restructuring sidebar ordering.
+- Moving FileSystem out of the `Core` sidebar group.
+- Changing the `/core/io.md` subprocess content.
+
+## Success criteria
+
+- FileSystem appears on `/` landing page features.
+- FileSystem appears in `/guide/` intro list and module table.
+- Walkthrough has a FileSystem section with working examples.
+- `npm run docs:build` succeeds (no broken links, no markdown errors).

--- a/uni-core/src/main/scala/wvlet/uni/io/IO.scala
+++ b/uni-core/src/main/scala/wvlet/uni/io/IO.scala
@@ -221,14 +221,25 @@ end ProcessApi
   * import wvlet.uni.io.IO
   *
   * // File operations
-  * val content = IO.readString(IOPath("file.txt"))
-  * IO.writeString(IOPath("out.txt"), "hello")
+  * val content = IO.readString(IO.path("file.txt"))
+  * IO.writeString(IO.path("out.txt"), "hello")
   *
   * // Process execution
   * val result = IO.run("ls -la")
   * }}}
   */
 object IO extends IOCompat:
+
+  /**
+    * Creates an [[IOPath]] from a path string, or by joining multiple path segments.
+    *
+    * {{{
+    * IO.path("/home/user/file.txt")       // parsed as an absolute path
+    * IO.path("home", "user", "file.txt")  // joined from segments
+    * }}}
+    */
+  def path(first: String, rest: String*): IOPath = IOPath.of(first, rest*)
+
   export FileSystem.{
     currentDirectory,
     homeDirectory,

--- a/uni/.jvm/src/test/scala/wvlet/uni/io/IOFileSystemTest.scala
+++ b/uni/.jvm/src/test/scala/wvlet/uni/io/IOFileSystemTest.scala
@@ -77,4 +77,27 @@ class IOFileSystemTest extends UniTest:
     IO.isDirectory(cwd) shouldBe true
   }
 
+  test("IO.path should parse a path string") {
+    val p = IO.path("/home/user/file.txt")
+    p.isAbsolute shouldBe true
+    p.segments shouldBe Seq("home", "user", "file.txt")
+    p.fileName shouldBe "file.txt"
+  }
+
+  test("IO.path should join segments") {
+    val p = IO.path("home", "user", "file.txt")
+    p.isAbsolute shouldBe false
+    p.segments shouldBe Seq("home", "user", "file.txt")
+  }
+
+  test("IO.path should compose with FileSystem operations") {
+    val tmpDir  = IO.createTempDirectory("io-path-test", None)
+    val tmpFile = IO.path(tmpDir.posixPath, "nested.txt")
+    try
+      IO.writeString(tmpFile, "io.path works", WriteMode.Create)
+      IO.readString(tmpFile) shouldBe "io.path works"
+    finally
+      IO.deleteRecursively(tmpDir)
+  }
+
 end IOFileSystemTest

--- a/uni/.jvm/src/test/scala/wvlet/uni/io/IOFileSystemTest.scala
+++ b/uni/.jvm/src/test/scala/wvlet/uni/io/IOFileSystemTest.scala
@@ -90,7 +90,7 @@ class IOFileSystemTest extends UniTest:
     p.segments shouldBe Seq("home", "user", "file.txt")
   }
 
-  test("IO.path should compose with FileSystem operations") {
+  test("IO.path should compose with IO operations") {
     val tmpDir  = IO.createTempDirectory("io-path-test", None)
     val tmpFile = IO.path(tmpDir.posixPath, "nested.txt")
     try


### PR DESCRIPTION
## Summary

Raise the visibility of uni's cross-platform filesystem and consolidate `IO` as the single user-facing entry point for file operations.

**Docs — visibility**
- `docs/index.md`: fold FileSystem into the existing **Core Primitives** feature card on the landing page.
- `docs/guide/index.md`: add FileSystem to the "What is Uni?" bullet list and the module table.
- `docs/uni-walkthrough.md`: add a new **FileSystem** section (paths, sync/async read-write, directory listing) plus a TOC entry.
- Frames the capability around the real gap it fills — Scala historically lacked a file I/O abstraction that works uniformly on JVM, Scala.js (Node and browser), and Scala Native.

**Code — `IO` as single entry point**
- Add `IO.path(first: String, rest: String*): IOPath` (delegates to `IOPath.of`) so path construction, reads, writes, listing, and subprocess execution are all reachable from one `IO` name.
- Sweep `docs/core/filesystem.md`, `docs/core/io.md`, and the walkthrough's FileSystem section to use `IO.*` / `IO.path(...)` consistently instead of mixing `FileSystem.*` and `IOPath(...)`.
- `IOPath` remains the underlying type — still imported when explicit type annotations are needed.

**Tests**
- 3 new cases in `IOFileSystemTest`: string parse, segment join, and an `IO.writeString` / `IO.readString` round-trip through `IO.path`.

## Test plan

- [x] `./sbt "uniJVM/testOnly *IOFileSystemTest *IOPathTest *FileSystemTest"` — 54 pass.
- [x] `./sbt scalafmtAll` runs clean.
- [x] `npm run docs:build` passes with no broken links.
- [x] Full CI green on Scala 3, Scala.js, Integration, sbt plugin scripted, docs build, format checks (Scala Native + sbt scripted in flight at auto-merge time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)