### PR TITLE
feature: Add a standard Result[A] type for exception-aware composition

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -170,6 +170,7 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Type Introspection', link: '/core/surface' },
             { text: 'IO', link: '/core/io' },
             { text: 'FileSystem', link: '/core/filesystem' },
+            { text: 'Result', link: '/core/result' },
             { text: 'Utilities', link: '/core/utilities' }
           ]
         },
@@ -246,6 +247,7 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Type Introspection', link: '/core/surface' },
             { text: 'IO', link: '/core/io' },
             { text: 'FileSystem', link: '/core/filesystem' },
+            { text: 'Result', link: '/core/result' },
             { text: 'Utilities', link: '/core/utilities' }
           ]
         },

--- a/docs/core/result.md
+++ b/docs/core/result.md
@@ -1,0 +1,139 @@
+# Result
+
+`Result[A]` is Uni's standard container for "a value that may have failed". It
+is a Rust-flavored counterpart to `scala.util.Try`: the error channel is
+always a `Throwable`, and the combinators match [`Rx`](/rx/)'s vocabulary so
+interop is mechanical.
+
+```scala
+import wvlet.uni.util.Result
+```
+
+`Result` lives in `uni-core` and is available on the JVM, Scala.js, and
+Scala Native.
+
+## When to Use Result
+
+Use `Result[A]` at API boundaries where failure is an expected outcome that
+callers need to handle as a value — parsers, external lookups, settled
+`Rx` evaluations — while keeping `throw` / `try` / `catch` inside internal
+code. Uni deliberately does **not** introduce a type-level error channel
+(like ZIO's `E` parameter): Scala's exception mechanism already carries the
+error type, and fixing `E = Throwable` keeps the shape single-parameter like
+`Option[A]` and `Rx[A]`.
+
+| Situation                                              | Recommended type        |
+|--------------------------------------------------------|-------------------------|
+| Internal helper that can throw                         | Exceptions + `NonFatal` |
+| Public API that distinguishes "failed" from "returned" | `Result[A]`             |
+| Async stream that produces zero or more values         | `Rx[A]`                 |
+
+## Constructing a Result
+
+`Result.apply` evaluates a block and wraps any non-fatal exception. Fatal
+errors (e.g. `InterruptedException`, `VirtualMachineError`) escape — this
+matches `scala.util.control.NonFatal`.
+
+```scala
+val parsed: Result[Int] = Result(Integer.parseInt("42"))
+// Result.Success(42)
+
+val failed: Result[Int] = Result(Integer.parseInt("not-a-number"))
+// Result.Failure(java.lang.NumberFormatException: For input string: "not-a-number")
+```
+
+Direct constructors and conversions are also available:
+
+```scala
+Result.success(1)                           // Result.Success(1)
+Result.failure(new RuntimeException("no"))  // Result.Failure(...)
+
+Result.fromTry(scala.util.Try("parse this".toInt))
+Result.fromEither(Right[Throwable, Int](42))
+Result.fromOption(Option.empty[Int], new NoSuchElementException("empty"))
+```
+
+## Composing Results
+
+`map`, `flatMap`, and `filter` work like any other monadic container, and
+they **catch any exceptions thrown inside the supplied function**, turning
+them into `Failure`. This is the "Rx-like propagation" property: exceptions
+never bypass the wrapper.
+
+```scala
+val r: Result[Int] =
+  for
+    a <- Result(Integer.parseInt("10"))
+    b <- Result(Integer.parseInt("20"))
+    if a + b > 0
+  yield a + b
+// Result.Success(30)
+```
+
+A `Failure` anywhere in the chain short-circuits the rest — no need to
+thread the error manually.
+
+## Handling Failure
+
+`recover` and `recoverWith` mirror the same-named methods on `Rx` and only
+fire when the partial function matches the wrapped throwable:
+
+```scala
+val recovered: Result[Int] =
+  Result(Integer.parseInt("nope")).recover {
+    case _: NumberFormatException => 0
+  }
+// Result.Success(0)
+
+val retried: Result[Int] =
+  Result.failure(new java.io.IOException("timeout")).recoverWith {
+    case _: java.io.IOException => Result(42)
+  }
+// Result.Success(42)
+```
+
+Other handlers:
+
+```scala
+Result.failure(boom).mapError(new IllegalStateException(_))  // rewrap
+result.fold(onFailure = _.getMessage, onSuccess = _.toString)
+result.getOrElse(0)
+result.orElse(Result.success(0))
+```
+
+## Conversions
+
+`Result` interoperates with the standard Scala types:
+
+```scala
+result.toOption     // Option[A] — Failure becomes None
+result.toEither     // Either[Throwable, A]
+result.toTry        // scala.util.Try[A]
+result.get          // A; rethrows on Failure
+```
+
+## Rx Interop
+
+`Rx[A].materialize` reifies each upstream event as a `Result[A]`, so errors
+are delivered as values instead of terminating the stream:
+
+```scala
+import wvlet.uni.rx.Rx
+
+val events: Rx[Result[Int]] =
+  Rx.exception[Int](new RuntimeException("boom")).materialize
+// Emits Result.Failure(RuntimeException("boom"))
+```
+
+To go the other way, use `Rx.fromResult` (or the `toRx` extension on
+`Result`, available after importing `wvlet.uni.rx.*`):
+
+```scala
+import wvlet.uni.rx.*
+
+val rx1: Rx[Int] = Rx.fromResult(Result.success(1))
+val rx2: Rx[Int] = Result.success(1).toRx
+```
+
+`Result.Failure(e)` converts to an `Rx` that emits `OnError(e)` — the same
+termination signal a thrown exception would produce.

--- a/plans/swirling-stargazing-crescent.md
+++ b/plans/swirling-stargazing-crescent.md
@@ -41,19 +41,17 @@ Scala's exception mechanism as the default for internal control flow.
 enums in the tree (see `uni-core/src/main/scala/wvlet/uni/log/LogLevel.scala`).
 
 ```scala
-package wvlet.uni
-
-import scala.util.control.NonFatal
-import scala.util.{Try, Success => TrySuccess, Failure => TryFailure}
+package wvlet.uni.util
 
 enum Result[+A]:
-  case Success(value: A)
-  case Failure(error: Throwable)
+  case Success(value: A) extends Result[A]
+  case Failure(error: Throwable) extends Result[Nothing]
 ```
 
-Placed at `uni-core/src/main/scala/wvlet/uni/Result.scala` (root of
-`wvlet.uni` inside `uni-core`), so it sits alongside foundational types and
-is reachable from `import wvlet.uni.Result`.
+Placed at `uni-core/src/main/scala/wvlet/uni/util/Result.scala` (inside
+`wvlet.uni.util` alongside `LazyF0`), so `wvlet.uni.*` stays reserved for
+subpackage organization and the type is reachable from
+`import wvlet.uni.util.Result`.
 
 ### Core API (instance methods)
 
@@ -77,7 +75,7 @@ Methods mirror `Rx`'s names where they overlap, so users switching between
 | `toOption` | `Option[A]` | `Failure → None`. |
 | `toEither` | `Either[Throwable, A]` | |
 | `toTry` | `scala.util.Try[A]` | |
-| `toRx` | `Rx[A]` | Single-element `Rx` (or errored `Rx`). |
+| `toRx` (extension) | `Rx[A]` | Provided via `wvlet.uni.rx.ResultConverter` — import `wvlet.uni.rx.*`. |
 
 `map` and `flatMap` always catch `NonFatal`, so `for` comprehensions propagate
 failures uniformly — this is the "`Rx[A]`-like propagation while wrapping
@@ -138,19 +136,26 @@ Fixing `E = Throwable` keeps the shape single-parameter like `Option[A]` and
 
 Added:
 
-- `uni-core/src/main/scala/wvlet/uni/Result.scala` — the enum and companion.
-- `uni-core/src/test/scala/wvlet/uni/ResultTest.scala` — unit tests using
-  `wvlet.uni.test.UniTest` (matches existing test style, e.g. `RxTest`).
+- `uni-core/src/main/scala/wvlet/uni/util/Result.scala` — the enum and
+  companion.
+- `uni/src/test/scala/wvlet/uni/util/ResultTest.scala` — unit tests using
+  `wvlet.uni.test.UniTest` (tests for `uni-core` live in the `uni` module).
 - `docs/core/result.md` — reference page following
   `docs/control/rate-limiter.md`'s shape (concept, API tour, interop with
   `Rx` and `Try`).
 
 Modified:
 
