### PR TITLE
docs: Document the RateLimiter utility

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,6 +179,7 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Overview', link: '/control/' },
             { text: 'Retry Logic', link: '/control/retry' },
             { text: 'Circuit Breaker', link: '/control/circuit-breaker' },
+            { text: 'Rate Limiter', link: '/control/rate-limiter' },
             { text: 'Caching', link: '/control/cache' },
             { text: 'Resource Management', link: '/control/resource' }
           ]
@@ -254,6 +255,7 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Overview', link: '/control/' },
             { text: 'Retry Logic', link: '/control/retry' },
             { text: 'Circuit Breaker', link: '/control/circuit-breaker' },
+            { text: 'Rate Limiter', link: '/control/rate-limiter' },
             { text: 'Caching', link: '/control/cache' },
             { text: 'Resource Management', link: '/control/resource' }
           ]

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -9,16 +9,14 @@ its own guide). Framework: VitePress 2 (`docs/.vitepress/config.mts`,
 Reference pages are contractual. Users paste snippets. Before documenting
 any method, Builder option, factory, or behavior:
 
-- **Read the source** and confirm signature, defaults, return type.
-- **Check that Builder fields are read, not just stored.** A `case class
-  Builder` may declare a field (`warmupPeriodMillis`, `name`) that no
-  implementation ever consumes. `Grep` for `config.fieldName` usage
-  before mentioning it.
-- **Blocking vs virtual time.** A manual `Ticker` fast-forwards refill
-  state; it does **not** skip `Thread.sleep` inside `acquire`/similar
-  blocking calls. Verify which path the snippet exercises.
-- **Platform matters.** Check whether the API lives under `src/` (shared)
-  or `.jvm/` / `.js/` / `.native/`. Call it out if platform-specific.
+- **Read the source** and confirm signature, defaults, and return type.
+- **Confirm config fields are actually consumed**, not just declared.
+  Grep the implementation for each field before documenting it.
+- **Confirm described behavior matches the code path the snippet
+  exercises** (e.g. whether a call blocks, is async, or only reads
+  state).
+- **Call out platform scope.** APIs live under `src/` (shared) or
+  `.jvm/` / `.js/` / `.native/`. Flag anything platform-specific.
 
 If any of the above is unverified, drop the claim.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,164 +1,43 @@
-# Writing Guide — Uni Reference Docs
+# docs/ — Contributor Notes
 
-> This file is for contributors (humans and Claude) writing the
-> **reference** docs under `docs/` (everything outside `docs/book/`,
-> which has its own [CLAUDE.md](./book/CLAUDE.md)). It is excluded from
-> the rendered site via VitePress's `srcExclude` config.
+Applies to reference pages under `docs/` (not `docs/book/`, which has
+its own guide). Framework: VitePress 2 (`docs/.vitepress/config.mts`,
+`package.json`).
 
-## Rule #0 — Verify before you write
+## Rule #0 — Verify every API claim against source
 
-**Every symbol, method signature, option name, and behavior mentioned in
-a reference page MUST correspond to code that exists in this repository
-right now.** Reference docs are contractual: users paste snippets into
-their code. If a doc promises `withWarmupPeriod(...)` and the builder
-silently ignores it, the bug is on us.
+Reference pages are contractual. Users paste snippets. Before documenting
+any method, Builder option, factory, or behavior:
 
-Before claiming an API exists:
+- **Read the source** and confirm signature, defaults, return type.
+- **Check that Builder fields are read, not just stored.** A `case class
+  Builder` may declare a field (`warmupPeriodMillis`, `name`) that no
+  implementation ever consumes. `Grep` for `config.fieldName` usage
+  before mentioning it.
+- **Blocking vs virtual time.** A manual `Ticker` fast-forwards refill
+  state; it does **not** skip `Thread.sleep` inside `acquire`/similar
+  blocking calls. Verify which path the snippet exercises.
+- **Platform matters.** Check whether the API lives under `src/` (shared)
+  or `.jvm/` / `.js/` / `.native/`. Call it out if platform-specific.
 
-1. **Read the source.** Open the module file (e.g.
-   `uni/.jvm/src/main/scala/wvlet/uni/control/RateLimiter.scala`) and
-   confirm the method, signature, default values, and return type.
-2. **Check that Builder fields are actually consumed.** A field on a
-   `case class Builder` is easy to mistake for a working feature — grep
-   the implementation (`Grep` for `config.fieldName`) to confirm it is
-   read, not just stored.
-3. **Distinguish blocking from non-blocking semantics.** If you describe
-   testing or timing behavior, verify whether the call uses
-   `Thread.sleep`, waits on a condition, or just reads state. A
-   manual/fake `Ticker` controls virtual time for state-based reads, not
-   real `Thread.sleep`.
-4. **Check platform availability.** The module layout encodes platform:
-   `src/main/scala` is shared, `.jvm/`, `.js/`, `.native/` are
-   platform-specific. Call out any JVM-only (or JS/Native-only) API
-   explicitly. Example: `RateLimiter` is under `uni/.jvm/...`.
-5. **Run the snippet mentally against the actual API.** If the snippet
-   depends on imports, factory methods, or return types you did not
-   verify, it does not go in.
+If any of the above is unverified, drop the claim.
 
-When in doubt, drop the claim. A shorter, correct doc is worth more than
-a longer one that needs retractions.
+## Non-obvious VitePress bits
 
-### Common hallucination shapes to watch for
+- **`__UNI_VERSION__`** inside code fences is replaced at build time
+  with the latest release (`docs/.vitepress/fetchLatestVersion.ts`).
+  Use it in `libraryDependencies` examples instead of a hardcoded
+  version.
+- **Sidebars are duplicated.** `docs/.vitepress/config.mts` defines
+  sidebars for `/guide/` **and** `/`. Adding a page requires updating
+  both — a single-location edit silently leaves the page un-navigable.
+- **`srcExclude: ['**/CLAUDE.md']`** keeps these files out of the
+  rendered site, so it is safe to put contributor notes next to the
+  content they describe.
+- **Clean URLs** are on; link to `/control/retry`, not `.html` or `.md`.
 
-- **Inventing Builder options** because they seem like they ought to
-  exist (warmup, name, metrics hooks).
-- **Assuming a factory method** is named after the nearest analogue
-  (`RateLimiter.newRateLimiter` when it is actually `newBuilder`).
-- **Mixing ticker semantics.** A manual ticker fast-forwards refill
-  state; it does not skip `Thread.sleep`.
-- **Stale package paths.** Packages move. `wvlet.uni.control` today may
-  re-export from elsewhere — verify the import you write resolves.
+## Before merging
 
-## Audience
-
-Reference readers know Scala 3 and already know *which* component they
-are looking up. Keep pages:
-
-- **Scannable.** Lead with the minimum working snippet, then options,
-  then composition patterns.
-- **API-shaped.** Organize around methods/classes, not around tasks.
-  Task-shaped narrative lives in `/book/`.
-- **Linked.** Cross-link freely into related reference pages; assume the
-  reader is navigating, not reading front-to-back.
-
-## Framework: VitePress
-
-Reference docs are built with [VitePress](https://vitepress.dev). A few
-project-specific conventions:
-
-- **`srcExclude`** (in `docs/.vitepress/config.mts`) hides
-  `**/CLAUDE.md` from the rendered site. Keep this guide and any
-  contributor-only notes in `CLAUDE.md` files.
-- **Version interpolation.** The token `__UNI_VERSION__` inside code
-  blocks is replaced at build time with the latest release version (see
-  `docs/.vitepress/fetchLatestVersion.ts`). Prefer `__UNI_VERSION__` in
-  `libraryDependencies` examples so docs stay current:
-
-  ````markdown
-  ```scala
-  libraryDependencies += "org.wvlet.uni" %% "uni" % "__UNI_VERSION__"
-  ```
-  ````
-
-- **Sidebars are explicit.** When you add or rename a page, update
-  **both** sidebar entries in `docs/.vitepress/config.mts`
-  (the `/guide/` sidebar and the `/` sidebar). Missing sidebar entries
-  produce pages that exist but are not navigable.
-- **Callout blocks** use VitePress containers:
-
-  ```markdown
-  ::: tip JVM-only
-  ...
-  :::
-
-  ::: warning
-  ...
-  :::
-  ```
-
-- **Code theme** is Nord (light + dark). No extra setup needed per page.
-- **Clean URLs** are enabled. Link to `/control/retry`, not
-  `/control/retry.html` or `/control/retry.md`.
-
-## Local workflow
-
-```bash
-npm run docs:dev     # http://localhost:5173 with hot reload
-npm run docs:build   # Production build; run before merging large changes
-```
-
-`docs:dev` does not fail on dead links. `docs:build` catches a lot more.
-For non-trivial changes, run the build locally and visit the page in a
-browser before opening the PR.
-
-## Structure of a reference page
-
-A typical reference page has this skeleton:
-
-1. **One-line purpose.** What the component does, in one sentence.
-2. **Package / import.** A single `import` line so the reader can copy.
-3. **Minimum example.** The smallest thing that works.
-4. **API tour.** Methods / options, grouped logically. Each with a
-   snippet.
-5. **Composition patterns.** How it plays with other Uni primitives.
-6. **Best practices.** 3–5 bullets. No filler.
-
-Not every page needs every section, but if you skip one, be deliberate
-about it.
-
-## Style
-
-- **Second person, active voice.** "You call `acquire()`…", not "`acquire()`
-  is called…".
-- **Present tense.** "returns", not "will return".
-- **Show the shape before the prose.** A code snippet followed by one
-  paragraph of explanation beats a paragraph introducing a snippet.
-- **No emoji** unless the user explicitly requests it.
-- **Scala 3 only.** Indentation-based syntax, `new` omitted, `${...}`
-  for interpolation.
-
-## Linking
-
-- Link **into** other reference pages (e.g. "see [Retry](/control/retry)")
-  rather than restating them.
-- Reference pages should **not** link into `/book/`. Reference stays
-  reference; the Book links out to reference when it wants the deep dive.
-- Use absolute site paths (`/control/rate-limiter`) for
-  cross-section links, relative paths (`./cache`) within the same
-  section.
-
-## Review checklist before merging a reference page
-
-- [ ] Every method, option, and class name appears in the source (verified
-      with `Read`/`Grep`, not memory).
-- [ ] Builder fields mentioned in docs are actually **read** by the
-      implementation, not just stored on the case class.
-- [ ] Platform availability is called out (JVM-only, JS-only, etc.).
-- [ ] Imports in snippets resolve against current packages.
-- [ ] Timing / blocking semantics match the implementation (`Thread.sleep`
-      vs virtual ticker vs state-only).
-- [ ] Sidebar entry added in both `/guide/` and `/` sidebars in
-      `docs/.vitepress/config.mts`.
-- [ ] Overview page (e.g. `docs/control/index.md`) updated if a new
-      component is added.
-- [ ] `npm run docs:build` succeeds.
+- Every symbol appears in current source (verified, not recalled).
+- Sidebar updated in both `/guide/` and `/` entries.
+- `npm run docs:build` succeeds (catches dead links `dev` misses).

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,164 @@
+# Writing Guide — Uni Reference Docs
+
+> This file is for contributors (humans and Claude) writing the
+> **reference** docs under `docs/` (everything outside `docs/book/`,
+> which has its own [CLAUDE.md](./book/CLAUDE.md)). It is excluded from
+> the rendered site via VitePress's `srcExclude` config.
+
+## Rule #0 — Verify before you write
+
+**Every symbol, method signature, option name, and behavior mentioned in
+a reference page MUST correspond to code that exists in this repository
+right now.** Reference docs are contractual: users paste snippets into
+their code. If a doc promises `withWarmupPeriod(...)` and the builder
+silently ignores it, the bug is on us.
+
+Before claiming an API exists:
+
+1. **Read the source.** Open the module file (e.g.
+   `uni/.jvm/src/main/scala/wvlet/uni/control/RateLimiter.scala`) and
+   confirm the method, signature, default values, and return type.
+2. **Check that Builder fields are actually consumed.** A field on a
+   `case class Builder` is easy to mistake for a working feature — grep
+   the implementation (`Grep` for `config.fieldName`) to confirm it is
+   read, not just stored.
+3. **Distinguish blocking from non-blocking semantics.** If you describe
+   testing or timing behavior, verify whether the call uses
+   `Thread.sleep`, waits on a condition, or just reads state. A
+   manual/fake `Ticker` controls virtual time for state-based reads, not
+   real `Thread.sleep`.
+4. **Check platform availability.** The module layout encodes platform:
+   `src/main/scala` is shared, `.jvm/`, `.js/`, `.native/` are
+   platform-specific. Call out any JVM-only (or JS/Native-only) API
+   explicitly. Example: `RateLimiter` is under `uni/.jvm/...`.
+5. **Run the snippet mentally against the actual API.** If the snippet
+   depends on imports, factory methods, or return types you did not
+   verify, it does not go in.
+
+When in doubt, drop the claim. A shorter, correct doc is worth more than
+a longer one that needs retractions.
+
+### Common hallucination shapes to watch for
+
+- **Inventing Builder options** because they seem like they ought to
+  exist (warmup, name, metrics hooks).
+- **Assuming a factory method** is named after the nearest analogue
+  (`RateLimiter.newRateLimiter` when it is actually `newBuilder`).
+- **Mixing ticker semantics.** A manual ticker fast-forwards refill
+  state; it does not skip `Thread.sleep`.
+- **Stale package paths.** Packages move. `wvlet.uni.control` today may
+  re-export from elsewhere — verify the import you write resolves.
+
+## Audience
+
+Reference readers know Scala 3 and already know *which* component they
+are looking up. Keep pages:
+
+- **Scannable.** Lead with the minimum working snippet, then options,
+  then composition patterns.
+- **API-shaped.** Organize around methods/classes, not around tasks.
+  Task-shaped narrative lives in `/book/`.
+- **Linked.** Cross-link freely into related reference pages; assume the
+  reader is navigating, not reading front-to-back.
+
+## Framework: VitePress
+
+Reference docs are built with [VitePress](https://vitepress.dev). A few
+project-specific conventions:
+
+- **`srcExclude`** (in `docs/.vitepress/config.mts`) hides
+  `**/CLAUDE.md` from the rendered site. Keep this guide and any
+  contributor-only notes in `CLAUDE.md` files.
+- **Version interpolation.** The token `__UNI_VERSION__` inside code
+  blocks is replaced at build time with the latest release version (see
+  `docs/.vitepress/fetchLatestVersion.ts`). Prefer `__UNI_VERSION__` in
+  `libraryDependencies` examples so docs stay current:
+
+  ````markdown
+  ```scala
+  libraryDependencies += "org.wvlet.uni" %% "uni" % "__UNI_VERSION__"
+  ```
+  ````
+
+- **Sidebars are explicit.** When you add or rename a page, update
+  **both** sidebar entries in `docs/.vitepress/config.mts`
+  (the `/guide/` sidebar and the `/` sidebar). Missing sidebar entries
+  produce pages that exist but are not navigable.
+- **Callout blocks** use VitePress containers:
+
+  ```markdown
+  ::: tip JVM-only
+  ...
+  :::
+
+  ::: warning
+  ...
+  :::
+  ```
+
+- **Code theme** is Nord (light + dark). No extra setup needed per page.
+- **Clean URLs** are enabled. Link to `/control/retry`, not
+  `/control/retry.html` or `/control/retry.md`.
+
+## Local workflow
+
+```bash
+npm run docs:dev     # http://localhost:5173 with hot reload
+npm run docs:build   # Production build; run before merging large changes
+```
+
+`docs:dev` does not fail on dead links. `docs:build` catches a lot more.
+For non-trivial changes, run the build locally and visit the page in a
+browser before opening the PR.
+
+## Structure of a reference page
+
+A typical reference page has this skeleton:
+
+1. **One-line purpose.** What the component does, in one sentence.
+2. **Package / import.** A single `import` line so the reader can copy.
+3. **Minimum example.** The smallest thing that works.
+4. **API tour.** Methods / options, grouped logically. Each with a
+   snippet.
+5. **Composition patterns.** How it plays with other Uni primitives.
+6. **Best practices.** 3–5 bullets. No filler.
+
+Not every page needs every section, but if you skip one, be deliberate
+about it.
+
+## Style
+
+- **Second person, active voice.** "You call `acquire()`…", not "`acquire()`
+  is called…".
+- **Present tense.** "returns", not "will return".
+- **Show the shape before the prose.** A code snippet followed by one
+  paragraph of explanation beats a paragraph introducing a snippet.
+- **No emoji** unless the user explicitly requests it.
+- **Scala 3 only.** Indentation-based syntax, `new` omitted, `${...}`
+  for interpolation.
+
+## Linking
+
+- Link **into** other reference pages (e.g. "see [Retry](/control/retry)")
+  rather than restating them.
+- Reference pages should **not** link into `/book/`. Reference stays
+  reference; the Book links out to reference when it wants the deep dive.
+- Use absolute site paths (`/control/rate-limiter`) for
+  cross-section links, relative paths (`./cache`) within the same
+  section.
+
+## Review checklist before merging a reference page
+
+- [ ] Every method, option, and class name appears in the source (verified
+      with `Read`/`Grep`, not memory).
+- [ ] Builder fields mentioned in docs are actually **read** by the
+      implementation, not just stored on the case class.
+- [ ] Platform availability is called out (JVM-only, JS-only, etc.).
+- [ ] Imports in snippets resolve against current packages.
+- [ ] Timing / blocking semantics match the implementation (`Thread.sleep`
+      vs virtual ticker vs state-only).
+- [ ] Sidebar entry added in both `/guide/` and `/` sidebars in
+      `docs/.vitepress/config.mts`.
+- [ ] Overview page (e.g. `docs/control/index.md`) updated if a new
+      component is added.
+- [ ] `npm run docs:build` succeeds.

--- a/docs/control/index.md
+++ b/docs/control/index.md
@@ -8,6 +8,7 @@ uni provides utilities for handling failures gracefully and managing resources p
 |-----------|-------------|
 | [Retry](./retry) | Automatic retry with backoff strategies |
 | [Circuit Breaker](./circuit-breaker) | Prevent cascade failures |
+| [Rate Limiter](./rate-limiter) | Throttle operation throughput (JVM) |
 | [Cache](./cache) | TTL and LRU caching |
 | [Resource](./resource) | Safe resource acquisition and release |
 

--- a/docs/control/rate-limiter.md
+++ b/docs/control/rate-limiter.md
@@ -65,10 +65,8 @@ limiter.withLimitN(10) {
 ```scala
 val limiter = RateLimiter
   .newBuilder
-  .withPermitsPerSecond(50.0)   // steady rate
-  .withBurstSize(10)            // max tokens stored
-  .withWarmupPeriod(1000L)      // gradually ramp up over 1s
-  .withName("external-api")     // for logs / metrics
+  .withPermitsPerSecond(50.0)      // steady rate
+  .withBurstSize(10)               // max tokens stored
   .withTicker(Ticker.systemTicker) // injectable for tests
   .build()
 ```
@@ -133,8 +131,9 @@ limiter.estimatedWaitTimeMillis // projected wait for the next permit
 
 ## Testing with a Manual Ticker
 
-Inject `Ticker.manualTicker` to advance time deterministically in tests, avoiding
-`Thread.sleep` in your test suite:
+Inject `Ticker.manualTicker` to advance virtual time deterministically. Exercise
+the limiter via `tryAcquire` / `availablePermits` — the ticker controls token
+refill, not blocking:
 
 ```scala
 import wvlet.uni.control.{RateLimiter, Ticker}
@@ -150,9 +149,14 @@ val limiter = RateLimiter
 limiter.tryAcquire() shouldBe true
 limiter.tryAcquire() shouldBe false
 
-ticker.tick(1_000_000_000L) // advance 1 second
+ticker.advance(1_000_000_000L) // advance 1 second
 limiter.tryAcquire() shouldBe true
 ```
+
+> **Note:** `acquire` / `acquireN` / `withLimit` still block on real wall clock
+> time via `Thread.sleep`, even with a manual ticker. Test the blocking path
+> with a system ticker and short intervals, or stick to `tryAcquire` for fully
+> deterministic tests.
 
 ## Composing with Retry and Circuit Breaker
 
@@ -182,6 +186,7 @@ val result = Retry.withBackOff(maxRetry = 3).run {
    downstream services; `burstSize = 1` enforces strict smoothing.
 3. **Prefer `tryAcquire` at system boundaries** — shed load explicitly instead
    of blocking caller threads indefinitely.
-4. **Inject a `Ticker` in tests** — avoid real sleeps; use `Ticker.manualTicker`.
+4. **Inject a `Ticker` in tests** — use `Ticker.manualTicker` with `tryAcquire`
+   to drive refill deterministically; note that `acquire` still uses real sleeps.
 5. **Combine with `CircuitBreaker` and `Retry`** — rate limiting alone does not
    protect against downstream outages.

--- a/docs/control/rate-limiter.md
+++ b/docs/control/rate-limiter.md
@@ -1,0 +1,187 @@
+# Rate Limiter
+
+Control the rate at which operations are performed. Unlike a semaphore that limits
+*concurrent* operations, `RateLimiter` caps the *throughput* (e.g. 100 ops/sec).
+
+`RateLimiter` is JVM-only and lives in `wvlet.uni.control`.
+
+```scala
+import wvlet.uni.control.RateLimiter
+```
+
+## Choosing an Algorithm
+
+| Algorithm      | Bursts         | Best For                                              |
+|----------------|----------------|-------------------------------------------------------|
+| Token Bucket   | Allowed        | Smooth average rate with occasional bursts (default)  |
+| Fixed Window   | At boundaries  | Simple per-window quotas (e.g. "100 requests/minute") |
+| Sliding Window | None           | Strict rolling-window guarantees                      |
+
+When in doubt, start with **token bucket** — it is the most flexible and the
+cheapest (lock-free).
+
+## Token Bucket
+
+Tokens refill at a steady rate up to a bucket capacity (`burstSize`). Each
+operation consumes one or more tokens. Permits bursts up to the bucket size and
+then enforces the steady rate.
+
+```scala
+val limiter = RateLimiter
+  .newBuilder
+  .withPermitsPerSecond(100.0)
+  .withBurstSize(20)
+  .build()
+
+// Blocks if the rate is exceeded; returns the wait time in ms
+val waitedMs = limiter.acquire()
+
+// Non-blocking variant
+if limiter.tryAcquire() then
+  callExternalService()
+```
+
+### Run a Block under a Limit
+
+```scala
+val result = limiter.withLimit {
+  callExternalService()
+}
+```
+
+### Acquire Multiple Permits
+
+Useful when operations have different costs (e.g. a bulk API call):
+
+```scala
+limiter.acquireN(5)
+limiter.withLimitN(10) {
+  bulkUpload(batch)
+}
+```
+
+### Builder Options
+
+```scala
+val limiter = RateLimiter
+  .newBuilder
+  .withPermitsPerSecond(50.0)   // steady rate
+  .withBurstSize(10)            // max tokens stored
+  .withWarmupPeriod(1000L)      // gradually ramp up over 1s
+  .withName("external-api")     // for logs / metrics
+  .withTicker(Ticker.systemTicker) // injectable for tests
+  .build()
+```
+
+### Steady Output (Leaky-Bucket Behavior)
+
+A token bucket with `burstSize = 1` refuses to burst, producing the smooth,
+drain-at-constant-rate behavior commonly associated with a leaky bucket:
+
+```scala
+val smooth = RateLimiter.newBuilder
+  .withPermitsPerSecond(10.0)
+  .withBurstSize(1)
+  .build()
+```
+
+## Fixed Window
+
+Allows up to `maxOperations` per discrete window; the counter resets at window
+boundaries. Simple and memory-efficient, but can spike at boundaries.
+
+```scala
+import java.util.concurrent.TimeUnit
+
+val limiter = RateLimiter.fixedWindow(
+  maxOperations = 100,
+  windowDuration = 1,
+  unit = TimeUnit.MINUTES
+)
+```
+
+## Sliding Window
+
+Allows up to `maxOperations` in any rolling `windowDuration`. More accurate than
+fixed window, at the cost of tracking per-request timestamps.
+
+```scala
+val limiter = RateLimiter.slidingWindow(
+  maxOperations = 100,
+  windowDuration = 1,
+  unit = TimeUnit.MINUTES
+)
+```
+
+## Unlimited (No-op)
+
+Useful as a default or in tests:
+
+```scala
+val limiter = RateLimiter.unlimited
+```
+
+## Inspecting State
+
+All algorithms expose:
+
+```scala
+limiter.ratePerSecond          // configured rate
+limiter.availablePermits       // current permits available
+limiter.estimatedWaitTimeMillis // projected wait for the next permit
+```
+
+## Testing with a Manual Ticker
+
+Inject `Ticker.manualTicker` to advance time deterministically in tests, avoiding
+`Thread.sleep` in your test suite:
+
+```scala
+import wvlet.uni.control.{RateLimiter, Ticker}
+
+val ticker  = Ticker.manualTicker
+val limiter = RateLimiter
+  .newBuilder
+  .withPermitsPerSecond(1.0)
+  .withBurstSize(1)
+  .withTicker(ticker)
+  .build()
+
+limiter.tryAcquire() shouldBe true
+limiter.tryAcquire() shouldBe false
+
+ticker.tick(1_000_000_000L) // advance 1 second
+limiter.tryAcquire() shouldBe true
+```
+
+## Composing with Retry and Circuit Breaker
+
+`RateLimiter` composes naturally with the other control primitives. A common
+pattern for calling a rate-limited external API:
+
+```scala
+import wvlet.uni.control.{CircuitBreaker, RateLimiter, Retry}
+
+val limiter = RateLimiter.newBuilder.withPermitsPerSecond(10.0).build()
+val breaker = CircuitBreaker.withConsecutiveFailures(5)
+
+val result = Retry.withBackOff(maxRetry = 3).run {
+  breaker.run {
+    limiter.withLimit {
+      callExternalService()
+    }
+  }
+}
+```
+
+## Best Practices
+
+1. **Pick the right algorithm** — token bucket for throughput smoothing, sliding
+   window for strict quotas, fixed window when memory is tight.
+2. **Size the burst deliberately** — a large burst increases tail pressure on
+   downstream services; `burstSize = 1` enforces strict smoothing.
+3. **Prefer `tryAcquire` at system boundaries** — shed load explicitly instead
+   of blocking caller threads indefinitely.
+4. **Inject a `Ticker` in tests** — avoid real sleeps; use `Ticker.manualTicker`.
+5. **Combine with `CircuitBreaker` and `Retry`** — rate limiting alone does not
+   protect against downstream outages.

--- a/plans/2026-04-18-rate-limiter-doc.md
+++ b/plans/2026-04-18-rate-limiter-doc.md
@@ -1,0 +1,32 @@
+# Rate Limiter Documentation
+
+## Problem
+
+The control module ships a JVM-only `RateLimiter` with three algorithms (token bucket, fixed window, sliding window), but it is not documented on the docs site. Users asking "does uni have rate limiting / leaky-bucket utilities?" cannot discover it.
+
+## Scope
+
+Add documentation only — no source changes. Out of scope: adding a dedicated leaky bucket algorithm.
+
+## Deliverables
+
+1. `docs/control/rate-limiter.md` — user-facing guide covering:
+   - When to use each algorithm (token bucket vs fixed window vs sliding window)
+   - Builder API for token bucket (permitsPerSecond, burstSize, warmupPeriod, ticker)
+   - Factory methods for fixed/sliding window
+   - Blocking (`acquire`) vs non-blocking (`tryAcquire`) semantics
+   - Composition with rest of control module (Retry, CircuitBreaker)
+   - Note on token bucket vs leaky bucket (token bucket permits bursts; for strict smoothing, set `burstSize = 1`)
+2. Sidebar entry in `docs/.vitepress/config.mts` (two locations: `/guide/` and `/` sidebars).
+3. Entry in `docs/control/index.md` overview table.
+
+## Non-goals
+
+- No new leaky-bucket implementation.
+- No changes to `RateLimiter.scala`.
+- No Book chapter changes.
+
+## Notes
+
+- Token bucket with `burstSize = 1` effectively approximates leaky-bucket output smoothing for the "I need steady output" use case. Call this out explicitly so users don't need to file a feature request.
+- `RateLimiter` is JVM-only today (`uni/.jvm/src/main/scala/wvlet/uni/control/RateLimiter.scala`). Mention the platform caveat.


### PR DESCRIPTION
## Summary
- Add `docs/control/rate-limiter.md` covering token bucket, fixed window, and sliding window algorithms, plus a `Ticker.manualTicker` testing pattern scoped to the non-blocking (`tryAcquire`) path.
- Register the page in `docs/.vitepress/config.mts` sidebars (both `/guide/` and root) and the control overview table.
- Include a note on getting leaky-bucket-style smoothing via `burstSize = 1`, so users looking for that don't conclude we lack the capability.
- Add `docs/CLAUDE.md` — a short contributor guide for reference docs, capturing the no-hallucination rule (verify every symbol against source; confirm config fields are consumed, not just declared) and a few non-obvious VitePress bits (`__UNI_VERSION__` interpolation, the duplicated sidebar, `srcExclude`).

## Test plan
- [ ] `npm run docs:dev` loads the new page under Control Flow → Rate Limiter.
- [ ] Sidebar entry renders in both `/guide/` and root sidebars.
- [ ] Code snippets compile-verified against `uni/.jvm/src/main/scala/wvlet/uni/control/RateLimiter.scala` and `uni-core/src/main/scala/wvlet/uni/rx/Ticker.scala`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)