-- `uni-core/src/main/scala/wvlet/uni/rx/Rx.scala` — add `materialize` on
-  `RxOps`, `fromResult` on the `Rx` companion. Small localized additions;
-  reuse the existing `FlatMapOp` / `RecoverOp` mechanics so no new
-  `RxEvent` is required.
+- `uni-core/src/main/scala/wvlet/uni/rx/Rx.scala` — add `materialize` method
+  on `Rx`, `fromResult` factory on the `Rx` companion, and a `MaterializeOp`
+  case class.
+- `uni-core/src/main/scala/wvlet/uni/rx/RxRunner.scala` — add the
+  `MaterializeOp` case. Unlike `recover`, `materialize` explicitly emits
+  `OnCompletion` after an `OnError`-derived `Failure` so downstream
+  operators (`toSeq`, `lastOption`, …) terminate cleanly.
+- `uni-core/src/main/scala/wvlet/uni/rx/package.scala` — add
+  `ResultConverter` implicit class so `Result[A].toRx` works after
+  `import wvlet.uni.rx.*`.
 - `docs/.vitepress/config.mts` — add the new page to **both** the `/guide/`
   and `/` sidebars (per `docs/CLAUDE.md` rule).
 

--- a/plans/swirling-stargazing-crescent.md
+++ b/plans/swirling-stargazing-crescent.md
@@ -1,0 +1,215 @@
+# Uni standard `Result[A]` type
+
+Date: 2026-04-18
+Topic: Add a standard `Result[A]` type to uni-core that aligns with `Rx[A]`
+propagation semantics and Scala's exception mechanism.
+
+## Context
+
+Uni currently handles "a value that could fail" in several ad-hoc ways:
+
+- `scala.util.Try[A]` (used internally by Rx for `transform` / `tapOn`).
+- `Either[Throwable, A]` at a few API boundaries.
+- `wvlet.uni.control.ResultClass` (retry classification only, not a value
+  wrapper).
+- `Rx`'s own `RxEvent` ADT (`OnNext` / `OnError` / `OnCompletion`) for stream
+  propagation inside `uni-core/src/main/scala/wvlet/uni/rx/`.
+
+None of these is an idiomatic, Rust-flavored single-value `Result[A]`:
+
+- `Try` is in `scala.util` and carries Scala-collections-ish naming that
+  predates Scala 3 and does not line up with `Rx`'s combinator vocabulary
+  (`recover` / `recoverWith`).
+- `Either[Throwable, A]` is conventionally "left = bias'd" and the error type
+  is unconstrained, so library authors keep re-picking a left type.
+- `ZIO`-style triples (`ZIO[R, E, A]`) solve more problems than we need: Scala
+  already has `throw`, `try/catch`, and `NonFatal`, and we do not want to
+  introduce a type-level environment.
+
+The goal is a **single-parameter** `Result[+A]` with the error type fixed to
+`Throwable`, with combinators and naming that match `Rx`, so Rx ⇄ Result
+interop is obvious. This becomes the recommended return type when a public
+API wants to represent "this may fail without throwing"
+(e.g. parser results, `IO` helpers, settled Rx evaluations) while keeping
+Scala's exception mechanism as the default for internal control flow.
+
+## Design
+
+### Definition
+
+`Result[+A]` is a Scala 3 `enum`, consistent with `LogLevel` and the 20+ other
+enums in the tree (see `uni-core/src/main/scala/wvlet/uni/log/LogLevel.scala`).
+
+```scala
+package wvlet.uni
+
+import scala.util.control.NonFatal
+import scala.util.{Try, Success => TrySuccess, Failure => TryFailure}
+
+enum Result[+A]:
+  case Success(value: A)
+  case Failure(error: Throwable)
+```
+
+Placed at `uni-core/src/main/scala/wvlet/uni/Result.scala` (root of
+`wvlet.uni` inside `uni-core`), so it sits alongside foundational types and
+is reachable from `import wvlet.uni.Result`.
+
+### Core API (instance methods)
+
+Methods mirror `Rx`'s names where they overlap, so users switching between
+`Rx[A]` and `Result[A]` see the same vocabulary.
+
+| Method | Signature | Notes |
+|---|---|---|
+| `isSuccess` / `isFailure` | `Boolean` | Predicate helpers. |
+| `get` | `A` | Rethrows the wrapped `Throwable` on `Failure`. |
+| `getOrElse` | `[B >: A](default: => B): B` | Lazy default on failure. |
+| `orElse` | `[B >: A](alt: => Result[B]): Result[B]` | Lazy alternative. |
+| `map` | `[B](f: A => B): Result[B]` | Exceptions in `f` become `Failure`. |
+| `flatMap` | `[B](f: A => Result[B]): Result[B]` | Exceptions in `f` become `Failure`. |
+| `filter` / `withFilter` | `(p: A => Boolean): Result[A]` | `for`-comprehension support; predicate failure → `Failure(NoSuchElementException)`. |
+| `foreach` | `(f: A => Unit): Unit` | Only runs on `Success`. |
+| `recover` | `[B >: A](pf: PartialFunction[Throwable, B]): Result[B]` | Mirrors `Rx.recover`. |
+| `recoverWith` | `[B >: A](pf: PartialFunction[Throwable, Result[B]]): Result[B]` | Mirrors `Rx.recoverWith`. |
+| `mapError` | `(f: Throwable => Throwable): Result[A]` | Translate/wrap the error. |
+| `fold` | `[B](onFailure: Throwable => B, onSuccess: A => B): B` | Eliminator. |
+| `toOption` | `Option[A]` | `Failure → None`. |
+| `toEither` | `Either[Throwable, A]` | |
+| `toTry` | `scala.util.Try[A]` | |
+| `toRx` | `Rx[A]` | Single-element `Rx` (or errored `Rx`). |
+
+`map` and `flatMap` always catch `NonFatal`, so `for` comprehensions propagate
+failures uniformly — this is the "`Rx[A]`-like propagation while wrapping
+exception" the user asked for.
+
+### Companion / constructors
+
+```scala
+object Result:
+  def apply[A](body: => A): Result[A] =
+    try Success(body)
+    catch { case NonFatal(e) => Failure(e) }
+
+  def success[A](v: A): Result[A] = Success(v)
+  def failure(e: Throwable): Result[Nothing] = Failure(e)
+
+  def fromTry[A](t: Try[A]): Result[A] =
+    t match
+      case TrySuccess(v) => Success(v)
+      case TryFailure(e) => Failure(e)
+
+  def fromEither[A](e: Either[Throwable, A]): Result[A] =
+    e.fold(Failure(_), Success(_))
+
+  def fromOption[A](o: Option[A], ifNone: => Throwable): Result[A] =
+    o.fold(Failure(ifNone))(Success(_))
+```
+
+`Result.apply { ... }` is the primary factory — it is the "try this block,
+wrap any non-fatal exception" entry point that parallels `Try { ... }` but
+returns the Uni type.
+
+### Rx interop
+
+A single conversion method on `RxOps[A]` returns `Rx[Result[A]]`, turning
+`OnError` events into `Result.Failure` values without terminating the stream.
+This closes the loop with the user's motivation ("Rx-like propagation"):
+
+- `RxOps[A].materialize: Rx[Result[A]]` — each upstream event becomes a
+  `Result`; `OnError` becomes `Failure` and the stream continues.
+- `Rx.fromResult[A](r: Result[A]): Rx[A]` — factory on `Rx` companion.
+- `Result[A].toRx: Rx[A]` — already covered above.
+
+Only `materialize` is a new method on `RxOps`; everything else is a factory
+or instance method on `Result`. This keeps `Rx`'s surface area minimal while
+making the interop obvious. (Naming mirrors RxJS/ReactiveX `materialize` so
+readers recognise the intent.)
+
+### Why not `Result[E, A]` / `Result[A, E]`?
+
+The user explicitly rejected the ZIO triple for this reason — Scala already
+has exceptions and `NonFatal`, and the purpose of `Result[A]` is to *wrap*
+exceptions at API boundaries, not to re-invent a type-level error channel.
+Fixing `E = Throwable` keeps the shape single-parameter like `Option[A]` and
+`Rx[A]`, and lets `mapError` cover the "translate the exception" use case.
+
+## Files to add / modify
+
+Added:
+
+- `uni-core/src/main/scala/wvlet/uni/Result.scala` — the enum and companion.
+- `uni-core/src/test/scala/wvlet/uni/ResultTest.scala` — unit tests using
+  `wvlet.uni.test.UniTest` (matches existing test style, e.g. `RxTest`).
+- `docs/core/result.md` — reference page following
+  `docs/control/rate-limiter.md`'s shape (concept, API tour, interop with
+  `Rx` and `Try`).
+
+Modified:
+
+- `uni-core/src/main/scala/wvlet/uni/rx/Rx.scala` — add `materialize` on
+  `RxOps`, `fromResult` on the `Rx` companion. Small localized additions;
+  reuse the existing `FlatMapOp` / `RecoverOp` mechanics so no new
+  `RxEvent` is required.
+- `docs/.vitepress/config.mts` — add the new page to **both** the `/guide/`
+  and `/` sidebars (per `docs/CLAUDE.md` rule).
+
+No other modules depend on this change — it is additive.
+
+## Testing
+
+`ResultTest` covers:
+
+1. `Result.apply { ... }` wraps `NonFatal` throwables; fatal errors escape
+   (`intercept[InterruptedException] { ... }`).
+2. `map` / `flatMap` propagate exceptions thrown inside `f` as `Failure`.
+3. `recover` / `recoverWith` only trigger on matching partial functions;
+   non-matching partials re-emit the original `Failure`.
+4. `for`-comprehension: two `Result` values compose; a middle `Failure`
+   short-circuits.
+5. `toTry` / `toEither` / `toOption` / `toRx` round-trips.
+6. `Rx[A].materialize` turns an errored `Rx` into `Rx[Result[A]]` that emits
+   exactly one `Failure` and completes.
+
+Run locally with:
+
+```bash
+./sbt "coreJVM/testOnly *ResultTest"
+./sbt "coreJS/testOnly *ResultTest"
+./sbt scalafmtAll
+```
+
+## Documentation
+
+`docs/core/result.md` follows the `RateLimiter` page's shape:
+
+- One-line concept and package line (`import wvlet.uni.Result`).
+- When to use `Result` vs `throw` vs `Rx`.
+- API tour with verified snippets (Rule #0 — every method referenced is
+  confirmed against `Result.scala`).
+- Interop subsection: `Rx.materialize`, `Result.toRx`, `fromTry` /
+  `toTry`, `fromEither` / `toEither`.
+
+Sidebar entries added in both `/guide/` and `/` blocks of
+`docs/.vitepress/config.mts`. `npm run docs:build` must pass.
+
+## Verification
+
+- `./sbt compile` — all modules build.
+- `./sbt test` — full suite green; the new `ResultTest` is the focused
+  signal.
+- `./sbt scalafmtAll` — CI format check.
+- `npm run docs:build` — no dead links, sidebar reachable.
+- Manual: open `http://localhost:5173/core/result` after `npm run docs:dev`
+  and confirm the page renders with the two sidebar entries.
+
+## Out of scope (deferred)
+
+- Adding a `Pending` / `Empty` third case (would conflate single-value with
+  stream semantics — keep `Rx` for that).
+- A bifunctor `Result[E, A]` — rejected above.
+- Rewriting existing `Try`-returning APIs in Uni to `Result`; callers can
+  migrate incrementally via `Result.fromTry` / `toTry`.
+- Integrating `Result` into `wvlet.uni.http.Response` error classification
+  (tracked separately if desired — HTTP errors are status-code driven, not
+  exception-driven).

--- a/uni-core/src/main/scala/wvlet/uni/rx/Rx.scala
+++ b/uni-core/src/main/scala/wvlet/uni/rx/Rx.scala
@@ -680,10 +680,15 @@ object Rx extends LogSupport:
   def fromTry[A](t: Try[A]): Rx[A] = TryOp(LazyF0(t))
 
   /**
-    * Convert a [[wvlet.uni.Result]] into a single-element Rx, propagating `Failure(e)` as
+    * Convert a [[wvlet.uni.util.Result]] into a single-element Rx, propagating `Failure(e)` as
     * `OnError(e)`.
     */
-  def fromResult[A](r: Result[A]): Rx[A] = fromTry(r.toTry)
+  def fromResult[A](r: Result[A]): Rx[A] =
+    r match
+      case Result.Success(v) =>
+        single(v)
+      case Result.Failure(e) =>
+        exception(e)
 
   /**
     * Create a sequence of values

--- a/uni-core/src/main/scala/wvlet/uni/rx/Rx.scala
+++ b/uni-core/src/main/scala/wvlet/uni/rx/Rx.scala
@@ -48,6 +48,15 @@ trait RxOps[+A]:
   def recoverWith[A](f: PartialFunction[Throwable, RxOps[A]]): Rx[A] = RecoverWithOp(this, f)
 
   /**
+    * Reify each upstream event as a [[wvlet.uni.util.Result]] so errors are delivered as values
+    * instead of terminating the stream. `OnNext(v)` becomes `Result.Success(v)` and `OnError(e)`
+    * becomes `Result.Failure(e)` followed by `OnCompletion` — the resulting stream always
+    * terminates cleanly, so downstream operators like `toSeq` and `lastOption` work on errored
+    * sources.
+    */
+  def materialize: Rx[Result[A]] = MaterializeOp(this)
+
+  /**
     * Applies `f` to the value for having a side effect, and return the original value.
     *
     * This method is useful for debugging Rx chains. For example:
@@ -545,15 +554,6 @@ trait Rx[+A] extends RxOps[A]:
     case other =>
       other
   }
-
-  /**
-    * Reify each upstream event as a [[wvlet.uni.util.Result]] so errors are delivered as values
-    * instead of terminating the stream. `OnNext(v)` becomes `Result.Success(v)` and `OnError(e)`
-    * becomes `Result.Failure(e)` followed by `OnCompletion` — the resulting stream always
-    * terminates cleanly, so downstream operators like `toSeq` and `lastOption` work on errored
-    * sources.
-    */
-  def materialize: Rx[Result[A]] = MaterializeOp(this)
 
   def concat[A1 >: A](other: Rx[A1]): Rx[A1] = Rx.concat(this, other)
   def lastOption: RxOption[A]                = LastOp(this).toOption

--- a/uni-core/src/main/scala/wvlet/uni/rx/Rx.scala
+++ b/uni-core/src/main/scala/wvlet/uni/rx/Rx.scala
@@ -16,6 +16,7 @@ package wvlet.uni.rx
 import java.util.concurrent.TimeUnit
 import wvlet.uni.log.LogSupport
 import wvlet.uni.util.LazyF0
+import wvlet.uni.util.Result
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -545,6 +546,18 @@ trait Rx[+A] extends RxOps[A]:
       other
   }
 
+  /**
+    * Reify each upstream event as a [[wvlet.uni.Result]] so errors are delivered as values instead
+    * of terminating the stream. `OnNext(v)` becomes `Result.Success(v)` and `OnError(e)` becomes
+    * `Result.Failure(e)`.
+    */
+  def materialize: Rx[Result[A]] = transform {
+    case Success(v) =>
+      Result.Success(v)
+    case Failure(e) =>
+      Result.Failure(e)
+  }
+
   def concat[A1 >: A](other: Rx[A1]): Rx[A1] = Rx.concat(this, other)
   def lastOption: RxOption[A]                = LastOp(this).toOption
 
@@ -668,6 +681,12 @@ object Rx extends LogSupport:
   def fromSeq[A](lst: => Seq[A]): Rx[A] = SeqOp(LazyF0(lst))
 
   def fromTry[A](t: Try[A]): Rx[A] = TryOp(LazyF0(t))
+
+  /**
+    * Convert a [[wvlet.uni.Result]] into a single-element Rx, propagating `Failure(e)` as
+    * `OnError(e)`.
+    */
+  def fromResult[A](r: Result[A]): Rx[A] = fromTry(r.toTry)
 
   /**
     * Create a sequence of values

--- a/uni-core/src/main/scala/wvlet/uni/rx/Rx.scala
+++ b/uni-core/src/main/scala/wvlet/uni/rx/Rx.scala
@@ -547,16 +547,13 @@ trait Rx[+A] extends RxOps[A]:
   }
 
   /**
-    * Reify each upstream event as a [[wvlet.uni.Result]] so errors are delivered as values instead
-    * of terminating the stream. `OnNext(v)` becomes `Result.Success(v)` and `OnError(e)` becomes
-    * `Result.Failure(e)`.
+    * Reify each upstream event as a [[wvlet.uni.util.Result]] so errors are delivered as values
+    * instead of terminating the stream. `OnNext(v)` becomes `Result.Success(v)` and `OnError(e)`
+    * becomes `Result.Failure(e)` followed by `OnCompletion` — the resulting stream always
+    * terminates cleanly, so downstream operators like `toSeq` and `lastOption` work on errored
+    * sources.
     */
-  def materialize: Rx[Result[A]] = transform {
-    case Success(v) =>
-      Result.Success(v)
-    case Failure(e) =>
-      Result.Failure(e)
-  }
+  def materialize: Rx[Result[A]] = MaterializeOp(this)
 
   def concat[A1 >: A](other: Rx[A1]): Rx[A1] = Rx.concat(this, other)
   def lastOption: RxOption[A]                = LastOp(this).toOption
@@ -1111,6 +1108,8 @@ object Rx extends LogSupport:
 
   case class RecoverWithOp[A, U](input: RxOps[A], f: PartialFunction[Throwable, RxOps[U]])
       extends UnaryRx[A, U]
+
+  case class MaterializeOp[A](input: RxOps[A]) extends UnaryRx[A, Result[A]]
 
   case class TapOnOp[A](input: RxOps[A], f: PartialFunction[Try[A], Unit]) extends UnaryRx[A, A]
 

--- a/uni-core/src/main/scala/wvlet/uni/rx/RxRunner.scala
+++ b/uni-core/src/main/scala/wvlet/uni/rx/RxRunner.scala
@@ -3,6 +3,7 @@ package wvlet.uni.rx
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import wvlet.uni.log.LogSupport
+import wvlet.uni.util.Result
 
 import scala.annotation.tailrec
 import scala.collection.immutable.Queue
@@ -481,6 +482,17 @@ class RxRunner(
                   effect(OnError(e))
             case other =>
               effect(other)
+        }
+      case MaterializeOp(in) =>
+        run(in) { ev =>
+          ev match
+            case OnNext(v) =>
+              effect(OnNext(Result.Success(v)))
+            case OnError(e) =>
+              effect(OnNext(Result.Failure(e)))
+              effect(OnCompletion)
+            case OnCompletion =>
+              effect(OnCompletion)
         }
       case RecoverWithOp(in, f) =>
         var toContinue: RxResult = RxResult.Continue

--- a/uni-core/src/main/scala/wvlet/uni/rx/RxRunner.scala
+++ b/uni-core/src/main/scala/wvlet/uni/rx/RxRunner.scala
@@ -489,8 +489,11 @@ class RxRunner(
             case OnNext(v) =>
               effect(OnNext(Result.Success(v)))
             case OnError(e) =>
-              effect(OnNext(Result.Failure(e)))
-              effect(OnCompletion)
+              val downstream = effect(OnNext(Result.Failure(e)))
+              if downstream.toContinue then
+                effect(OnCompletion)
+              else
+                downstream
             case OnCompletion =>
               effect(OnCompletion)
         }

--- a/uni-core/src/main/scala/wvlet/uni/rx/package.scala
+++ b/uni-core/src/main/scala/wvlet/uni/rx/package.scala
@@ -13,6 +13,8 @@
  */
 package wvlet.uni
 
+import wvlet.uni.util.Result
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -21,3 +23,6 @@ import scala.concurrent.Future
 package object rx:
   implicit class FutureConverter[A](private val f: Future[A]) extends AnyVal:
     def toRx(using ec: ExecutionContext): RxOption[A] = Rx.fromFuture(f)
+
+  implicit class ResultConverter[A](private val r: Result[A]) extends AnyVal:
+    def toRx: Rx[A] = Rx.fromResult(r)

--- a/uni-core/src/main/scala/wvlet/uni/util/Result.scala
+++ b/uni-core/src/main/scala/wvlet/uni/util/Result.scala
@@ -107,25 +107,32 @@ enum Result[+A]:
   /** Recover from a matching throwable by emitting a replacement value. Mirrors `Rx.recover`. */
   def recover[B >: A](pf: PartialFunction[Throwable, B]): Result[B] =
     this match
-      case Failure(e) if pf.isDefinedAt(e) =>
-        Result.catching(pf(e))
-      case _ =>
+      case Failure(e) =>
+        pf.lift(e) match
+          case Some(v) =>
+            Result.catching(v)
+          case None =>
+            this
+      case _: Success[?] =>
         this
 
   /** Recover from a matching throwable by returning another `Result`. Mirrors `Rx.recoverWith`. */
   def recoverWith[B >: A](pf: PartialFunction[Throwable, Result[B]]): Result[B] =
     this match
-      case Failure(e) if pf.isDefinedAt(e) =>
-        Result.catchingResult(pf(e))
-      case _ =>
+      case Failure(e) =>
+        Result.catchingResult(pf.lift(e).getOrElse(this))
+      case _: Success[?] =>
         this
 
-  /** Translate the wrapped throwable on failure. */
+  /**
+    * Translate the wrapped throwable on failure. Exceptions thrown by `f` become `Failure`,
+    * matching `map` / `flatMap`.
+    */
   def mapError(f: Throwable => Throwable): Result[A] =
     this match
       case Failure(e) =>
-        Result.Failure(f(e))
-      case _ =>
+        Result.catchingResult(Result.Failure(f(e)))
+      case _: Success[?] =>
         this
 
   /** Eliminator: handle both branches. */

--- a/uni-core/src/main/scala/wvlet/uni/util/Result.scala
+++ b/uni-core/src/main/scala/wvlet/uni/util/Result.scala
@@ -60,7 +60,7 @@ enum Result[+A]:
       case _: Success[?] =>
         this
       case _: Failure =>
-        alt
+        Result.catchingResult(alt)
 
   /** Apply `f` to the success value. Exceptions thrown by `f` become `Failure`. */
   def map[B](f: A => B): Result[B] =
@@ -211,6 +211,6 @@ object Result:
       case Some(v) =>
         Success(v)
       case None =>
-        Failure(ifNone)
+        catchingResult(Failure(ifNone))
 
 end Result

--- a/uni-core/src/main/scala/wvlet/uni/util/Result.scala
+++ b/uni-core/src/main/scala/wvlet/uni/util/Result.scala
@@ -108,11 +108,7 @@ enum Result[+A]:
   def recover[B >: A](pf: PartialFunction[Throwable, B]): Result[B] =
     this match
       case Failure(e) =>
-        pf.lift(e) match
-          case Some(v) =>
-            Result.catching(v)
-          case None =>
-            this
+        Result.catchingResult(pf.lift(e).fold[Result[B]](this)(Result.Success(_)))
       case _: Success[?] =>
         this
 

--- a/uni-core/src/main/scala/wvlet/uni/util/Result.scala
+++ b/uni-core/src/main/scala/wvlet/uni/util/Result.scala
@@ -107,17 +107,17 @@ enum Result[+A]:
   /** Recover from a matching throwable by emitting a replacement value. Mirrors `Rx.recover`. */
   def recover[B >: A](pf: PartialFunction[Throwable, B]): Result[B] =
     this match
-      case Failure(e) =>
-        Result.catchingResult(pf.lift(e).fold[Result[B]](this)(Result.Success(_)))
-      case _: Success[?] =>
+      case Failure(e) if pf.isDefinedAt(e) =>
+        Result.catching(pf(e))
+      case _ =>
         this
 
   /** Recover from a matching throwable by returning another `Result`. Mirrors `Rx.recoverWith`. */
   def recoverWith[B >: A](pf: PartialFunction[Throwable, Result[B]]): Result[B] =
     this match
-      case Failure(e) =>
-        Result.catchingResult(pf.lift(e).getOrElse(this))
-      case _: Success[?] =>
+      case Failure(e) if pf.isDefinedAt(e) =>
+        Result.catchingResult(pf(e))
+      case _ =>
         this
 
   /**

--- a/uni-core/src/main/scala/wvlet/uni/util/Result.scala
+++ b/uni-core/src/main/scala/wvlet/uni/util/Result.scala
@@ -66,11 +66,7 @@ enum Result[+A]:
   def map[B](f: A => B): Result[B] =
     this match
       case Success(v) =>
-        try
-          Result.Success(f(v))
-        catch
-          case NonFatal(e) =>
-            Result.Failure(e)
+        Result.catching(f(v))
       case fail: Failure =>
         fail
 
@@ -78,11 +74,7 @@ enum Result[+A]:
   def flatMap[B](f: A => Result[B]): Result[B] =
     this match
       case Success(v) =>
-        try
-          f(v)
-        catch
-          case NonFatal(e) =>
-            Result.Failure(e)
+        Result.catchingResult(f(v))
       case fail: Failure =>
         fail
 
@@ -93,14 +85,12 @@ enum Result[+A]:
   def filter(p: A => Boolean): Result[A] =
     this match
       case Success(v) =>
-        try
+        Result.catchingResult {
           if p(v) then
             this
           else
             Result.Failure(new NoSuchElementException("Result.filter predicate is not satisfied"))
-        catch
-          case NonFatal(e) =>
-            Result.Failure(e)
+        }
       case _: Failure =>
         this
 
@@ -118,11 +108,7 @@ enum Result[+A]:
   def recover[B >: A](pf: PartialFunction[Throwable, B]): Result[B] =
     this match
       case Failure(e) if pf.isDefinedAt(e) =>
-        try
-          Result.Success(pf(e))
-        catch
-          case NonFatal(e2) =>
-            Result.Failure(e2)
+        Result.catching(pf(e))
       case _ =>
         this
 
@@ -130,11 +116,7 @@ enum Result[+A]:
   def recoverWith[B >: A](pf: PartialFunction[Throwable, Result[B]]): Result[B] =
     this match
       case Failure(e) if pf.isDefinedAt(e) =>
-        try
-          pf(e)
-        catch
-          case NonFatal(e2) =>
-            Result.Failure(e2)
+        Result.catchingResult(pf(e))
       case _ =>
         this
 
@@ -183,9 +165,23 @@ object Result:
     * Evaluate `body` and wrap the outcome. Non-fatal exceptions become `Failure`; fatal errors
     * (e.g. `InterruptedException`, `VirtualMachineError`) escape the wrapper.
     */
-  def apply[A](body: => A): Result[A] =
+  def apply[A](body: => A): Result[A] = catching(body)
+
+  /**
+    * Evaluate `body` and wrap the value in `Success`, converting `NonFatal` throwables to
+    * `Failure`.
+    */
+  private[util] def catching[A](body: => A): Result[A] =
     try
       Success(body)
+    catch
+      case NonFatal(e) =>
+        Failure(e)
+
+  /** Like [[catching]] but for blocks that already return a `Result`. */
+  private[util] def catchingResult[A](body: => Result[A]): Result[A] =
+    try
+      body
     catch
       case NonFatal(e) =>
         Failure(e)

--- a/uni-core/src/main/scala/wvlet/uni/util/Result.scala
+++ b/uni-core/src/main/scala/wvlet/uni/util/Result.scala
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.util
+
+import scala.util.control.NonFatal
+import scala.util.{Try, Success as TrySuccess, Failure as TryFailure}
+
+/**
+  * A standard container for "a value that may have failed," carrying a `Throwable` on failure.
+  *
+  * `Result[A]` is Uni's Rust-flavored counterpart to `scala.util.Try`: it wraps exceptions into a
+  * value so that callers can compose potentially-failing computations without losing Scala's native
+  * exception mechanism. Its combinators (`recover`, `recoverWith`, `map`, `flatMap`, ...) mirror
+  * those of [[wvlet.uni.rx.Rx]] so switching between the two is mechanical.
+  *
+  * Prefer `Result` at API boundaries that need to represent failure as a value; keep normal `throw`
+  * / `try` inside internal code.
+  */
+enum Result[+A]:
+  case Success(value: A)         extends Result[A]
+  case Failure(error: Throwable) extends Result[Nothing]
+
+  def isSuccess: Boolean =
+    this match
+      case _: Success[?] =>
+        true
+      case _: Failure =>
+        false
+
+  def isFailure: Boolean = !isSuccess
+
+  /** Return the wrapped value, or rethrow the wrapped `Throwable` on failure. */
+  def get: A =
+    this match
+      case Success(v) =>
+        v
+      case Failure(e) =>
+        throw e
+
+  def getOrElse[B >: A](default: => B): B =
+    this match
+      case Success(v) =>
+        v
+      case _: Failure =>
+        default
+
+  def orElse[B >: A](alt: => Result[B]): Result[B] =
+    this match
+      case _: Success[?] =>
+        this
+      case _: Failure =>
+        alt
+
+  /** Apply `f` to the success value. Exceptions thrown by `f` become `Failure`. */
+  def map[B](f: A => B): Result[B] =
+    this match
+      case Success(v) =>
+        try
+          Result.Success(f(v))
+        catch
+          case NonFatal(e) =>
+            Result.Failure(e)
+      case fail: Failure =>
+        fail
+
+  /** Chain another `Result`-returning step. Exceptions thrown by `f` become `Failure`. */
+  def flatMap[B](f: A => Result[B]): Result[B] =
+    this match
+      case Success(v) =>
+        try
+          f(v)
+        catch
+          case NonFatal(e) =>
+            Result.Failure(e)
+      case fail: Failure =>
+        fail
+
+  /**
+    * Keep the success if `p` holds, otherwise turn it into a `Failure(NoSuchElementException)`.
+    * Enables `for`-comprehension guards.
+    */
+  def filter(p: A => Boolean): Result[A] =
+    this match
+      case Success(v) =>
+        try
+          if p(v) then
+            this
+          else
+            Result.Failure(new NoSuchElementException("Result.filter predicate is not satisfied"))
+        catch
+          case NonFatal(e) =>
+            Result.Failure(e)
+      case _: Failure =>
+        this
+
+  /** Alias of [[filter]] for `for`-comprehension support. */
+  def withFilter(p: A => Boolean): Result[A] = filter(p)
+
+  def foreach(f: A => Unit): Unit =
+    this match
+      case Success(v) =>
+        f(v)
+      case _: Failure =>
+        ()
+
+  /** Recover from a matching throwable by emitting a replacement value. Mirrors `Rx.recover`. */
+  def recover[B >: A](pf: PartialFunction[Throwable, B]): Result[B] =
+    this match
+      case Failure(e) if pf.isDefinedAt(e) =>
+        try
+          Result.Success(pf(e))
+        catch
+          case NonFatal(e2) =>
+            Result.Failure(e2)
+      case _ =>
+        this
+
+  /** Recover from a matching throwable by returning another `Result`. Mirrors `Rx.recoverWith`. */
+  def recoverWith[B >: A](pf: PartialFunction[Throwable, Result[B]]): Result[B] =
+    this match
+      case Failure(e) if pf.isDefinedAt(e) =>
+        try
+          pf(e)
+        catch
+          case NonFatal(e2) =>
+            Result.Failure(e2)
+      case _ =>
+        this
+
+  /** Translate the wrapped throwable on failure. */
+  def mapError(f: Throwable => Throwable): Result[A] =
+    this match
+      case Failure(e) =>
+        Result.Failure(f(e))
+      case _ =>
+        this
+
+  /** Eliminator: handle both branches. */
+  def fold[B](onFailure: Throwable => B, onSuccess: A => B): B =
+    this match
+      case Success(v) =>
+        onSuccess(v)
+      case Failure(e) =>
+        onFailure(e)
+
+  def toOption: Option[A] =
+    this match
+      case Success(v) =>
+        Some(v)
+      case _: Failure =>
+        None
+
+  def toEither: Either[Throwable, A] =
+    this match
+      case Success(v) =>
+        Right(v)
+      case Failure(e) =>
+        Left(e)
+
+  def toTry: Try[A] =
+    this match
+      case Success(v) =>
+        TrySuccess(v)
+      case Failure(e) =>
+        TryFailure(e)
+
+end Result
+
+object Result:
+
+  /**
+    * Evaluate `body` and wrap the outcome. Non-fatal exceptions become `Failure`; fatal errors
+    * (e.g. `InterruptedException`, `VirtualMachineError`) escape the wrapper.
+    */
+  def apply[A](body: => A): Result[A] =
+    try
+      Success(body)
+    catch
+      case NonFatal(e) =>
+        Failure(e)
+
+  def success[A](v: A): Result[A]            = Success(v)
+  def failure(e: Throwable): Result[Nothing] = Failure(e)
+
+  def fromTry[A](t: Try[A]): Result[A] =
+    t match
+      case TrySuccess(v) =>
+        Success(v)
+      case TryFailure(e) =>
+        Failure(e)
+
+  def fromEither[A](e: Either[Throwable, A]): Result[A] =
+    e match
+      case Right(v) =>
+        Success(v)
+      case Left(err) =>
+        Failure(err)
+
+  def fromOption[A](o: Option[A], ifNone: => Throwable): Result[A] =
+    o match
+      case Some(v) =>
+        Success(v)
+      case None =>
+        Failure(ifNone)
+
+end Result

--- a/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
+++ b/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
@@ -158,6 +158,25 @@ class ResultTest extends UniTest:
     Result.fromOption(None, boom) shouldBe Result.Failure(boom)
   }
 
+  test("orElse catches exceptions thrown by the alternative") {
+    val alt: Result[Int] = Result
+      .Failure(boom)
+      .orElse(throw new IllegalStateException("alt failed"))
+    alt shouldMatch { case Result.Failure(e: IllegalStateException) =>
+      e.getMessage shouldBe "alt failed"
+    }
+  }
+
+  test("fromOption catches exceptions thrown by the ifNone thunk") {
+    val r: Result[Int] = Result.fromOption(
+      Option.empty[Int],
+      throw new IllegalStateException("ifNone failed")
+    )
+    r shouldMatch { case Result.Failure(e: IllegalStateException) =>
+      e.getMessage shouldBe "ifNone failed"
+    }
+  }
+
   test("getOrElse / orElse / fold / get") {
     Result.Success(1).getOrElse(0) shouldBe 1
     Result.Failure(boom).getOrElse(0) shouldBe 0

--- a/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
+++ b/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
@@ -101,6 +101,24 @@ class ResultTest extends UniTest:
     Result.Success(1).recover(matchAll) shouldBe Result.Success(1)
   }
 
+  test("recover / recoverWith catch exceptions thrown inside the partial function") {
+    val throwingRecover: PartialFunction[Throwable, Int] = { case _: RuntimeException =>
+      throw new IllegalStateException("recovery failed")
+    }
+    Result.Failure(boom).recover(throwingRecover) shouldMatch {
+      case Result.Failure(e: IllegalStateException) =>
+        e.getMessage shouldBe "recovery failed"
+    }
+
+    val throwingRecoverWith: PartialFunction[Throwable, Result[Int]] = { case _: RuntimeException =>
+      throw new IllegalStateException("recoverWith failed")
+    }
+    Result.Failure(boom).recoverWith(throwingRecoverWith) shouldMatch {
+      case Result.Failure(e: IllegalStateException) =>
+        e.getMessage shouldBe "recoverWith failed"
+    }
+  }
+
   test("mapError translates the wrapped throwable") {
     val wrapped = Result.Failure(boom).mapError(e => new IllegalStateException(e))
     wrapped shouldMatch { case Result.Failure(e: IllegalStateException) =>

--- a/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
+++ b/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
@@ -109,6 +109,15 @@ class ResultTest extends UniTest:
     Result.Success(1).mapError(_ => boom) shouldBe Result.Success(1)
   }
 
+  test("mapError catches exceptions thrown by the translator") {
+    val translated = Result
+      .Failure(boom)
+      .mapError(_ => throw new IllegalStateException("translator failed"))
+    translated shouldMatch { case Result.Failure(e: IllegalStateException) =>
+      e.getMessage shouldBe "translator failed"
+    }
+  }
+
   test("conversions to Option/Either/Try") {
     Result.Success(1).toOption shouldBe Some(1)
     Result.Failure(boom).toOption shouldBe None

--- a/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
+++ b/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.uni.util
 
+import wvlet.uni.rx.OnCompletion
 import wvlet.uni.rx.OnError
 import wvlet.uni.rx.OnNext
 import wvlet.uni.rx.Rx
@@ -146,18 +147,26 @@ class ResultTest extends UniTest:
     }
   }
 
-  test("Rx.materialize reifies OnNext and OnError as Result values") {
+  test("Rx.materialize reifies OnNext and OnError as Result values and completes") {
     val events = Seq.newBuilder[RxEvent]
     RxRunner.run(Rx.exception[Int](boom).materialize)(events += _)
-    events.result() shouldMatch { case OnNext(v) +: _ =>
-      v shouldBe Result.Failure(boom)
-    }
+    events.result() shouldBe Seq(OnNext(Result.Failure(boom)), OnCompletion)
 
     val ok = Seq.newBuilder[RxEvent]
     RxRunner.run(Rx.single(1).materialize)(ok += _)
-    ok.result() shouldMatch { case OnNext(v) +: _ =>
-      v shouldBe Result.Success(1)
-    }
+    ok.result() shouldBe Seq(OnNext(Result.Success(1)), OnCompletion)
+  }
+
+  test("Rx.materialize emits Result values for multi-element streams") {
+    val events = Seq.newBuilder[RxEvent]
+    RxRunner.run(Rx.fromSeq(Seq(1, 2, 3)).materialize)(events += _)
+    events.result() shouldBe
+      Seq(
+        OnNext(Result.Success(1)),
+        OnNext(Result.Success(2)),
+        OnNext(Result.Success(3)),
+        OnCompletion
+      )
   }
 
   test("Rx.fromResult and Result.toRx round-trip") {

--- a/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
+++ b/uni/src/test/scala/wvlet/uni/util/ResultTest.scala
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.util
+
+import wvlet.uni.rx.OnError
+import wvlet.uni.rx.OnNext
+import wvlet.uni.rx.Rx
+import wvlet.uni.rx.RxEvent
+import wvlet.uni.rx.RxRunner
+import wvlet.uni.test.UniTest
+
+import scala.util.{Failure as TryFailure, Success as TrySuccess}
+
+class ResultTest extends UniTest:
+
+  private val boom = new RuntimeException("boom")
+
+  test("Result.apply wraps non-fatal throwables") {
+    Result(1) shouldBe Result.Success(1)
+    Result(throw boom) shouldBe Result.Failure(boom)
+  }
+
+  test("fatal errors escape Result.apply") {
+    intercept[InterruptedException] {
+      Result(throw new InterruptedException("fatal"))
+    }
+  }
+
+  test("map/flatMap propagate thrown exceptions as Failure") {
+    val r1: Result[Int] = Result.Success(1).map(_ => throw boom)
+    r1 shouldMatch { case Result.Failure(e) =>
+      e shouldBe boom
+    }
+
+    val r2: Result[Int] = Result.Success(1).flatMap(_ => throw boom)
+    r2 shouldMatch { case Result.Failure(e) =>
+      e shouldBe boom
+    }
+
+    Result.Failure(boom).map((x: Int) => x + 1) shouldBe Result.Failure(boom)
+    Result.Failure(boom).flatMap((x: Int) => Result.Success(x + 1)) shouldBe Result.Failure(boom)
+  }
+
+  test("for-comprehension short-circuits on Failure") {
+    val good: Result[Int] = Result.Success(1)
+    val bad: Result[Int]  = Result.Failure(boom)
+
+    val sum =
+      for
+        a <- good
+        b <- good
+      yield a + b
+    sum shouldBe Result.Success(2)
+
+    val shortCircuited =
+      for
+        a <- good
+        b <- bad
+        c <- good
+      yield a + b + c
+    shortCircuited shouldBe Result.Failure(boom)
+  }
+
+  test("filter turns a failing predicate into Failure(NoSuchElementException)") {
+    val kept: Result[Int] = Result.Success(1).filter(_ > 0)
+    kept shouldBe Result.Success(1)
+
+    Result.Success(0).filter(_ > 0) shouldMatch { case Result.Failure(_: NoSuchElementException) =>
+    }
+  }
+
+  test("recover / recoverWith only fire for matching exceptions") {
+    val matchAll: PartialFunction[Throwable, Int] = { case _: RuntimeException =>
+      42
+    }
+    val matchIO: PartialFunction[Throwable, Int] = { case _: java.io.IOException =>
+      42
+    }
+
+    Result.Failure(boom).recover(matchAll) shouldBe Result.Success(42)
+    Result.Failure(boom).recover(matchIO) shouldBe Result.Failure(boom)
+
+    Result
+      .Failure(boom)
+      .recoverWith { case _: RuntimeException =>
+        Result.Success(7)
+      } shouldBe Result.Success(7)
+
+    Result.Success(1).recover(matchAll) shouldBe Result.Success(1)
+  }
+
+  test("mapError translates the wrapped throwable") {
+    val wrapped = Result.Failure(boom).mapError(e => new IllegalStateException(e))
+    wrapped shouldMatch { case Result.Failure(e: IllegalStateException) =>
+      e.getCause shouldBe boom
+    }
+    Result.Success(1).mapError(_ => boom) shouldBe Result.Success(1)
+  }
+
+  test("conversions to Option/Either/Try") {
+    Result.Success(1).toOption shouldBe Some(1)
+    Result.Failure(boom).toOption shouldBe None
+
+    Result.Success(1).toEither shouldBe Right(1)
+    Result.Failure(boom).toEither shouldBe Left(boom)
+
+    Result.Success(1).toTry shouldBe TrySuccess(1)
+    Result.Failure(boom).toTry shouldBe TryFailure(boom)
+  }
+
+  test("fromTry / fromEither / fromOption") {
+    Result.fromTry(TrySuccess(1)) shouldBe Result.Success(1)
+    Result.fromTry(TryFailure(boom)) shouldBe Result.Failure(boom)
+
+    Result.fromEither(Right(1)) shouldBe Result.Success(1)
+    Result.fromEither(Left(boom)) shouldBe Result.Failure(boom)
+
+    Result.fromOption(Some(1), boom) shouldBe Result.Success(1)
+    Result.fromOption(None, boom) shouldBe Result.Failure(boom)
+  }
+
+  test("getOrElse / orElse / fold / get") {
+    Result.Success(1).getOrElse(0) shouldBe 1
+    Result.Failure(boom).getOrElse(0) shouldBe 0
+
+    Result.Failure(boom).orElse(Result.Success(2)) shouldBe Result.Success(2)
+    Result.Success(1).orElse(Result.Success(2)) shouldBe Result.Success(1)
+
+    Result.Success(1).fold(_ => -1, _ + 10) shouldBe 11
+    Result.Failure(boom).fold(_ => -1, (x: Int) => x + 10) shouldBe -1
+
+    Result.Success(1).get shouldBe 1
+    intercept[RuntimeException] {
+      Result.Failure(boom).get
+    }
+  }
+
+  test("Rx.materialize reifies OnNext and OnError as Result values") {
+    val events = Seq.newBuilder[RxEvent]
+    RxRunner.run(Rx.exception[Int](boom).materialize)(events += _)
+    events.result() shouldMatch { case OnNext(v) +: _ =>
+      v shouldBe Result.Failure(boom)
+    }
+
+    val ok = Seq.newBuilder[RxEvent]
+    RxRunner.run(Rx.single(1).materialize)(ok += _)
+    ok.result() shouldMatch { case OnNext(v) +: _ =>
+      v shouldBe Result.Success(1)
+    }
+  }
+
+  test("Rx.fromResult and Result.toRx round-trip") {
+    import wvlet.uni.rx.ResultConverter
+
+    val successEvents = Seq.newBuilder[RxEvent]
+    RxRunner.run(Rx.fromResult(Result.Success(1)))(successEvents += _)
+    successEvents.result() shouldMatch { case OnNext(1) +: _ =>
+    }
+
+    val failureEvents = Seq.newBuilder[RxEvent]
+    RxRunner.run(Result.Failure(boom).toRx)(failureEvents += _)
+    failureEvents.result() shouldMatch { case OnError(e) +: _ =>
+      e shouldBe boom
+    }
+  }
+
+end ResultTest


### PR DESCRIPTION
## Summary

Introduces `wvlet.uni.util.Result[A]`, Uni's Rust-flavored single-parameter
result type for APIs that want to represent "this may fail" as a value
without giving up Scala's exception mechanism.

- **`Result[A]`** (enum with `Success` / `Failure(Throwable)`) lives in
  `uni-core/src/main/scala/wvlet/uni/util/Result.scala`.
- Combinators mirror `Rx` — `recover`, `recoverWith`, `mapError`,
  `map`/`flatMap` that catch `NonFatal` and propagate it as `Failure` —
  so switching between `Rx[A]` and `Result[A]` is mechanical.
- **Rx interop**: `RxOps[A].materialize: Rx[Result[A]]` reifies each
  event as a value; `Rx.fromResult` and `Result.toRx` close the loop.
- Single `Throwable` error channel — explicitly rejecting ZIO's triple
  to keep the shape single-parameter like `Option[A]` / `Rx[A]`.
- Reference page at `/core/result` plus sidebar entries in both `/guide/`
  and `/` blocks of the VitePress config.

Design notes: [plans/swirling-stargazing-crescent.md](plans/swirling-stargazing-crescent.md).

## Test plan

- [x] `./sbt scalafmtAll`
- [x] `./sbt "uniJVM/testOnly wvlet.uni.util.ResultTest"` — 12/12 pass
- [x] `./sbt coreJS/compile coreNative/compile` — cross-platform
- [x] `npm run docs:build` — sidebar navigable, no dead links