### PR TITLE
feature: Port property-based testing into UniTest, drop ScalaCheck dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ val JS_JAVA_LOGGING_VERSION             = "1.0.0"
 val JUNIT_PLATFORM_VERSION              = "6.0.3"
 val SCALA_NATIVE_TEST_INTERFACE_VERSION = "0.5.8"
 val SBT_TEST_INTERFACE_VERSION          = "1.0"
-val SCALACHECK_VERSION                  = "1.19.0"
 
 // Common build settings
 val buildSettings = Seq[Setting[?]](
@@ -188,12 +187,7 @@ lazy val test = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     buildSettings,
     name           := "uni-test",
     description    := "Lightweight testing framework with AirSpec syntax",
-    testFrameworks := Seq(new TestFramework("wvlet.uni.test.Framework")),
-    libraryDependencies ++=
-      Seq(
-        // ScalaCheck for property-based testing
-        "org.scalacheck" %%% "scalacheck" % SCALACHECK_VERSION
-      )
+    testFrameworks := Seq(new TestFramework("wvlet.uni.test.Framework"))
   )
   .jvmSettings(
     libraryDependencies ++=

--- a/docs/core/unitest.md
+++ b/docs/core/unitest.md
@@ -360,32 +360,216 @@ class UserServiceTest extends UniTest:
 
 ## Property-Based Testing
 
-UniTest integrates with ScalaCheck for property-based testing:
+UniTest ships a self-contained property-based testing toolkit — no external
+dependency. Mix in the `PropertyCheck` trait and call `forAll` with a body
+that holds for every randomly generated input. A failing run is automatically
+*shrunk* to a minimal counter-example, and the seed is reported so the run
+can be replayed.
 
 ```scala
 import wvlet.uni.test.UniTest
 import wvlet.uni.test.PropertyCheck
-import org.scalacheck.Gen
 
-class PropertyTest extends UniTest with PropertyCheck:
+class ListLawsTest extends UniTest with PropertyCheck:
   test("addition is commutative") {
     forAll { (a: Int, b: Int) =>
       (a + b) shouldBe (b + a)
     }
   }
 
-  test("list reverse") {
-    forAll { (list: List[Int]) =>
-      list.reverse.reverse shouldBe list
-    }
-  }
-
-  test("custom generator") {
-    forAll(Gen.posNum[Int]) { n =>
-      (n > 0) shouldBe true
+  test("reverse is an involution") {
+    forAll { (xs: List[Int]) =>
+      xs.reverse.reverse shouldBe xs
     }
   }
 ```
+
+### Generators
+
+Generators live in `wvlet.uni.test.check.Gen`. Every `forAll` body receives
+randomly generated values — by default drawn from the type's implicit
+`Arbitrary` instance, or from a `Gen` you supply explicitly.
+
+```scala
+import wvlet.uni.test.check.Gen
+
+test("positive integers") {
+  forAll(Gen.posNum[Int]) { n =>
+    (n > 0) shouldBe true
+  }
+}
+
+test("bounded integers") {
+  forAll(Gen.chooseNum(1, 100)) { n =>
+    (n >= 1 && n <= 100) shouldBe true
+  }
+}
+```
+
+Common combinators:
+
+| Factory | Produces |
+|---------|----------|
+| `Gen.const(x)` | Always `x` |
+| `Gen.chooseNum[T](min, max)` | Uniform integer in `[min, max]` |
+| `Gen.posNum[T]` | Positive, non-zero value |
+| `Gen.oneOf(a, b, c)` | Uniform choice from values |
+| `Gen.oneOfGen(g1, g2)` | Uniform choice from generators |
+| `Gen.frequency(w1 -> g1, w2 -> g2)` | Weighted choice from generators |
+| `Gen.listOf(g)` / `Gen.nonEmptyListOf(g)` | List of `g`, size-aware |
+| `Gen.listOfN(n, g)` | List of exactly `n` elements |
+| `Gen.setOf(g)` / `Gen.mapOf(gK, gV)` | Set / Map, size-aware |
+| `Gen.option(g)` | `Some(g)` or `None` |
+| `Gen.alphaChar` / `.numChar` / `.alphaNumChar` / `.asciiChar` | Single character |
+| `Gen.alphaStr` / `.numStr` / `.alphaNumStr` / `.asciiStr` | Size-aware string |
+| `Gen.identifier` | `[A-Za-z][A-Za-z0-9]*` |
+| `Gen.sized(n => g)` / `Gen.resize(n, g)` | Read or override the current size |
+
+Generators compose like `Option`s: `g.map`, `g.flatMap`, `g.filter`, `g.zip`,
+plus for-comprehensions.
+
+```scala
+val evenPositive: Gen[Int] = Gen.posNum[Int].map(_ * 2)
+
+val labeledInt: Gen[(String, Int)] =
+  for
+    label <- Gen.alphaStr
+    value <- Gen.chooseNum(0, 100)
+  yield (label, value)
+```
+
+### Arbitrary and derivation
+
+Implicit `Arbitrary[T]` instances drive the argument-less `forAll` overload.
+Defaults ship for primitives, `String`, `Array[Byte]`, `List`, `Vector`,
+`Option`, and small tuples. For your own types, use Scala 3's `derives`:
+
+```scala
+import wvlet.uni.test.check.Arbitrary
+
+case class Point(x: Int, y: Int) derives Arbitrary
+
+sealed trait Shape derives Arbitrary
+case class Circle(r: Int)                   extends Shape
+case class Rect(w: Int, h: Int)             extends Shape
+case class Triangle(a: Int, b: Int, c: Int) extends Shape
+
+test("shapes round-trip through the renderer") {
+  forAll { (s: Shape) =>
+    Renderer.parse(Renderer.show(s)) shouldBe s
+  }
+}
+```
+
+Derivation is recursive: a `derives Arbitrary` on a sealed trait picks up
+each case class automatically, and fields of user types that themselves have
+an `Arbitrary` given (or a `Mirror`) are threaded through.
+
+To summon a default generator explicitly, use `Arbitrary.arbitrary[T]`:
+
+```scala
+forAll(Arbitrary.arbitrary[String]) { s =>
+  s.length >= 0 shouldBe true
+}
+```
+
+### Shrinking
+
+When a property fails, the runner shrinks the counter-example to a minimal
+value. Default shrinkers ship for numeric primitives, `Char`, `String`,
+`Array[Byte]`, `List`, `Option`, and tuples up to arity 5.
+
+```scala
+test("sum is never negative for non-negative inputs") {
+  forAll { (xs: List[Int]) =>
+    xs.filter(_ >= 0).sum >= 0 shouldBe true
+  }
+}
+```
+
+If this property were broken, the error message would point at a minimal
+list — typically `List(...)` with one or two elements — rather than the raw
+random failing input.
+
+User types get an empty shrinker by default, so `forAll[MyCaseClass]`
+compiles even without a shrink instance. To customize, provide a given:
+
+```scala
+import wvlet.uni.test.check.Shrink
+
+given Shrink[Point] = Shrink { p =>
+  LazyList(Point(0, 0), Point(p.x, 0), Point(0, p.y))
+}
+```
+
+### Preconditions with `==>`
+
+Use `==>` to discard samples that don't satisfy a precondition. The runner
+retries with a new sample and fails the test only if the discard budget
+(default: 500) runs out.
+
+```scala
+test("division by non-zero is self-inverse") {
+  forAll { (a: Int, b: Int) =>
+    (b != 0) ==> {
+      ((a * b) / b) shouldBe a
+    }
+  }
+}
+```
+
+### Statistics: `classify` and `collect`
+
+Break down what the generator is actually producing to make sure your
+property is exercising the cases you care about. Counts print after the
+run.
+
+```scala
+test("partition respects predicate") {
+  forAll(Gen.listOf(Gen.chooseNum(-100, 100))) { xs =>
+    classify(xs.isEmpty, "empty")
+    classify(xs.size > 50, "large")
+    collect(s"size=${xs.size / 10 * 10}")
+    val (neg, nonNeg) = xs.partition(_ < 0)
+    (neg ++ nonNeg).sorted shouldBe xs.sorted
+  }
+}
+```
+
+Output (example):
+```
+[property] 42 × size=10, 31 × size=0, 18 × large, 9 × size=20, 7 × empty
+```
+
+### Configuration
+
+Override `propertyConfig` on the test class to change sample count, seed,
+size range, discard limit, or shrink budget for every `forAll` in that
+class. For a one-off tweak of the sample count, override
+`minSuccessfulTests`.
+
+```scala
+import wvlet.uni.test.check.PropertyConfig
+
+class HeavyPropertyTest extends UniTest with PropertyCheck:
+  override protected def propertyConfig: PropertyConfig =
+    PropertyConfig.default
+      .withMinSuccessful(500)
+      .withSize(0, 256)
+      .withSeed(1_234L) // reproducible runs
+```
+
+| Knob | Method | Default |
+|------|--------|---------|
+| Samples | `withMinSuccessful(n)` | 100 |
+| Discard limit | `withMaxDiscarded(n)` | 500 |
+| Size range | `withSize(min, max)` | `0..100` |
+| Shrink budget | `withMaxShrinks(n)` | 1000 |
+| Seed | `withSeed(s)` | `System.nanoTime()` |
+
+Every failure includes the seed. To reproduce a flaky failure, copy the
+seed from the error message into `propertyConfig.withSeed(...)` and rerun
+— the exact same samples are drawn.
 
 ## Running Tests
 

--- a/docs/core/unitest.md
+++ b/docs/core/unitest.md
@@ -361,16 +361,16 @@ class UserServiceTest extends UniTest:
 ## Property-Based Testing
 
 UniTest ships a self-contained property-based testing toolkit — no external
-dependency. Mix in the `PropertyCheck` trait and call `forAll` with a body
-that holds for every randomly generated input. A failing run is automatically
-*shrunk* to a minimal counter-example, and the seed is reported so the run
-can be replayed.
+dependency — and it's part of the base `UniTest` trait. Any test class
+gets `forAll` automatically. Call it with a body that holds for every
+randomly generated input; a failing run is automatically *shrunk* to a
+minimal counter-example, and the seed is reported so the run can be
+replayed.
 
 ```scala
 import wvlet.uni.test.UniTest
-import wvlet.uni.test.PropertyCheck
 
-class ListLawsTest extends UniTest with PropertyCheck:
+class ListLawsTest extends UniTest:
   test("addition is commutative") {
     forAll { (a: Int, b: Int) =>
       (a + b) shouldBe (b + a)
@@ -502,17 +502,25 @@ given Shrink[Point] = Shrink { p =>
 }
 ```
 
-### Preconditions with `==>`
+### Preconditions with `==>` / `implies`
 
-Use `==>` to discard samples that don't satisfy a precondition. The runner
-retries with a new sample and fails the test only if the discard budget
-(default: 500) runs out.
+Use `==>` (or its English alias `implies`) to discard samples that don't
+satisfy a precondition. The runner retries with a new sample and fails the
+test only if the discard budget (default: 500) runs out.
 
 ```scala
 test("division by non-zero is self-inverse") {
   forAll { (a: Int, b: Int) =>
     (b != 0) ==> {
       ((a * b) / b) shouldBe a
+    }
+  }
+}
+
+test("reads the same way in prose") {
+  forAll { (xs: List[Int]) =>
+    xs.nonEmpty implies {
+      xs.head shouldBe xs(0)
     }
   }
 }
@@ -551,7 +559,7 @@ class. For a one-off tweak of the sample count, override
 ```scala
 import wvlet.uni.test.check.PropertyConfig
 
-class HeavyPropertyTest extends UniTest with PropertyCheck:
+class HeavyPropertyTest extends UniTest:
   override protected def propertyConfig: PropertyConfig =
     PropertyConfig.default
       .withMinSuccessful(500)
@@ -633,5 +641,7 @@ UniTest works across all Scala 3 platforms:
 
 ```scala
 import wvlet.uni.test.UniTest
-import wvlet.uni.test.PropertyCheck  // For property-based testing
+// Property-based testing is part of UniTest — nothing else to import.
+// For custom generators / shrinkers:
+import wvlet.uni.test.check.{Arbitrary, Gen, Shrink, PropertyConfig}
 ```

--- a/plans/2026-04-18-port-property-check.md
+++ b/plans/2026-04-18-port-property-check.md
@@ -1,0 +1,144 @@
+# Port Property-Based Testing into UniTest
+
+## Motivation
+
+UniTest currently depends on ScalaCheck (`org.scalacheck:scalacheck:1.19.0`) solely to back its `PropertyCheck` trait. This is the only runtime dependency uni-test carries beyond sbt/JUnit test interfaces.
+
+Goals of uni-test:
+- Minimal dependencies (per project CLAUDE.md guidance for uni)
+- Be a self-contained lightweight test framework
+
+The ScalaCheck surface actually used by the project is small, but we want enough parity with ScalaCheck that future tests in uni and in consumer projects don't feel cramped. The user asked for a broad port in one pass.
+
+## Scope
+
+**Ported into uni-test**:
+
+1. **Generators (`wvlet.uni.test.check.Gen`)**
+   - Core: `map`, `flatMap`, `filter`/`withFilter`, `zip`
+   - Factories: `const`, `oneOf`, `chooseNum[T]`, `posNum[T]`
+   - Size-aware: `sized`, `resize`
+   - Weighted: `frequency`
+   - Containers: `listOf`, `listOfN`, `nonEmptyListOf`, `setOf`, `mapOf`, `option`
+   - Characters: `alphaChar`, `alphaLowerChar`, `alphaUpperChar`, `numChar`, `alphaNumChar`, `asciiChar`, `asciiPrintableChar`
+   - Strings: `stringOf`, `stringOfN`, `alphaStr`, `numStr`, `alphaNumStr`, `asciiStr`, `identifier`
+2. **Arbitrary typeclass (`wvlet.uni.test.check.Arbitrary`)**
+   - Defaults for `Boolean`, `Byte`, `Short`, `Int`, `Long`, `Float`, `Double`, `Char`, `String`, `Array[Byte]`, `List[A]`, `Option[A]`, `Tuple2..5`
+   - Scala 3 `Mirror`-based derivation for product and sum types (opt-in via `Arbitrary.derived`)
+3. **Shrink typeclass (`wvlet.uni.test.check.Shrink`)**
+   - Defaults for numeric primitives, `String`, `List[A]`, `Option[A]`, `Tuple2..5`
+   - Runner minimises the counter-example on failure (breadth-first shrink with bounded iterations)
+4. **Property runner (`wvlet.uni.test.PropertyCheck`)**
+   - Backward-compatible `forAll` API (1–5 parameters, implicit `Arbitrary` or explicit `Gen`)
+   - `PropertyConfig` with `minSuccessfulTests`, `maxDiscarded`, `minSize`, `maxSize`, optional `seed`
+   - Per-test override: `propertyConfig`
+   - Seeded, reproducible runs: failure messages include the seed so failing runs can be replayed
+   - `==>` implication / discard support
+   - `classify(cond, label, fallback?)` and `collect(labels)` for result bucketing, reported on test success
+5. **Removal of the ScalaCheck dependency** from `build.sbt`.
+
+**Explicitly out of scope for this PR**:
+- ScalaCheck's stateful `Commands` framework (model-based testing). It's rarely used and would be several days of additional work; port on demand.
+- Full ScalaCheck `Prop` / `Properties` combinator tree (`prop1 && prop2`, `exists`, `==>` at `Prop` level). We support the common case via imperative test bodies; richer combinators can be layered on later.
+
+## Design
+
+### Layout
+
+```
+uni-test/src/main/scala/wvlet/uni/test/
+├── PropertyCheck.scala                  # public forAll API + runner + classify/discard
+└── check/
+    ├── Gen.scala                        # Gen[A], Params, Choose, PosNum, combinators
+    ├── Arbitrary.scala                  # typeclass, default givens, derivation
+    ├── Shrink.scala                     # typeclass, default givens, minimiser
+    └── PropertyConfig.scala             # config + discard exception
+```
+
+### Gen threads size + RNG
+
+`Gen[A]` is a function from `Params` to `A`, where `Params` holds a `Random` and a current size:
+
+```scala
+final case class Params(rng: Random, size: Int)
+final class Gen[+A](val run: Params => A)
+```
+
+`sized(f: Int => Gen[A])` reads `Params.size`; `resize(n)(g)` substitutes it. Containers default to `sized(n => Gen.chooseNum(0, n).flatMap(listOfN(_, g)))` so the generated shape grows with size.
+
+### Shrink: breadth-first bounded minimiser
+
+```scala
+trait Shrink[A]:
+  def shrink(a: A): LazyList[A]
+```
+
+Primitive shrinks follow ScalaCheck-style halving-toward-zero. `List`/`String` shrink by shortening plus element-wise shrinks. The runner, upon failure, tries each candidate in order, keeps the first candidate that still fails, and recurses with a cap of ~1000 shrink steps to bound runtime.
+
+### PropertyConfig
+
+```scala
+final case class PropertyConfig(
+    minSuccessfulTests: Int = 100,
+    maxDiscarded: Int = 500,
+    minSize: Int = 0,
+    maxSize: Int = 100,
+    seed: Option[Long] = None
+):
+  def withMinSuccessful(n: Int): PropertyConfig
+  def withMaxDiscarded(n: Int): PropertyConfig
+  def withSize(min: Int, max: Int): PropertyConfig
+  def withSeed(s: Long): PropertyConfig
+```
+
+`PropertyCheck` exposes `propertyConfig: PropertyConfig` that subclasses can override.
+
+### Discard / implication
+
+```scala
+object PropertyCheck:
+  extension (cond: Boolean)
+    def ==>[A](body: => A): A = if cond then body else throw DiscardException
+```
+
+`DiscardException` is caught by the runner and counted toward `maxDiscarded`. Exhaustion throws a failure.
+
+### classify / collect
+
+A thread-local `StatsCollector` is active for the duration of a single `forAll` run. On successful completion, counts are logged via `info(...)` unless suppressed. Adds no fields to test bodies — works through effectful methods on the trait.
+
+### Derivation
+
+Scala 3 inline derivation from `scala.deriving.Mirror`:
+
+```scala
+inline def derived[T](using m: Mirror.Of[T]): Arbitrary[T]
+```
+
+For products: summon `Arbitrary` for each element type, produce a tuple, hand to `fromProduct`.
+For sums: `Gen.oneOf` over the sub-type instances.
+
+## Migration Plan
+
+1. Add `check.Gen`, `check.Arbitrary`, `check.Shrink`, `check.PropertyConfig` to uni-test.
+2. Rewrite `PropertyCheck.scala` to use them. Public `forAll(...)` signatures stay source-compatible with the ScalaCheck-backed version.
+3. Update call sites in `uni`:
+   - `org.scalacheck.Gen` → `wvlet.uni.test.check.Gen`
+   - `org.scalacheck.Arbitrary.arbitrary` → `wvlet.uni.test.check.Arbitrary.arbitrary`
+4. Drop `scalacheck` from `build.sbt`.
+5. Add comprehensive self-tests in `uni-test/src/test/` covering generators, shrinking, discard, classify, derivation, and failure reporting.
+6. Run the full JVM test suite; verify JS/Native compile.
+
+## Risks
+
+- **Shrinking correctness**: a broken shrinker can loop or report wrong counter-examples. Mitigation: bounded iterations; self-tests assert that a deliberate failing property reports the minimal expected input.
+- **Derivation compile-time cost**: inline deriving of recursive ADTs can blow up; we only derive on explicit `Arbitrary.derived` and keep the derivation shallow.
+- **String generator semantics**: must produce broad unicode (including surrogate pairs) to keep roundtrip coverage on par with ScalaCheck. Verified by `RoundTripTest.support String`.
+- **Float/Double NaN**: equality-based assertions fail on NaN; our defaults exclude NaN to match the practical ScalaCheck behavior in existing tests. Callers that need NaN can build an explicit `Gen`.
+- **Seed reproducibility**: the seed used by each property is logged in failure messages; callers can replay by overriding `propertyConfig.withSeed(seed)`.
+
+## Testing
+
+- Existing property tests continue to pass: `RoundTripTest`, `ValueTest`, `ULIDTest`, `CrockfordBase32Test`, `PrefixedULIDTest`.
+- New `PropertyCheckTest` covers: chooseNum bounds, posNum, sized/resize, frequency, listOf/mapOf, char/string gens, discard, shrink minimisation, derivation, failure messages with seed.
+- JS and Native compile.

--- a/uni-test/src/main/scala/wvlet/uni/test/PropertyCheck.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/PropertyCheck.scala
@@ -62,35 +62,42 @@ trait PropertyCheck:
 
   // ---- Classify/collect support ---------------------------------------------------------------
 
-  private val statsStack = scala
-    .collection
-    .mutable
-    .ArrayDeque
-    .empty[mutable.LinkedHashMap[String, Int]]
+  // Per-thread stack of stats collectors. Using a ThreadLocal keeps `classify`/`collect` correct
+  // when two threads in the same suite run property checks concurrently.
+  private val statsStack =
+    new ThreadLocal[mutable.ArrayDeque[mutable.LinkedHashMap[String, Int]]]:
+      override def initialValue(): mutable.ArrayDeque[mutable.LinkedHashMap[String, Int]] =
+        mutable.ArrayDeque.empty
+
+  private def currentStats: Option[mutable.LinkedHashMap[String, Int]] =
+    val s = statsStack.get()
+    if s.isEmpty then
+      None
+    else
+      Some(s.last)
 
   /**
     * Record a classification label within the current property. Only active while a `forAll` is
     * running; counts are surfaced in the final success message.
     */
-  protected def classify(cond: Boolean, ifTrue: String, ifFalse: String = ""): Unit =
-    if statsStack.nonEmpty then
+  protected def classify(cond: Boolean, ifTrue: String, ifFalse: String = ""): Unit = currentStats
+    .foreach { stats =>
       val label =
         if cond then
           ifTrue
         else
           ifFalse
       if label.nonEmpty then
-        val stats = statsStack.last
         stats.update(label, stats.getOrElse(label, 0) + 1)
+    }
 
   /**
     * Record a classification label for the current property. Typical use:
     * `collect(s"bucket=${bucket(n)}")`.
     */
-  protected def collect(label: String): Unit =
-    if statsStack.nonEmpty then
-      val stats = statsStack.last
-      stats.update(label, stats.getOrElse(label, 0) + 1)
+  protected def collect(label: String): Unit = currentStats.foreach(stats =>
+    stats.update(label, stats.getOrElse(label, 0) + 1)
+  )
 
   // ---- ==> operator ---------------------------------------------------------------------------
 
@@ -130,7 +137,8 @@ trait PropertyCheck:
   private def mkParams(rng: Random, config: PropertyConfig, sampleIdx: Int, total: Int): Params =
     val span = math.max(1, config.maxSize - config.minSize)
     // Linearly grow size with sample index so early samples stay small (helpful for shrinking).
-    val size = config.minSize + ((sampleIdx * span) / math.max(1, total))
+    // Use a Long intermediate: for large `maxSize * minSuccessfulTests`, the Int product overflows.
+    val size = config.minSize + ((sampleIdx.toLong * span) / math.max(1, total)).toInt
     Params(rng, math.min(config.maxSize, size))
 
   /**
@@ -148,7 +156,8 @@ trait PropertyCheck:
     val seed   = runnerSeed()
     val rng    = Random(seed)
     val stats  = mutable.LinkedHashMap.empty[String, Int]
-    statsStack += stats
+    val stack  = statsStack.get()
+    stack += stats
     var succeeded = 0
     var discarded = 0
     try
@@ -182,7 +191,7 @@ trait PropertyCheck:
               buildFailureMessage(describe(minimal), e, seed),
               TestSource.generate
             )
-    finally statsStack.removeLast()
+    finally stack.removeLast()
     end try
 
     if stats.nonEmpty then
@@ -259,7 +268,11 @@ trait PropertyCheck:
       case null =>
         "null"
       case ba: Array[Byte] =>
-        ba.mkString("Array(", ", ", ")")
+        // Cap long arrays so a failing large sample can't blow up the failure message.
+        if ba.length > 32 then
+          ba.take(32).mkString("Array(", ", ", s", …+${ba.length - 32} bytes)")
+        else
+          ba.mkString("Array(", ", ", ")")
       case s: String =>
         s"\"${s}\""
       case other =>

--- a/uni-test/src/main/scala/wvlet/uni/test/PropertyCheck.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/PropertyCheck.scala
@@ -13,15 +13,22 @@
  */
 package wvlet.uni.test
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
-import org.scalacheck.Prop
-import org.scalacheck.Test
-import org.scalacheck.Test.Parameters
+import scala.collection.mutable
+import scala.util.Random
+import wvlet.uni.test.check.Arbitrary
+import wvlet.uni.test.check.DiscardException
+import wvlet.uni.test.check.Gen
+import wvlet.uni.test.check.Params
+import wvlet.uni.test.check.PropertyConfig
+import wvlet.uni.test.check.Shrink
 
 /**
-  * Property-based testing support using ScalaCheck. Mix in this trait with UniTest to use forAll
-  * method for property-based testing.
+  * Property-based testing support, self-contained within uni-test (no external dependency).
+  *
+  * Mix in this trait with [[UniTest]] to use [[forAll]] for property-based testing. Each property
+  * runs [[PropertyConfig.minSuccessfulTests]] random samples; a failing sample is shrunk to a
+  * minimal counter-example (see [[Shrink]]), and the failing input plus the RNG seed are reported
+  * so the run can be replayed by overriding [[propertyConfig]] with `withSeed(...)`.
   *
   * Example:
   * {{{
@@ -34,160 +41,355 @@ import org.scalacheck.Test.Parameters
   * }}}
   */
 trait PropertyCheck:
-  private val testParameters: Parameters = Parameters.default.withMinSuccessfulTests(100)
 
   /**
-    * Run a property check with implicit Arbitrary generators for a single parameter.
+    * Number of successful samples required for a property to pass. Overriding this method is the
+    * simplest way to tighten or loosen an individual test; for finer control (seed, size range,
+    * discard budget) override [[propertyConfig]] instead.
     */
-  inline def forAll[A](body: A => Unit)(using arb: Arbitrary[A]): Unit =
-    val prop = Prop.forAll { (a: A) =>
-      body(a)
-      true
-    }
-    checkProperty(prop)
+  protected def minSuccessfulTests: Int = PropertyConfig.default.minSuccessfulTests
 
   /**
-    * Run a property check with implicit Arbitrary generators for two parameters.
+    * Override to customise the property runner (seed, size range, discard budget, shrink budget,
+    * etc.). The default honours [[minSuccessfulTests]] so that overriding just the sample count
+    * continues to work.
     */
-  inline def forAll[A, B](
-      body: (A, B) => Unit
-  )(using arbA: Arbitrary[A], arbB: Arbitrary[B]): Unit =
-    val prop = Prop.forAll { (a: A, b: B) =>
-      body(a, b)
-      true
-    }
-    checkProperty(prop)
+  protected def propertyConfig: PropertyConfig = PropertyConfig
+    .default
+    .withMinSuccessful(minSuccessfulTests)
+
+  // ---- Classify/collect support ---------------------------------------------------------------
+
+  private val statsStack = scala
+    .collection
+    .mutable
+    .ArrayDeque
+    .empty[mutable.LinkedHashMap[String, Int]]
 
   /**
-    * Run a property check with implicit Arbitrary generators for three parameters.
+    * Record a classification label within the current property. Only active while a `forAll` is
+    * running; counts are surfaced in the final success message.
     */
-  inline def forAll[A, B, C](
-      body: (A, B, C) => Unit
-  )(using arbA: Arbitrary[A], arbB: Arbitrary[B], arbC: Arbitrary[C]): Unit =
-    val prop = Prop.forAll { (a: A, b: B, c: C) =>
-      body(a, b, c)
-      true
-    }
-    checkProperty(prop)
+  protected def classify(cond: Boolean, ifTrue: String, ifFalse: String = ""): Unit =
+    if statsStack.nonEmpty then
+      val label =
+        if cond then
+          ifTrue
+        else
+          ifFalse
+      if label.nonEmpty then
+        val stats = statsStack.last
+        stats.update(label, stats.getOrElse(label, 0) + 1)
 
   /**
-    * Run a property check with implicit Arbitrary generators for four parameters.
+    * Record an arbitrary value as a classification label for the current property. Typical use:
+    * `collect(s"bucket=${bucket(n)}")`.
     */
-  inline def forAll[A, B, C, D](
-      body: (A, B, C, D) => Unit
-  )(using arbA: Arbitrary[A], arbB: Arbitrary[B], arbC: Arbitrary[C], arbD: Arbitrary[D]): Unit =
-    val prop = Prop.forAll { (a: A, b: B, c: C, d: D) =>
-      body(a, b, c, d)
-      true
-    }
-    checkProperty(prop)
+  protected def collect(label: Any): Unit =
+    if statsStack.nonEmpty then
+      val stats = statsStack.last
+      val key   = String.valueOf(label)
+      stats.update(key, stats.getOrElse(key, 0) + 1)
+
+  // ---- ==> operator ---------------------------------------------------------------------------
+
+  extension (cond: Boolean)
+    /**
+      * Discard the current sample if `cond` is false. The runner retries with a new sample, failing
+      * the property if too many discards accumulate.
+      */
+    inline def ==>[A](inline body: => A): A =
+      if cond then
+        body
+      else
+        throw DiscardException()
+
+  // ---- Runner ---------------------------------------------------------------------------------
+
+  private def runnerSeed(): Long = propertyConfig.seed.getOrElse(System.nanoTime())
+
+  private def mkParams(rng: Random, config: PropertyConfig, sampleIdx: Int, total: Int): Params =
+    val span = math.max(1, config.maxSize - config.minSize)
+    // Linearly grow size with sample index so early samples stay small (helpful for shrinking).
+    val size = config.minSize + ((sampleIdx * span) / math.max(1, total))
+    Params(rng, math.min(config.maxSize, size))
 
   /**
-    * Run a property check with implicit Arbitrary generators for five parameters.
+    * Core runner used by every `forAll` overload. `sample` produces the next tuple of inputs from
+    * the current `Params`; `describe` formats them for error messages; `body` is the property; and
+    * `shrinkInput` returns a lazy list of simpler candidate inputs.
     */
-  inline def forAll[A, B, C, D, E](body: (A, B, C, D, E) => Unit)(using
+  private def runProperty[I](
+      sample: Params => I,
+      describe: I => String,
+      body: I => Any,
+      shrinkInput: I => LazyList[I]
+  ): Unit =
+    val config = propertyConfig
+    val seed   = runnerSeed()
+    val rng    = Random(seed)
+    val stats  = mutable.LinkedHashMap.empty[String, Int]
+    statsStack += stats
+    var succeeded = 0
+    var discarded = 0
+    try
+      while succeeded < config.minSuccessfulTests do
+        val params  = mkParams(rng, config, succeeded + discarded, config.minSuccessfulTests)
+        val input   = sample(params)
+        val outcome =
+          try
+            body(input)
+            Outcome.Passed
+          catch
+            case _: DiscardException =>
+              Outcome.Discarded
+            case af: AssertionFailure =>
+              Outcome.Failed(af)
+            case e: Throwable =>
+              Outcome.Failed(e)
+        outcome match
+          case Outcome.Passed =>
+            succeeded += 1
+          case Outcome.Discarded =>
+            discarded += 1
+            if discarded > config.maxDiscarded then
+              throw AssertionFailure(
+                s"Property check gave up after ${discarded} discards (seed=${seed})",
+                TestSource.generate
+              )
+          case Outcome.Failed(e) =>
+            val minimal = minimise(input, body, shrinkInput, config.maxShrinks)
+            throw AssertionFailure(
+              buildFailureMessage(describe(minimal), e, seed),
+              TestSource.generate
+            )
+    finally statsStack.removeLast()
+    end try
+
+    // Log classifications if any were collected.
+    if stats.nonEmpty then
+      val formatted = stats
+        .toSeq
+        .sortBy { case (_, n) =>
+          -n
+        }
+        .map { case (l, n) =>
+          s"${n} × ${l}"
+        }
+        .mkString(", ")
+      // Not LogSupport-dependent — use println to avoid changing the trait's parent set. Test
+      // frameworks capture stdout so these lines show alongside test output.
+      println(s"[property] ${formatted}")
+
+  end runProperty
+
+  private def buildFailureMessage(desc: String, e: Throwable, seed: Long): String =
+    val prefix =
+      e match
+        case af: AssertionFailure =>
+          af.getMessage
+        case other =>
+          Option(other.getMessage).getOrElse(other.getClass.getSimpleName)
+    s"${prefix} (property input: ${desc}, seed=${seed})"
+
+  /**
+    * Greedy shrink: given a failing input, try each candidate from `shrinkInput(current)` and keep
+    * the first that also fails. Recurse until no candidate still fails, up to `maxSteps`.
+    */
+  private def minimise[I](
+      initial: I,
+      body: I => Any,
+      shrinkInput: I => LazyList[I],
+      maxSteps: Int
+  ): I =
+    var current = initial
+    var steps   = 0
+    var done    = false
+    while !done && steps < maxSteps do
+      val next = shrinkInput(current).find { candidate =>
+        steps += 1
+        if steps > maxSteps then
+          false
+        else
+          try
+            body(candidate)
+            false
+          catch
+            case _: DiscardException =>
+              false
+            case _: Throwable =>
+              true
+      }
+      next match
+        case Some(smaller) =>
+          current = smaller
+        case None =>
+          done = true
+    current
+
+  end minimise
+
+  private enum Outcome:
+    case Passed
+    case Discarded
+    case Failed(cause: Throwable)
+
+  /**
+    * Pretty-print a generated value for error messages. Expands arrays since their default
+    * `toString` is the unreadable `[B@…` form.
+    */
+  private def display(a: Any): String =
+    a match
+      case null =>
+        "null"
+      case ba: Array[Byte] =>
+        ba.mkString("Array(", ", ", ")")
+      case s: String =>
+        s"\"${s}\""
+      case other =>
+        String.valueOf(other)
+
+  // ---- forAll with implicit Arbitrary generators --------------------------------------------
+
+  def forAll[A](body: A => Any)(using arb: Arbitrary[A], sa: Shrink[A]): Unit = runProperty[A](
+    arb.gen.apply,
+    display,
+    body,
+    sa.shrink
+  )
+
+  def forAll[A, B](
+      body: (A, B) => Any
+  )(using arbA: Arbitrary[A], arbB: Arbitrary[B], sa: Shrink[A], sb: Shrink[B]): Unit =
+    runProperty[(A, B)](
+      p => (arbA.gen(p), arbB.gen(p)),
+      t => s"(${display(t._1)}, ${display(t._2)})",
+      t => body(t._1, t._2),
+      t => shrinkPair(t._1, t._2, sa, sb)
+    )
+
+  def forAll[A, B, C](body: (A, B, C) => Any)(using
+      arbA: Arbitrary[A],
+      arbB: Arbitrary[B],
+      arbC: Arbitrary[C],
+      sa: Shrink[A],
+      sb: Shrink[B],
+      sc: Shrink[C]
+  ): Unit = runProperty[(A, B, C)](
+    p => (arbA.gen(p), arbB.gen(p), arbC.gen(p)),
+    t => s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)})",
+    t => body(t._1, t._2, t._3),
+    t => shrinkTriple(t._1, t._2, t._3, sa, sb, sc)
+  )
+
+  def forAll[A, B, C, D](body: (A, B, C, D) => Any)(using
       arbA: Arbitrary[A],
       arbB: Arbitrary[B],
       arbC: Arbitrary[C],
       arbD: Arbitrary[D],
-      arbE: Arbitrary[E]
-  ): Unit =
-    val prop = Prop.forAll { (a: A, b: B, c: C, d: D, e: E) =>
-      body(a, b, c, d, e)
-      true
-    }
-    checkProperty(prop)
+      sa: Shrink[A],
+      sb: Shrink[B],
+      sc: Shrink[C],
+      sd: Shrink[D]
+  ): Unit = runProperty[(A, B, C, D)](
+    p => (arbA.gen(p), arbB.gen(p), arbC.gen(p), arbD.gen(p)),
+    t => s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)}, ${display(t._4)})",
+    t => body(t._1, t._2, t._3, t._4),
+    t => shrinkQuad(t, sa, sb, sc, sd)
+  )
 
-  /**
-    * Run a property check with an explicit generator for a single parameter.
-    */
-  inline def forAll[A](gen: Gen[A])(body: A => Unit): Unit =
-    val prop =
-      Prop.forAll(gen) { (a: A) =>
-        body(a)
-        true
-      }
-    checkProperty(prop)
+  def forAll[A, B, C, D, E](body: (A, B, C, D, E) => Any)(using
+      arbA: Arbitrary[A],
+      arbB: Arbitrary[B],
+      arbC: Arbitrary[C],
+      arbD: Arbitrary[D],
+      arbE: Arbitrary[E],
+      sa: Shrink[A],
+      sb: Shrink[B],
+      sc: Shrink[C],
+      sd: Shrink[D],
+      se: Shrink[E]
+  ): Unit = runProperty[(A, B, C, D, E)](
+    p => (arbA.gen(p), arbB.gen(p), arbC.gen(p), arbD.gen(p), arbE.gen(p)),
+    t =>
+      s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)}, ${display(t._4)}, ${display(t._5)})",
+    t => body(t._1, t._2, t._3, t._4, t._5),
+    t => shrinkQuint(t, sa, sb, sc, sd, se)
+  )
 
-  /**
-    * Run a property check with explicit generators for two parameters.
-    */
-  inline def forAll[A, B](genA: Gen[A], genB: Gen[B])(body: (A, B) => Unit): Unit =
-    val prop =
-      Prop.forAll(genA, genB) { (a: A, b: B) =>
-        body(a, b)
-        true
-      }
-    checkProperty(prop)
+  // ---- forAll with explicit Gen (no shrinking) ----------------------------------------------
 
-  /**
-    * Run a property check with explicit generators for three parameters.
-    */
-  inline def forAll[A, B, C](genA: Gen[A], genB: Gen[B], genC: Gen[C])(
-      body: (A, B, C) => Unit
-  ): Unit =
-    val prop =
-      Prop.forAll(genA, genB, genC) { (a: A, b: B, c: C) =>
-        body(a, b, c)
-        true
-      }
-    checkProperty(prop)
+  def forAll[A](gen: Gen[A])(body: A => Any): Unit = runProperty[A](
+    gen.apply,
+    display,
+    body,
+    _ => LazyList.empty
+  )
 
-  /**
-    * Run a property check with explicit generators for four parameters.
-    */
-  inline def forAll[A, B, C, D](genA: Gen[A], genB: Gen[B], genC: Gen[C], genD: Gen[D])(
-      body: (A, B, C, D) => Unit
-  ): Unit =
-    val prop =
-      Prop.forAll(genA, genB, genC, genD) { (a: A, b: B, c: C, d: D) =>
-        body(a, b, c, d)
-        true
-      }
-    checkProperty(prop)
+  def forAll[A, B](genA: Gen[A], genB: Gen[B])(body: (A, B) => Any): Unit = runProperty[(A, B)](
+    p => (genA(p), genB(p)),
+    t => s"(${display(t._1)}, ${display(t._2)})",
+    t => body(t._1, t._2),
+    _ => LazyList.empty
+  )
 
-  private inline def checkProperty(prop: Prop): Unit =
-    val result = Test.check(testParameters, prop)
-    result.status match
-      case Test.Passed =>
-      // Success
-      case Test.Proved(_) =>
-      // Success
-      case Test.Exhausted =>
-        throw AssertionFailure(
-          s"Property check exhausted: unable to generate enough test cases after ${result
-              .discarded} discarded",
-          TestSource.generate
-        )
-      case Test.Failed(args, labels) =>
-        val argsStr   = args.map(_.arg).mkString(", ")
-        val labelsStr =
-          if labels.isEmpty then
-            ""
-          else
-            s" [${labels.mkString(", ")}]"
-        throw AssertionFailure(
-          s"Property check failed for args: (${argsStr})${labelsStr}",
-          TestSource.generate
-        )
-      case Test.PropException(args, e, labels) =>
-        val argsStr   = args.map(_.arg).mkString(", ")
-        val labelsStr =
-          if labels.isEmpty then
-            ""
-          else
-            s" [${labels.mkString(", ")}]"
-        e match
-          case af: AssertionFailure =>
-            throw af
-          case _ =>
-            throw AssertionFailure(
-              s"Property check failed for args: (${argsStr})${labelsStr}: ${e.getMessage}",
-              TestSource.generate
-            )
+  def forAll[A, B, C](genA: Gen[A], genB: Gen[B], genC: Gen[C])(body: (A, B, C) => Any): Unit =
+    runProperty[(A, B, C)](
+      p => (genA(p), genB(p), genC(p)),
+      t => s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)})",
+      t => body(t._1, t._2, t._3),
+      _ => LazyList.empty
+    )
 
-    end match
+  def forAll[A, B, C, D](genA: Gen[A], genB: Gen[B], genC: Gen[C], genD: Gen[D])(
+      body: (A, B, C, D) => Any
+  ): Unit = runProperty[(A, B, C, D)](
+    p => (genA(p), genB(p), genC(p), genD(p)),
+    t => s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)}, ${display(t._4)})",
+    t => body(t._1, t._2, t._3, t._4),
+    _ => LazyList.empty
+  )
 
-  end checkProperty
+  // ---- Private: tuple shrinkers ----------------------------------------------------------
+
+  private def shrinkPair[A, B](a: A, b: B, sa: Shrink[A], sb: Shrink[B]): LazyList[(A, B)] =
+    sa.shrink(a).map(a2 => (a2, b)) #::: sb.shrink(b).map(b2 => (a, b2))
+
+  private def shrinkTriple[A, B, C](
+      a: A,
+      b: B,
+      c: C,
+      sa: Shrink[A],
+      sb: Shrink[B],
+      sc: Shrink[C]
+  ): LazyList[(A, B, C)] =
+    sa.shrink(a).map(x => (x, b, c)) #::: sb.shrink(b).map(x => (a, x, c)) #:::
+      sc.shrink(c).map(x => (a, b, x))
+
+  private def shrinkQuad[A, B, C, D](
+      t: (A, B, C, D),
+      sa: Shrink[A],
+      sb: Shrink[B],
+      sc: Shrink[C],
+      sd: Shrink[D]
+  ): LazyList[(A, B, C, D)] =
+    sa.shrink(t._1).map(x => (x, t._2, t._3, t._4)) #:::
+      sb.shrink(t._2).map(x => (t._1, x, t._3, t._4)) #:::
+      sc.shrink(t._3).map(x => (t._1, t._2, x, t._4)) #:::
+      sd.shrink(t._4).map(x => (t._1, t._2, t._3, x))
+
+  private def shrinkQuint[A, B, C, D, E](
+      t: (A, B, C, D, E),
+      sa: Shrink[A],
+      sb: Shrink[B],
+      sc: Shrink[C],
+      sd: Shrink[D],
+      se: Shrink[E]
+  ): LazyList[(A, B, C, D, E)] =
+    sa.shrink(t._1).map(x => (x, t._2, t._3, t._4, t._5)) #:::
+      sb.shrink(t._2).map(x => (t._1, x, t._3, t._4, t._5)) #:::
+      sc.shrink(t._3).map(x => (t._1, t._2, x, t._4, t._5)) #:::
+      sd.shrink(t._4).map(x => (t._1, t._2, t._3, x, t._5)) #:::
+      se.shrink(t._5).map(x => (t._1, t._2, t._3, t._4, x))
 
 end PropertyCheck

--- a/uni-test/src/main/scala/wvlet/uni/test/PropertyCheck.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/PropertyCheck.scala
@@ -25,14 +25,16 @@ import wvlet.uni.test.check.Shrink
 /**
   * Property-based testing support, self-contained within uni-test (no external dependency).
   *
-  * Mix in this trait with [[UniTest]] to use [[forAll]] for property-based testing. Each property
-  * runs [[PropertyConfig.minSuccessfulTests]] random samples; a failing sample is shrunk to a
-  * minimal counter-example (see [[Shrink]]), and the failing input plus the RNG seed are reported
-  * so the run can be replayed by overriding [[propertyConfig]] with `withSeed(...)`.
+  * Already mixed into [[UniTest]], so any test class picks up [[forAll]] automatically. Mixing it
+  * in explicitly is harmless and kept for backward compatibility.
+  *
+  * Each property runs [[PropertyConfig.minSuccessfulTests]] random samples; a failing sample is
+  * shrunk to a minimal counter-example (see [[Shrink]]), and the failing input plus the RNG seed
+  * are reported so the run can be replayed by overriding [[propertyConfig]] with `withSeed(...)`.
   *
   * Example:
   * {{{
-  *   class MyTest extends UniTest with PropertyCheck:
+  *   class MyTest extends UniTest:
   *     test("property test") {
   *       forAll { (a: Int, b: Int) =>
   *         (a + b) shouldBe (b + a)
@@ -95,9 +97,27 @@ trait PropertyCheck:
   extension (cond: Boolean)
     /**
       * Discard the current sample if `cond` is false. The runner retries with a new sample, failing
-      * the property if too many discards accumulate.
+      * the property if too many discards accumulate. Reads naturally as "precondition implies
+      * property".
+      *
+      * {{{
+      *   forAll { (n: Int) =>
+      *     (n != 0) ==> {
+      *       ((n * 0) == 0) shouldBe true
+      *     }
+      *   }
+      * }}}
       */
     inline def ==>[A](inline body: => A): A =
+      if cond then
+        body
+      else
+        throw DiscardException()
+
+    /**
+      * English-language alias for [[==>]]: `cond implies body`. Same discard semantics.
+      */
+    inline def implies[A](inline body: => A): A =
       if cond then
         body
       else

--- a/uni-test/src/main/scala/wvlet/uni/test/PropertyCheck.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/PropertyCheck.scala
@@ -82,14 +82,13 @@ trait PropertyCheck:
         stats.update(label, stats.getOrElse(label, 0) + 1)
 
   /**
-    * Record an arbitrary value as a classification label for the current property. Typical use:
+    * Record a classification label for the current property. Typical use:
     * `collect(s"bucket=${bucket(n)}")`.
     */
-  protected def collect(label: Any): Unit =
+  protected def collect(label: String): Unit =
     if statsStack.nonEmpty then
       val stats = statsStack.last
-      val key   = String.valueOf(label)
-      stats.update(key, stats.getOrElse(key, 0) + 1)
+      stats.update(label, stats.getOrElse(label, 0) + 1)
 
   // ---- ==> operator ---------------------------------------------------------------------------
 
@@ -166,7 +165,6 @@ trait PropertyCheck:
     finally statsStack.removeLast()
     end try
 
-    // Log classifications if any were collected.
     if stats.nonEmpty then
       val formatted = stats
         .toSeq
@@ -177,8 +175,6 @@ trait PropertyCheck:
           s"${n} × ${l}"
         }
         .mkString(", ")
-      // Not LogSupport-dependent — use println to avoid changing the trait's parent set. Test
-      // frameworks capture stdout so these lines show alongside test output.
       println(s"[property] ${formatted}")
 
   end runProperty
@@ -258,64 +254,21 @@ trait PropertyCheck:
     sa.shrink
   )
 
-  def forAll[A, B](
-      body: (A, B) => Any
-  )(using arbA: Arbitrary[A], arbB: Arbitrary[B], sa: Shrink[A], sb: Shrink[B]): Unit =
-    runProperty[(A, B)](
-      p => (arbA.gen(p), arbB.gen(p)),
-      t => s"(${display(t._1)}, ${display(t._2)})",
-      t => body(t._1, t._2),
-      t => shrinkPair(t._1, t._2, sa, sb)
-    )
+  def forAll[A, B](body: (A, B) => Any)(using Arbitrary[(A, B)], Shrink[(A, B)]): Unit =
+    forAll[(A, B)](t => body(t._1, t._2))
 
-  def forAll[A, B, C](body: (A, B, C) => Any)(using
-      arbA: Arbitrary[A],
-      arbB: Arbitrary[B],
-      arbC: Arbitrary[C],
-      sa: Shrink[A],
-      sb: Shrink[B],
-      sc: Shrink[C]
-  ): Unit = runProperty[(A, B, C)](
-    p => (arbA.gen(p), arbB.gen(p), arbC.gen(p)),
-    t => s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)})",
-    t => body(t._1, t._2, t._3),
-    t => shrinkTriple(t._1, t._2, t._3, sa, sb, sc)
-  )
+  def forAll[A, B, C](body: (A, B, C) => Any)(using Arbitrary[(A, B, C)], Shrink[(A, B, C)]): Unit =
+    forAll[(A, B, C)](t => body(t._1, t._2, t._3))
 
   def forAll[A, B, C, D](body: (A, B, C, D) => Any)(using
-      arbA: Arbitrary[A],
-      arbB: Arbitrary[B],
-      arbC: Arbitrary[C],
-      arbD: Arbitrary[D],
-      sa: Shrink[A],
-      sb: Shrink[B],
-      sc: Shrink[C],
-      sd: Shrink[D]
-  ): Unit = runProperty[(A, B, C, D)](
-    p => (arbA.gen(p), arbB.gen(p), arbC.gen(p), arbD.gen(p)),
-    t => s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)}, ${display(t._4)})",
-    t => body(t._1, t._2, t._3, t._4),
-    t => shrinkQuad(t, sa, sb, sc, sd)
-  )
+      Arbitrary[(A, B, C, D)],
+      Shrink[(A, B, C, D)]
+  ): Unit = forAll[(A, B, C, D)](t => body(t._1, t._2, t._3, t._4))
 
   def forAll[A, B, C, D, E](body: (A, B, C, D, E) => Any)(using
-      arbA: Arbitrary[A],
-      arbB: Arbitrary[B],
-      arbC: Arbitrary[C],
-      arbD: Arbitrary[D],
-      arbE: Arbitrary[E],
-      sa: Shrink[A],
-      sb: Shrink[B],
-      sc: Shrink[C],
-      sd: Shrink[D],
-      se: Shrink[E]
-  ): Unit = runProperty[(A, B, C, D, E)](
-    p => (arbA.gen(p), arbB.gen(p), arbC.gen(p), arbD.gen(p), arbE.gen(p)),
-    t =>
-      s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)}, ${display(t._4)}, ${display(t._5)})",
-    t => body(t._1, t._2, t._3, t._4, t._5),
-    t => shrinkQuint(t, sa, sb, sc, sd, se)
-  )
+      Arbitrary[(A, B, C, D, E)],
+      Shrink[(A, B, C, D, E)]
+  ): Unit = forAll[(A, B, C, D, E)](t => body(t._1, t._2, t._3, t._4, t._5))
 
   // ---- forAll with explicit Gen (no shrinking) ----------------------------------------------
 
@@ -326,70 +279,34 @@ trait PropertyCheck:
     _ => LazyList.empty
   )
 
-  def forAll[A, B](genA: Gen[A], genB: Gen[B])(body: (A, B) => Any): Unit = runProperty[(A, B)](
-    p => (genA(p), genB(p)),
-    t => s"(${display(t._1)}, ${display(t._2)})",
-    t => body(t._1, t._2),
-    _ => LazyList.empty
-  )
+  def forAll[A, B](genA: Gen[A], genB: Gen[B])(body: (A, B) => Any): Unit =
+    forAll(genA.zip(genB))(t => body(t._1, t._2))
 
   def forAll[A, B, C](genA: Gen[A], genB: Gen[B], genC: Gen[C])(body: (A, B, C) => Any): Unit =
-    runProperty[(A, B, C)](
-      p => (genA(p), genB(p), genC(p)),
-      t => s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)})",
-      t => body(t._1, t._2, t._3),
-      _ => LazyList.empty
-    )
+    forAll(
+      genA
+        .zip(genB)
+        .zip(genC)
+        .map { case ((a, b), c) =>
+          (a, b, c)
+        }
+    ) { t =>
+      body(t._1, t._2, t._3)
+    }
 
   def forAll[A, B, C, D](genA: Gen[A], genB: Gen[B], genC: Gen[C], genD: Gen[D])(
       body: (A, B, C, D) => Any
-  ): Unit = runProperty[(A, B, C, D)](
-    p => (genA(p), genB(p), genC(p), genD(p)),
-    t => s"(${display(t._1)}, ${display(t._2)}, ${display(t._3)}, ${display(t._4)})",
-    t => body(t._1, t._2, t._3, t._4),
-    _ => LazyList.empty
-  )
-
-  // ---- Private: tuple shrinkers ----------------------------------------------------------
-
-  private def shrinkPair[A, B](a: A, b: B, sa: Shrink[A], sb: Shrink[B]): LazyList[(A, B)] =
-    sa.shrink(a).map(a2 => (a2, b)) #::: sb.shrink(b).map(b2 => (a, b2))
-
-  private def shrinkTriple[A, B, C](
-      a: A,
-      b: B,
-      c: C,
-      sa: Shrink[A],
-      sb: Shrink[B],
-      sc: Shrink[C]
-  ): LazyList[(A, B, C)] =
-    sa.shrink(a).map(x => (x, b, c)) #::: sb.shrink(b).map(x => (a, x, c)) #:::
-      sc.shrink(c).map(x => (a, b, x))
-
-  private def shrinkQuad[A, B, C, D](
-      t: (A, B, C, D),
-      sa: Shrink[A],
-      sb: Shrink[B],
-      sc: Shrink[C],
-      sd: Shrink[D]
-  ): LazyList[(A, B, C, D)] =
-    sa.shrink(t._1).map(x => (x, t._2, t._3, t._4)) #:::
-      sb.shrink(t._2).map(x => (t._1, x, t._3, t._4)) #:::
-      sc.shrink(t._3).map(x => (t._1, t._2, x, t._4)) #:::
-      sd.shrink(t._4).map(x => (t._1, t._2, t._3, x))
-
-  private def shrinkQuint[A, B, C, D, E](
-      t: (A, B, C, D, E),
-      sa: Shrink[A],
-      sb: Shrink[B],
-      sc: Shrink[C],
-      sd: Shrink[D],
-      se: Shrink[E]
-  ): LazyList[(A, B, C, D, E)] =
-    sa.shrink(t._1).map(x => (x, t._2, t._3, t._4, t._5)) #:::
-      sb.shrink(t._2).map(x => (t._1, x, t._3, t._4, t._5)) #:::
-      sc.shrink(t._3).map(x => (t._1, t._2, x, t._4, t._5)) #:::
-      sd.shrink(t._4).map(x => (t._1, t._2, t._3, x, t._5)) #:::
-      se.shrink(t._5).map(x => (t._1, t._2, t._3, t._4, x))
+  ): Unit =
+    forAll(
+      genA
+        .zip(genB)
+        .zip(genC)
+        .zip(genD)
+        .map { case (((a, b), c), d) =>
+          (a, b, c, d)
+        }
+    ) { t =>
+      body(t._1, t._2, t._3, t._4)
+    }
 
 end PropertyCheck

--- a/uni-test/src/main/scala/wvlet/uni/test/UniTest.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/UniTest.scala
@@ -60,7 +60,12 @@ case class TestDef(
   *     }
   * }}}
   */
-trait UniTest extends PlatformUniTest with LogSupport with Assertions with TestControl:
+trait UniTest
+    extends PlatformUniTest
+    with LogSupport
+    with Assertions
+    with TestControl
+    with PropertyCheck:
   // Storage for registered tests
   private val _tests: ListBuffer[TestDef] = ListBuffer.empty
 

--- a/uni-test/src/main/scala/wvlet/uni/test/check/Arbitrary.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/check/Arbitrary.scala
@@ -104,9 +104,16 @@ object Arbitrary:
     }
   )
 
+  // Bound `size + 1` so `size == Int.MaxValue` doesn't wrap to a negative upper bound.
+  private inline def sizeBound(size: Int): Int =
+    if size >= Int.MaxValue - 1 then
+      Int.MaxValue
+    else
+      math.max(1, size + 1)
+
   given Arbitrary[String] = Arbitrary(
     Gen { p =>
-      val target = p.rng.nextInt(math.max(1, p.size + 1)) // 0..size
+      val target = p.rng.nextInt(sizeBound(p.size)) // 0..size
       val sb     = StringBuilder()
       var count  = 0
       while count < target do
@@ -128,7 +135,7 @@ object Arbitrary:
 
   given Arbitrary[Array[Byte]] = Arbitrary(
     Gen { p =>
-      val len = p.rng.nextInt(math.max(1, p.size + 1))
+      val len = p.rng.nextInt(sizeBound(p.size))
       val arr = new Array[Byte](len)
       p.rng.nextBytes(arr)
       arr

--- a/uni-test/src/main/scala/wvlet/uni/test/check/Arbitrary.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/check/Arbitrary.scala
@@ -201,12 +201,18 @@ object Arbitrary:
   private def productArbitrary[T](
       m: Mirror.ProductOf[T],
       elems: List[Arbitrary[Any]]
-  ): Arbitrary[T] = Arbitrary(
-    Gen { p =>
-      val values = elems.map(_.gen.apply(p))
-      m.fromProduct(Tuple.fromArray(values.toArray))
-    }
-  )
+  ): Arbitrary[T] =
+    val arr = elems.toArray
+    Arbitrary(
+      Gen { p =>
+        val values = new Array[AnyRef](arr.length)
+        var i      = 0
+        while i < arr.length do
+          values(i) = arr(i).gen.apply(p).asInstanceOf[AnyRef]
+          i += 1
+        m.fromProduct(Tuple.fromArray(values))
+      }
+    )
 
   private def sumArbitrary[T](alts: List[Arbitrary[Any]]): Arbitrary[T] =
     require(alts.nonEmpty, "derived Arbitrary: sum type has no alternatives")

--- a/uni-test/src/main/scala/wvlet/uni/test/check/Arbitrary.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/check/Arbitrary.scala
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.test.check
+
+import scala.compiletime.erasedValue
+import scala.compiletime.summonFrom
+import scala.deriving.Mirror
+
+/**
+  * Default random-value generator for a given type, used by [[wvlet.uni.test.PropertyCheck.forAll]]
+  * when no explicit [[Gen]] is provided.
+  */
+trait Arbitrary[A]:
+  def gen: Gen[A]
+
+object Arbitrary:
+
+  /**
+    * Summon the generator for a type. Mirrors ScalaCheck's `Arbitrary.arbitrary[T]` helper.
+    */
+  def arbitrary[A](using arb: Arbitrary[A]): Gen[A] = arb.gen
+
+  def apply[A](g: Gen[A]): Arbitrary[A] =
+    new Arbitrary[A]:
+      def gen: Gen[A] = g
+
+  // ---- Primitive givens ----
+
+  given Arbitrary[Boolean] = Arbitrary(Gen(_.rng.nextBoolean()))
+
+  given Arbitrary[Byte]  = Arbitrary(Gen(p => p.rng.nextInt().toByte))
+  given Arbitrary[Short] = Arbitrary(Gen(p => p.rng.nextInt().toShort))
+  given Arbitrary[Int]   = Arbitrary(Gen(_.rng.nextInt()))
+  given Arbitrary[Long]  = Arbitrary(Gen(_.rng.nextLong()))
+
+  // Special float/double values to sprinkle in alongside uniformly-random values. NaN is
+  // intentionally excluded because `NaN != NaN`, which would break equality-based assertions.
+  // Callers that need NaN can build an explicit Gen.
+  private val floatSpecials: Seq[Float] = Seq(
+    0f,
+    -0f,
+    1f,
+    -1f,
+    Float.MinValue,
+    Float.MaxValue,
+    Float.PositiveInfinity,
+    Float.NegativeInfinity
+  )
+
+  private val doubleSpecials: Seq[Double] = Seq(
+    0d,
+    -0d,
+    1d,
+    -1d,
+    Double.MinValue,
+    Double.MaxValue,
+    Double.PositiveInfinity,
+    Double.NegativeInfinity
+  )
+
+  given Arbitrary[Float] = Arbitrary(
+    Gen { p =>
+      if p.rng.nextInt(10) == 0 then
+        floatSpecials(p.rng.nextInt(floatSpecials.size))
+      else
+        var f = java.lang.Float.intBitsToFloat(p.rng.nextInt())
+        while java.lang.Float.isNaN(f) do
+          f = java.lang.Float.intBitsToFloat(p.rng.nextInt())
+        f
+    }
+  )
+
+  given Arbitrary[Double] = Arbitrary(
+    Gen { p =>
+      if p.rng.nextInt(10) == 0 then
+        doubleSpecials(p.rng.nextInt(doubleSpecials.size))
+      else
+        var d = java.lang.Double.longBitsToDouble(p.rng.nextLong())
+        while java.lang.Double.isNaN(d) do
+          d = java.lang.Double.longBitsToDouble(p.rng.nextLong())
+        d
+    }
+  )
+
+  given Arbitrary[Char] = Arbitrary(
+    Gen { p =>
+      // Sample from the Basic Multilingual Plane, skipping the surrogate range. Full unicode
+      // including surrogate pairs is delegated to the String generator.
+      var c = p.rng.nextInt(0x10000)
+      while c >= 0xd800 && c <= 0xdfff do
+        c = p.rng.nextInt(0x10000)
+      c.toChar
+    }
+  )
+
+  given Arbitrary[String] = Arbitrary(
+    Gen { p =>
+      val target = p.rng.nextInt(math.max(1, p.size + 1)) // 0..size
+      val sb     = StringBuilder()
+      var count  = 0
+      while count < target do
+        // 10% chance to emit a supplementary-plane code point (a surrogate pair) to exercise
+        // unicode handling; otherwise a BMP character (skipping the surrogate range).
+        if p.rng.nextInt(10) == 0 && count + 1 < target then
+          val cp = 0x10000 + p.rng.nextInt(0x100000)
+          sb.appendAll(Character.toChars(cp))
+          count += 2
+        else
+          var c = p.rng.nextInt(0x10000)
+          while c >= 0xd800 && c <= 0xdfff do
+            c = p.rng.nextInt(0x10000)
+          sb.append(c.toChar)
+          count += 1
+      sb.result()
+    }
+  )
+
+  given Arbitrary[Array[Byte]] = Arbitrary(
+    Gen { p =>
+      val len = p.rng.nextInt(math.max(1, p.size + 1))
+      val arr = new Array[Byte](len)
+      p.rng.nextBytes(arr)
+      arr
+    }
+  )
+
+  // ---- Container givens ----
+
+  given [A](using arb: Arbitrary[A]): Arbitrary[List[A]]   = Arbitrary(Gen.listOf(arb.gen))
+  given [A](using arb: Arbitrary[A]): Arbitrary[Option[A]] = Arbitrary(Gen.option(arb.gen))
+  given [A](using arb: Arbitrary[A]): Arbitrary[Vector[A]] = Arbitrary(
+    Gen.listOf(arb.gen).map(_.toVector)
+  )
+
+  given [A, B](using arbA: Arbitrary[A], arbB: Arbitrary[B]): Arbitrary[(A, B)] = Arbitrary(
+    arbA.gen.zip(arbB.gen)
+  )
+
+  given [A, B, C](using
+      arbA: Arbitrary[A],
+      arbB: Arbitrary[B],
+      arbC: Arbitrary[C]
+  ): Arbitrary[(A, B, C)] = Arbitrary(
+    for
+      a <- arbA.gen
+      b <- arbB.gen
+      c <- arbC.gen
+    yield (a, b, c)
+  )
+
+  // ---- Derivation (Scala 3 Mirror) ----
+
+  /**
+    * Derive an `Arbitrary[T]` for a product or sum type `T`. For products, the generator samples
+    * each field independently. For sums (sealed hierarchies / enums), one subtype is picked
+    * uniformly. Usage:
+    * {{{
+    *   case class Point(x: Int, y: Int)
+    *   given Arbitrary[Point] = Arbitrary.derived
+    * }}}
+    */
+  inline def derived[T](using m: Mirror.Of[T]): Arbitrary[T] =
+    inline m match
+      case p: Mirror.ProductOf[T] =>
+        val elems = summonOrDeriveAll[p.MirroredElemTypes]
+        productArbitrary[T](p, elems)
+      case s: Mirror.SumOf[T] =>
+        val alts = summonOrDeriveAll[s.MirroredElemTypes]
+        sumArbitrary[T](alts)
+
+  /**
+    * Summon an `Arbitrary[T]` if one is in implicit scope, otherwise derive it via `Mirror.Of[T]`.
+    * Enables `derives Arbitrary` on sealed hierarchies without requiring the user to hand-write an
+    * `Arbitrary` for every case class in the tree.
+    */
+  private inline def summonOrDerive[T]: Arbitrary[T] = summonFrom {
+    case existing: Arbitrary[T] =>
+      existing
+    case m: Mirror.Of[T] =>
+      derived[T](using m)
+  }
+
+  private inline def summonOrDeriveAll[T <: Tuple]: List[Arbitrary[Any]] =
+    inline erasedValue[T] match
+      case _: EmptyTuple =>
+        Nil
+      case _: (h *: t) =>
+        summonOrDerive[h].asInstanceOf[Arbitrary[Any]] :: summonOrDeriveAll[t]
+
+  private def productArbitrary[T](
+      m: Mirror.ProductOf[T],
+      elems: List[Arbitrary[Any]]
+  ): Arbitrary[T] = Arbitrary(
+    Gen { p =>
+      val values = elems.map(_.gen.apply(p))
+      m.fromProduct(Tuple.fromArray(values.toArray))
+    }
+  )
+
+  private def sumArbitrary[T](alts: List[Arbitrary[Any]]): Arbitrary[T] =
+    require(alts.nonEmpty, "derived Arbitrary: sum type has no alternatives")
+    Arbitrary(
+      Gen { p =>
+        val picked = alts(p.rng.nextInt(alts.size))
+        picked.gen.apply(p).asInstanceOf[T]
+      }
+    )
+
+end Arbitrary

--- a/uni-test/src/main/scala/wvlet/uni/test/check/Gen.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/check/Gen.scala
@@ -115,15 +115,17 @@ object Gen:
     require(pairs.nonEmpty, "frequency: requires at least one (weight, gen) pair")
     val positive = pairs.filter(_._1 > 0)
     require(positive.nonEmpty, "frequency: at least one weight must be positive")
-    val total = positive.map(_._1).sum
+    // Sum widened to Long: many large weights can overflow Int and then `nextLong(total)` would
+    // throw on a negative bound.
+    val total = positive.iterator.map(_._1.toLong).sum
     Gen { p =>
-      val pick           = p.rng.nextInt(total)
-      var acc            = 0
-      var iter           = positive.iterator
+      val pick           = (p.rng.nextLong() & Long.MaxValue) % total
+      var acc            = 0L
+      val iter           = positive.iterator
       var result: Gen[A] = null
       while result == null && iter.hasNext do
         val (w, g) = iter.next()
-        acc += w
+        acc += w.toLong
         if pick < acc then
           result = g
       result.run(p)

--- a/uni-test/src/main/scala/wvlet/uni/test/check/Gen.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/check/Gen.scala
@@ -1,0 +1,314 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.test.check
+
+import scala.util.Random
+
+/**
+  * Parameters threaded through a generator: the random source and the current `size` used by
+  * size-aware combinators (e.g. [[Gen.listOf]], [[Gen.stringOf]], [[Gen.sized]]).
+  */
+final case class Params(rng: Random, size: Int)
+
+/**
+  * Random value generator for property-based testing.
+  *
+  * A [[Gen]] is a function from [[Params]] to a value. Generators compose via [[map]], [[flatMap]],
+  * [[filter]], and [[zip]]. Size is threaded through automatically so that size-aware generators
+  * (lists, strings, derived ADTs) scale with the property runner's configured size range.
+  */
+final class Gen[+A](private[check] val run: Params => A):
+  def apply(p: Params): A                 = run(p)
+  def map[B](f: A => B): Gen[B]           = Gen(p => f(run(p)))
+  def flatMap[B](f: A => Gen[B]): Gen[B]  = Gen(p => f(run(p)).run(p))
+  def withFilter(p: A => Boolean): Gen[A] = filter(p)
+
+  /**
+    * Keep drawing a value until it satisfies the predicate. Bounded retries prevent infinite loops
+    * on impossible filters.
+    */
+  def filter(pred: A => Boolean): Gen[A] = Gen { p =>
+    var attempts = 0
+    var value    = run(p)
+    while !pred(value) do
+      attempts += 1
+      if attempts > 1000 then
+        throw RuntimeException(
+          s"Gen.filter: unable to generate a value matching the predicate after 1000 attempts"
+        )
+      value = run(p)
+    value
+  }
+
+  /**
+    * Pair two generators into a tuple generator.
+    */
+  def zip[B](other: Gen[B]): Gen[(A, B)] = Gen(p => (run(p), other.run(p)))
+
+end Gen
+
+object Gen:
+  def apply[A](f: Params => A): Gen[A] = new Gen[A](f)
+
+  def const[A](a: A): Gen[A] = Gen(_ => a)
+
+  // ---- Numeric ranges ----
+
+  /**
+    * Uniformly choose a numeric value in `[min, max]` (inclusive on both ends for integral types).
+    * Mirrors ScalaCheck's `Gen.chooseNum[T]` signature so call sites remain source-compatible.
+    */
+  def chooseNum[T](min: T, max: T)(using c: Choose[T]): Gen[T] = c.choose(min, max)
+
+  /**
+    * Generate a positive, non-zero value of type `T`.
+    */
+  def posNum[T](using p: PosNum[T]): Gen[T] = p.gen
+
+  // ---- Size-aware combinators ----
+
+  /**
+    * Build a generator that depends on the current [[Params.size]].
+    */
+  def sized[A](f: Int => Gen[A]): Gen[A] = Gen(p => f(p.size).run(p))
+
+  /**
+    * Override the size parameter for the wrapped generator.
+    */
+  def resize[A](size: Int, gen: Gen[A]): Gen[A] = Gen(p =>
+    gen.run(p.copy(size = math.max(0, size)))
+  )
+
+  // ---- Choice ----
+
+  /**
+    * Pick one element uniformly at random from a non-empty sequence.
+    */
+  def oneOf[A](xs: Seq[A]): Gen[A] =
+    require(xs.nonEmpty, "oneOf: sequence must be non-empty")
+    Gen(p => xs(p.rng.nextInt(xs.size)))
+
+  def oneOf[A](head: A, tail: A*): Gen[A] = oneOf(head +: tail)
+
+  /**
+    * Pick one of the supplied generators uniformly.
+    */
+  def oneOfGen[A](head: Gen[A], tail: Gen[A]*): Gen[A] =
+    val all = head +: tail
+    Gen(p => all(p.rng.nextInt(all.size)).run(p))
+
+  /**
+    * Weighted choice: each generator is selected with probability proportional to its weight.
+    */
+  def frequency[A](pairs: (Int, Gen[A])*): Gen[A] =
+    require(pairs.nonEmpty, "frequency: requires at least one (weight, gen) pair")
+    val positive = pairs.filter(_._1 > 0)
+    require(positive.nonEmpty, "frequency: at least one weight must be positive")
+    val total = positive.map(_._1).sum
+    Gen { p =>
+      val pick           = p.rng.nextInt(total)
+      var acc            = 0
+      var iter           = positive.iterator
+      var result: Gen[A] = null
+      while result == null && iter.hasNext do
+        val (w, g) = iter.next()
+        acc += w
+        if pick < acc then
+          result = g
+      result.run(p)
+    }
+
+  // ---- Containers ----
+
+  /**
+    * Generate a list of exactly `n` elements.
+    */
+  def listOfN[A](n: Int, gen: Gen[A]): Gen[List[A]] =
+    require(n >= 0, s"listOfN: n must be non-negative (was ${n})")
+    Gen { p =>
+      val buf = scala.collection.mutable.ListBuffer.empty[A]
+      var i   = 0
+      while i < n do
+        buf += gen.run(p)
+        i += 1
+      buf.toList
+    }
+
+  /**
+    * Generate a list whose size grows with the current `size` parameter (0..size).
+    */
+  def listOf[A](gen: Gen[A]): Gen[List[A]] = sized(s => chooseNum(0, s).flatMap(listOfN(_, gen)))
+
+  /**
+    * Generate a non-empty list whose size grows with `size` (1..max(1, size)).
+    */
+  def nonEmptyListOf[A](gen: Gen[A]): Gen[List[A]] = sized(s =>
+    chooseNum(1, math.max(1, s)).flatMap(listOfN(_, gen))
+  )
+
+  /**
+    * Generate a `Set` whose cardinality grows with `size`.
+    */
+  def setOf[A](gen: Gen[A]): Gen[Set[A]] = listOf(gen).map(_.toSet)
+
+  /**
+    * Generate a `Map` whose cardinality grows with `size`.
+    */
+  def mapOf[K, V](genK: Gen[K], genV: Gen[V]): Gen[Map[K, V]] = listOf(genK.zip(genV)).map(_.toMap)
+
+  /**
+    * Generate `None` occasionally and `Some(gen)` otherwise (1:3 ratio).
+    */
+  def option[A](gen: Gen[A]): Gen[Option[A]] = frequency(1 -> const(None), 3 -> gen.map(Some(_)))
+
+  // ---- Characters ----
+
+  def alphaLowerChar: Gen[Char] = chooseNum(0, 25).map(n => ('a' + n).toChar)
+  def alphaUpperChar: Gen[Char] = chooseNum(0, 25).map(n => ('A' + n).toChar)
+  def alphaChar: Gen[Char]      = oneOfGen(alphaLowerChar, alphaUpperChar)
+  def numChar: Gen[Char]        = chooseNum(0, 9).map(n => ('0' + n).toChar)
+  def alphaNumChar: Gen[Char]   = frequency(9 -> alphaChar, 1 -> numChar)
+
+  /**
+    * Any 7-bit ASCII character (0x00..0x7f).
+    */
+  def asciiChar: Gen[Char] = chooseNum(0, 0x7f).map(_.toChar)
+
+  /**
+    * Any printable ASCII character (0x20..0x7e).
+    */
+  def asciiPrintableChar: Gen[Char] = chooseNum(0x20, 0x7e).map(_.toChar)
+
+  // ---- Strings ----
+
+  def stringOfN(n: Int, charGen: Gen[Char]): Gen[String] = Gen { p =>
+    val sb = StringBuilder()
+    var i  = 0
+    while i < n do
+      sb.append(charGen.run(p))
+      i += 1
+    sb.result()
+  }
+
+  /**
+    * Size-aware string generator: length ∈ [0, size].
+    */
+  def stringOf(charGen: Gen[Char]): Gen[String] = sized(s =>
+    chooseNum(0, s).flatMap(stringOfN(_, charGen))
+  )
+
+  def alphaStr: Gen[String]    = stringOf(alphaChar)
+  def numStr: Gen[String]      = stringOf(numChar)
+  def alphaNumStr: Gen[String] = stringOf(alphaNumChar)
+  def asciiStr: Gen[String]    = stringOf(asciiChar)
+
+  /**
+    * A non-empty identifier: starts with a letter, followed by alphanumerics.
+    */
+  def identifier: Gen[String] =
+    for
+      head <- alphaChar
+      rest <- stringOf(alphaNumChar)
+    yield s"${head}${rest}"
+
+end Gen
+
+/**
+  * Typeclass describing how to uniformly choose a value in `[min, max]` for type `T`.
+  */
+trait Choose[T]:
+  def choose(min: T, max: T): Gen[T]
+
+object Choose:
+  given Choose[Int] with
+    def choose(min: Int, max: Int): Gen[Int] =
+      require(min <= max, s"chooseNum: min (${min}) must be <= max (${max})")
+      if min == max then
+        Gen.const(min)
+      else
+        Gen { p =>
+          val span = max.toLong - min.toLong + 1L
+          (min.toLong + (p.rng.nextLong() & Long.MaxValue) % span).toInt
+        }
+
+  given Choose[Long] with
+    def choose(min: Long, max: Long): Gen[Long] =
+      require(min <= max, s"chooseNum: min (${min}) must be <= max (${max})")
+      if min == max then
+        Gen.const(min)
+      else if min == Long.MinValue && max == Long.MaxValue then
+        // Full range — every Long is a valid draw.
+        Gen(_.rng.nextLong())
+      else
+        val width = max - min
+        if width > 0 && width < Long.MaxValue then
+          // Span fits in a positive, non-max Long; use modulo sampling.
+          Gen { p =>
+            val span = width + 1L
+            min + (p.rng.nextLong() & Long.MaxValue) % span
+          }
+        else
+          // Wide range where `max - min + 1` would overflow. Fall back to rejection sampling so
+          // we never return a value outside `[min, max]`. For realistic wide ranges the rejection
+          // rate stays below 50% per draw.
+          Gen { p =>
+            var v = p.rng.nextLong()
+            while v < min || v > max do
+              v = p.rng.nextLong()
+            v
+          }
+
+  given Choose[Short] with
+    def choose(min: Short, max: Short): Gen[Short] = summon[Choose[Int]]
+      .choose(min.toInt, max.toInt)
+      .map(_.toShort)
+
+  given Choose[Byte] with
+    def choose(min: Byte, max: Byte): Gen[Byte] = summon[Choose[Int]]
+      .choose(min.toInt, max.toInt)
+      .map(_.toByte)
+
+  given Choose[Double] with
+    def choose(min: Double, max: Double): Gen[Double] =
+      require(min <= max, s"chooseNum: min (${min}) must be <= max (${max})")
+      if min == max then
+        Gen.const(min)
+      else
+        Gen(p => min + p.rng.nextDouble() * (max - min))
+
+end Choose
+
+/**
+  * Typeclass witnessing that a numeric type has a positive-value generator. Mirrors ScalaCheck's
+  * `Gen.posNum[T]` so existing call sites compile unchanged.
+  */
+trait PosNum[T]:
+  def gen: Gen[T]
+
+object PosNum:
+  given PosNum[Byte] =
+    new PosNum[Byte]:
+      def gen: Gen[Byte] = Gen.chooseNum[Byte](1.toByte, Byte.MaxValue)
+
+  given PosNum[Short] =
+    new PosNum[Short]:
+      def gen: Gen[Short] = Gen.chooseNum[Short](1.toShort, Short.MaxValue)
+
+  given PosNum[Int] =
+    new PosNum[Int]:
+      def gen: Gen[Int] = Gen.chooseNum[Int](1, Int.MaxValue)
+
+  given PosNum[Long] =
+    new PosNum[Long]:
+      def gen: Gen[Long] = Gen.chooseNum[Long](1L, Long.MaxValue)

--- a/uni-test/src/main/scala/wvlet/uni/test/check/PropertyConfig.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/check/PropertyConfig.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.test.check
+
+/**
+  * Configuration knobs for a property run. Mirrors the commonly used subset of ScalaCheck's
+  * `Test.Parameters`.
+  */
+final case class PropertyConfig(
+    minSuccessfulTests: Int = 100,
+    maxDiscarded: Int = 500,
+    minSize: Int = 0,
+    maxSize: Int = 100,
+    maxShrinks: Int = 1000,
+    seed: Option[Long] = None
+):
+  def withMinSuccessful(n: Int): PropertyConfig    = copy(minSuccessfulTests = n)
+  def withMaxDiscarded(n: Int): PropertyConfig     = copy(maxDiscarded = n)
+  def withSize(min: Int, max: Int): PropertyConfig =
+    val newMin = math.max(0, min)
+    val newMax = math.max(newMin, max)
+    copy(minSize = newMin, maxSize = newMax)
+
+  def withMaxShrinks(n: Int): PropertyConfig = copy(maxShrinks = n)
+  def withSeed(s: Long): PropertyConfig      = copy(seed = Some(s))
+  def noSeed: PropertyConfig                 = copy(seed = None)
+
+object PropertyConfig:
+  val default: PropertyConfig = PropertyConfig()
+
+/**
+  * Thrown by [[wvlet.uni.test.PropertyCheck.==>]] when a property's precondition is false. The
+  * runner catches this and increments the discard counter instead of reporting a failure.
+  */
+final class DiscardException extends RuntimeException with scala.util.control.NoStackTrace

--- a/uni-test/src/main/scala/wvlet/uni/test/check/Shrink.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/check/Shrink.scala
@@ -75,14 +75,13 @@ object Shrink extends LowPriorityShrinks:
     if s.isEmpty then
       LazyList.empty
     else
-      // Shorten by half, then by dropping one char at a time
       val halves =
         if s.length > 1 then
           LazyList(s.substring(0, s.length / 2))
         else
           LazyList.empty
       val drops = LazyList.tabulate(s.length)(i => s.substring(0, i) + s.substring(i + 1))
-      (LazyList("") #::: halves #::: drops).distinct
+      LazyList("") #::: halves #::: drops
   }
 
   given Shrink[Array[Byte]] = apply { arr =>
@@ -108,26 +107,30 @@ object Shrink extends LowPriorityShrinks:
     if xs.isEmpty then
       LazyList.empty
     else
-      val drops  = LazyList.tabulate(xs.size)(i => xs.take(i) ++ xs.drop(i + 1)).filter(_ != xs)
+      // Operate via Vector to keep per-index access O(log N) rather than O(N).
+      val vec    = xs.toVector
+      val n      = vec.size
+      val empty  = LazyList(List.empty[A])
       val halves =
-        if xs.size > 1 then
-          LazyList(xs.take(xs.size / 2))
+        if n > 1 then
+          LazyList(vec.take(n / 2).toList)
         else
           LazyList.empty
-      val elementShrinks =
+      val drops = LazyList.tabulate(n)(i => (vec.take(i) ++ vec.drop(i + 1)).toList)
+      def elementShrinks: LazyList[List[A]] =
         LazyList
-          .tabulate(xs.size) { i =>
-            elem.shrink(xs(i)).map(replaced => xs.updated(i, replaced))
+          .tabulate(n) { i =>
+            elem.shrink(vec(i)).map(replaced => vec.updated(i, replaced).toList)
           }
           .flatten
-      (LazyList(List.empty[A]) #::: halves #::: drops #::: elementShrinks).distinct
+      empty #::: halves #::: drops #::: elementShrinks
   }
 
   given [A](using elem: Shrink[A]): Shrink[Option[A]] = apply {
     case None =>
       LazyList.empty
     case Some(a) =>
-      Some(a) #:: elem.shrink(a).map(Some(_)).prepended(None)
+      None #:: elem.shrink(a).map(Some(_))
   }
 
   given [A, B](using sa: Shrink[A], sb: Shrink[B]): Shrink[(A, B)] = apply { case (a, b) =>
@@ -138,6 +141,28 @@ object Shrink extends LowPriorityShrinks:
     case (a, b, c) =>
       sa.shrink(a).map(a2 => (a2, b, c)) #::: sb.shrink(b).map(b2 => (a, b2, c)) #:::
         sc.shrink(c).map(c2 => (a, b, c2))
+  }
+
+  given [A, B, C, D](using
+      sa: Shrink[A],
+      sb: Shrink[B],
+      sc: Shrink[C],
+      sd: Shrink[D]
+  ): Shrink[(A, B, C, D)] = apply { case (a, b, c, d) =>
+    sa.shrink(a).map(x => (x, b, c, d)) #::: sb.shrink(b).map(x => (a, x, c, d)) #:::
+      sc.shrink(c).map(x => (a, b, x, d)) #::: sd.shrink(d).map(x => (a, b, c, x))
+  }
+
+  given [A, B, C, D, E](using
+      sa: Shrink[A],
+      sb: Shrink[B],
+      sc: Shrink[C],
+      sd: Shrink[D],
+      se: Shrink[E]
+  ): Shrink[(A, B, C, D, E)] = apply { case (a, b, c, d, e) =>
+    sa.shrink(a).map(x => (x, b, c, d, e)) #::: sb.shrink(b).map(x => (a, x, c, d, e)) #:::
+      sc.shrink(c).map(x => (a, b, x, d, e)) #::: sd.shrink(d).map(x => (a, b, c, x, e)) #:::
+      se.shrink(e).map(x => (a, b, c, d, x))
   }
 
   // ---- integral shrinker ----
@@ -161,13 +186,12 @@ object Shrink extends LowPriorityShrinks:
           LazyList.empty
         else
           val diff = n - x
-          diff #:: halves(x / 2)
-      val base = halves(n / 2).map(n - _)
-      (zero #::: neg #::: base).distinct.filter(_ != n)
-
-  // ---- Low-priority fallback ---------------------------------------------------------------
-
-  private[check] def noShrink[A]: Shrink[A] = apply(_ => LazyList.empty)
+          if diff == n then
+            halves(x / 2)
+          else
+            diff #:: halves(x / 2)
+      val base = halves(n / 2)
+      zero #::: neg #::: base
 
   private def shrinkFloating(d: Double): LazyList[Double] =
     if d == 0d then
@@ -186,4 +210,4 @@ end Shrink
   * allowing `forAll[Point]` to compile without the caller having to define a shrinker.
   */
 sealed trait LowPriorityShrinks:
-  given fallbackShrink[A]: Shrink[A] = Shrink.noShrink
+  given fallbackShrink[A]: Shrink[A] = Shrink.none

--- a/uni-test/src/main/scala/wvlet/uni/test/check/Shrink.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/check/Shrink.scala
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.test.check
+
+/**
+  * Typeclass describing how to reduce a value toward a simpler counter-example when a property
+  * fails. The property runner (see [[wvlet.uni.test.PropertyCheck]]) consumes the returned
+  * [[LazyList]] lazily and keeps the first candidate that still fails the property, recursing until
+  * no further simplification is possible.
+  */
+trait Shrink[A]:
+  def shrink(a: A): LazyList[A]
+
+object Shrink extends LowPriorityShrinks:
+
+  def apply[A](f: A => LazyList[A]): Shrink[A] =
+    new Shrink[A]:
+      def shrink(a: A): LazyList[A] = f(a)
+
+  /**
+    * Default: don't shrink. Returns an empty stream.
+    */
+  def none[A]: Shrink[A] = apply(_ => LazyList.empty)
+
+  given Shrink[Boolean] = apply {
+    case true =>
+      LazyList(false)
+    case false =>
+      LazyList.empty
+  }
+
+  given Shrink[Int] = apply { i =>
+    shrinkIntegral(i.toLong).filter(x => x.toInt == x).map(_.toInt)
+  }
+
+  given Shrink[Long]  = apply(i => shrinkIntegral(i))
+  given Shrink[Short] = apply(i =>
+    shrinkIntegral(i.toLong).filter(x => x.toShort == x).map(_.toShort)
+  )
+
+  given Shrink[Byte] = apply(i => shrinkIntegral(i.toLong).filter(x => x.toByte == x).map(_.toByte))
+
+  given Shrink[Float] = apply { f =>
+    shrinkFloating(f.toDouble).map(_.toFloat).filter(x => !java.lang.Float.isNaN(x) && x != f)
+  }
+
+  given Shrink[Double] = apply(d => shrinkFloating(d))
+
+  given Shrink[Char] = apply { c =>
+    // Shrink toward 'a' (for letters), 'A', or space. Keep it simple: step by halving.
+    val candidates =
+      if c == 'a' then
+        LazyList.empty
+      else if c.isLetter then
+        LazyList('a', 'A')
+      else if c.isDigit then
+        LazyList('0')
+      else
+        LazyList('a', ' ')
+    candidates.filter(_ != c)
+  }
+
+  given Shrink[String] = apply { s =>
+    if s.isEmpty then
+      LazyList.empty
+    else
+      // Shorten by half, then by dropping one char at a time
+      val halves =
+        if s.length > 1 then
+          LazyList(s.substring(0, s.length / 2))
+        else
+          LazyList.empty
+      val drops = LazyList.tabulate(s.length)(i => s.substring(0, i) + s.substring(i + 1))
+      (LazyList("") #::: halves #::: drops).distinct
+  }
+
+  given Shrink[Array[Byte]] = apply { arr =>
+    if arr.isEmpty then
+      LazyList.empty
+    else
+      val halves =
+        if arr.length > 1 then
+          LazyList(arr.slice(0, arr.length / 2))
+        else
+          LazyList.empty
+      val drops =
+        LazyList.tabulate(arr.length) { i =>
+          val copy = new Array[Byte](arr.length - 1)
+          System.arraycopy(arr, 0, copy, 0, i)
+          System.arraycopy(arr, i + 1, copy, i, arr.length - i - 1)
+          copy
+        }
+      LazyList(Array.empty[Byte]) #::: halves #::: drops
+  }
+
+  given [A](using elem: Shrink[A]): Shrink[List[A]] = apply { xs =>
+    if xs.isEmpty then
+      LazyList.empty
+    else
+      val drops  = LazyList.tabulate(xs.size)(i => xs.take(i) ++ xs.drop(i + 1)).filter(_ != xs)
+      val halves =
+        if xs.size > 1 then
+          LazyList(xs.take(xs.size / 2))
+        else
+          LazyList.empty
+      val elementShrinks =
+        LazyList
+          .tabulate(xs.size) { i =>
+            elem.shrink(xs(i)).map(replaced => xs.updated(i, replaced))
+          }
+          .flatten
+      (LazyList(List.empty[A]) #::: halves #::: drops #::: elementShrinks).distinct
+  }
+
+  given [A](using elem: Shrink[A]): Shrink[Option[A]] = apply {
+    case None =>
+      LazyList.empty
+    case Some(a) =>
+      Some(a) #:: elem.shrink(a).map(Some(_)).prepended(None)
+  }
+
+  given [A, B](using sa: Shrink[A], sb: Shrink[B]): Shrink[(A, B)] = apply { case (a, b) =>
+    sa.shrink(a).map(a2 => (a2, b)) #::: sb.shrink(b).map(b2 => (a, b2))
+  }
+
+  given [A, B, C](using sa: Shrink[A], sb: Shrink[B], sc: Shrink[C]): Shrink[(A, B, C)] = apply {
+    case (a, b, c) =>
+      sa.shrink(a).map(a2 => (a2, b, c)) #::: sb.shrink(b).map(b2 => (a, b2, c)) #:::
+        sc.shrink(c).map(c2 => (a, b, c2))
+  }
+
+  // ---- integral shrinker ----
+
+  /**
+    * Shrink candidates for an integral value: 0, and a sequence halving toward 0 (positive), then
+    * the negation for negative values. Based on ScalaCheck's classical strategy.
+    */
+  private def shrinkIntegral(n: Long): LazyList[Long] =
+    if n == 0L then
+      LazyList.empty
+    else
+      val zero = LazyList(0L)
+      val neg  =
+        if n < 0 then
+          LazyList(-n)
+        else
+          LazyList.empty
+      def halves(x: Long): LazyList[Long] =
+        if x == 0L then
+          LazyList.empty
+        else
+          val diff = n - x
+          diff #:: halves(x / 2)
+      val base = halves(n / 2).map(n - _)
+      (zero #::: neg #::: base).distinct.filter(_ != n)
+
+  // ---- Low-priority fallback ---------------------------------------------------------------
+
+  private[check] def noShrink[A]: Shrink[A] = apply(_ => LazyList.empty)
+
+  private def shrinkFloating(d: Double): LazyList[Double] =
+    if d == 0d then
+      LazyList.empty
+    else if java.lang.Double.isNaN(d) || java.lang.Double.isInfinite(d) then
+      LazyList(0d)
+    else
+      val base = LazyList(0d, d.toLong.toDouble, d / 2)
+      base.filter(x => x != d && !java.lang.Double.isNaN(x))
+
+end Shrink
+
+/**
+  * Low-priority fallback [[Shrink]] for arbitrary types. Extending this trait from the `Shrink`
+  * companion ensures that specific givens (e.g. `Shrink[Int]`) win over this catch-all, while still
+  * allowing `forAll[Point]` to compile without the caller having to define a shrinker.
+  */
+sealed trait LowPriorityShrinks:
+  given fallbackShrink[A]: Shrink[A] = Shrink.noShrink

--- a/uni-test/src/test/scala/wvlet/uni/test/PropertyCheckTest.scala
+++ b/uni-test/src/test/scala/wvlet/uni/test/PropertyCheckTest.scala
@@ -1,0 +1,282 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.test
+
+import wvlet.uni.test.check.Arbitrary
+import wvlet.uni.test.check.Gen
+import wvlet.uni.test.check.PropertyConfig
+import wvlet.uni.test.check.Shrink
+
+/**
+  * Self-test for the built-in property-based testing support.
+  */
+class PropertyCheckTest extends UniTest with PropertyCheck:
+
+  // Reduce sample count to keep the suite snappy.
+  override protected def propertyConfig: PropertyConfig = PropertyConfig
+    .default
+    .withMinSuccessful(50)
+
+  test("forAll with implicit Arbitrary") {
+    forAll { (a: Int, b: Int) =>
+      (a + b) shouldBe (b + a)
+    }
+  }
+
+  test("forAll with explicit Gen") {
+    forAll(Gen.chooseNum(1, 100)) { (n: Int) =>
+      (n >= 1) shouldBe true
+      (n <= 100) shouldBe true
+    }
+  }
+
+  test("chooseNum is inclusive on both ends") {
+    forAll(Gen.chooseNum(7, 7)) { (n: Int) =>
+      n shouldBe 7
+    }
+  }
+
+  test("chooseNum[Long] keeps wide overflowing ranges in-bounds") {
+    // `max - min + 1` overflows when min=-10 and max=Long.MaxValue, so the runner must use
+    // rejection sampling rather than returning an unbounded `nextLong()`.
+    forAll(Gen.chooseNum[Long](-10L, Long.MaxValue)) { (l: Long) =>
+      (l >= -10L) shouldBe true
+      (l <= Long.MaxValue) shouldBe true
+    }
+  }
+
+  test("chooseNum for Byte/Short/Long") {
+    forAll(Gen.chooseNum[Byte](-10, 10)) { (b: Byte) =>
+      (b >= -10) shouldBe true
+      (b <= 10) shouldBe true
+    }
+    forAll(Gen.chooseNum[Short](-1000, 1000)) { (s: Short) =>
+      (s >= -1000) shouldBe true
+      (s <= 1000) shouldBe true
+    }
+    forAll(Gen.chooseNum[Long](Long.MinValue, Long.MaxValue)) { (l: Long) =>
+      (l >= Long.MinValue) shouldBe true
+    }
+  }
+
+  test("posNum always produces positive values") {
+    forAll(Gen.posNum[Int]) { (n: Int) =>
+      (n > 0) shouldBe true
+    }
+    forAll(Gen.posNum[Long]) { (n: Long) =>
+      (n > 0) shouldBe true
+    }
+  }
+
+  test("Arbitrary.arbitrary[T] summons the default generator") {
+    forAll(Arbitrary.arbitrary[String]) { (s: String) =>
+      (s.length >= 0) shouldBe true
+    }
+  }
+
+  test("float/double generators never emit NaN") {
+    forAll { (f: Float) =>
+      java.lang.Float.isNaN(f) shouldBe false
+    }
+    forAll { (d: Double) =>
+      java.lang.Double.isNaN(d) shouldBe false
+    }
+  }
+
+  test("Gen.map composes") {
+    forAll(Gen.chooseNum(0, 100).map(_ * 2)) { (n: Int) =>
+      (n % 2 == 0) shouldBe true
+    }
+  }
+
+  test("Gen.listOfN produces the requested length") {
+    forAll(Gen.listOfN(5, Gen.chooseNum(0, 10))) { (xs: List[Int]) =>
+      xs.size shouldBe 5
+    }
+  }
+
+  test("Gen.frequency respects weights (smoke)") {
+    val g      = Gen.frequency(1 -> Gen.const("a"), 9 -> Gen.const("b"))
+    var aCount = 0
+    var bCount = 0
+    forAll(g) { (s: String) =>
+      if s == "a" then
+        aCount += 1
+      else
+        bCount += 1
+    }
+    // With 50 samples and 1:9 ratio, "b" should dominate. Allow generous slack.
+    (bCount > aCount) shouldBe true
+  }
+
+  test("Gen.listOf grows with size") {
+    forAll(Gen.listOf(Gen.chooseNum(0, 10))) { (xs: List[Int]) =>
+      (xs.size >= 0) shouldBe true
+      (xs.size <= propertyConfig.maxSize) shouldBe true
+    }
+  }
+
+  test("Gen.option yields Some and None") {
+    var sawSome = false
+    var sawNone = false
+    forAll(Gen.option(Gen.const(42))) { (o: Option[Int]) =>
+      o match
+        case Some(42) =>
+          sawSome = true
+        case None =>
+          sawNone = true
+        case other =>
+          fail(s"unexpected ${other}")
+    }
+    sawSome shouldBe true
+    sawNone shouldBe true
+  }
+
+  test("Gen.mapOf produces a Map") {
+    forAll(Gen.mapOf(Gen.chooseNum(0, 100), Gen.alphaStr)) { (m: Map[Int, String]) =>
+      (m.size >= 0) shouldBe true
+    }
+  }
+
+  test("Gen.alphaNumStr contains only alphanumerics") {
+    forAll(Gen.alphaNumStr) { (s: String) =>
+      s.forall(c => c.isLetterOrDigit) shouldBe true
+    }
+  }
+
+  test("Gen.identifier starts with a letter") {
+    forAll(Gen.identifier) { (s: String) =>
+      s.nonEmpty shouldBe true
+      s.head.isLetter shouldBe true
+      s.tail.forall(_.isLetterOrDigit) shouldBe true
+    }
+  }
+
+  test("Gen.sized/resize") {
+    forAll(Gen.resize(3, Gen.listOf(Gen.chooseNum(0, 10)))) { (xs: List[Int]) =>
+      (xs.size <= 3) shouldBe true
+    }
+  }
+
+  test("failing property reports the counter-example and seed") {
+    val ex = intercept[AssertionFailure] {
+      forAll(Gen.chooseNum(1, 1)) { (n: Int) =>
+        n shouldBe 2
+      }
+    }
+    ex.getMessage shouldContain "1"
+    ex.getMessage shouldContain "seed="
+  }
+
+  test("==> discards when precondition is false") {
+    // Without discard this would fail the moment we draw 0; with discard it simply skips 0.
+    forAll { (n: Int) =>
+      (n != 0) ==> {
+        (n * 0 == 0) shouldBe true
+      }
+    }
+  }
+
+  test("too many discards surfaces an error") {
+    val ex = intercept[AssertionFailure] {
+      forAll(Gen.const(0)) { (n: Int) =>
+        (n != 0) ==> {
+          // Never reached
+          1 shouldBe 1
+        }
+      }
+    }
+    ex.getMessage shouldContain "discard"
+  }
+
+  test("seeded runs are reproducible") {
+    val seededConfig = PropertyConfig.default.withMinSuccessful(10).withSeed(42L)
+    var firstValues  = List.empty[Int]
+    var secondValues = List.empty[Int]
+
+    val runner =
+      new PropertyCheck:
+        override protected def propertyConfig = seededConfig
+    runner.forAll(Arbitrary.arbitrary[Int]) { (n: Int) =>
+      firstValues = n :: firstValues
+    }
+    runner.forAll(Arbitrary.arbitrary[Int]) { (n: Int) =>
+      secondValues = n :: secondValues
+    }
+    firstValues shouldBe secondValues
+  }
+
+  test("shrinking produces a minimal counter-example") {
+    val ex = intercept[AssertionFailure] {
+      forAll { (n: Int) =>
+        // Any non-zero value fails.
+        (n == 0) shouldBe true
+      }
+    }
+    // The shrinker should drive the counter-example toward 0-adjacent values; any reasonable
+    // shrink stops at a small magnitude. Verify the reported input is much smaller than Int.MaxValue.
+    val extracted = """property input: (-?\d+)"""
+      .r
+      .findFirstMatchIn(ex.getMessage)
+      .map(_.group(1).toLong)
+    extracted shouldMatch {
+      case Some(v) if math.abs(v) <= 1L =>
+    }
+  }
+
+  test("shrinking reduces lists to empty or small when empty list fails") {
+    val ex = intercept[AssertionFailure] {
+      forAll { (xs: List[Int]) =>
+        // Any list fails the property.
+        xs.size < 0 shouldBe true
+      }
+    }
+    ex.getMessage shouldContain "property input: List()"
+  }
+
+  test("classify records label counts") {
+    forAll(Gen.chooseNum(-100, 100)) { (n: Int) =>
+      classify(n >= 0, "non-negative", "negative")
+      (n * 1 == n) shouldBe true
+    }
+    // No assertion on log output itself (captured via println); we verify the run completes.
+  }
+
+  test("derived Arbitrary for a case class") {
+    case class Point(x: Int, y: Int)
+    given Arbitrary[Point] = Arbitrary.derived
+
+    forAll { (p: Point) =>
+      // Both components should be Ints (trivially true via the type)
+      (p.x == p.x) shouldBe true
+      (p.y == p.y) shouldBe true
+    }
+  }
+
+  test("derived Arbitrary for a sum type") {
+    sealed trait Shape derives Arbitrary
+    case class Circle(r: Int)                   extends Shape
+    case class Rect(w: Int, h: Int)             extends Shape
+    case class Triangle(a: Int, b: Int, c: Int) extends Shape
+
+    forAll { (s: Shape) =>
+      s shouldMatch {
+        case _: Circle   =>
+        case _: Rect     =>
+        case _: Triangle =>
+      }
+    }
+  }
+
+end PropertyCheckTest

--- a/uni-test/src/test/scala/wvlet/uni/test/PropertyCheckTest.scala
+++ b/uni-test/src/test/scala/wvlet/uni/test/PropertyCheckTest.scala
@@ -21,7 +21,7 @@ import wvlet.uni.test.check.Shrink
 /**
   * Self-test for the built-in property-based testing support.
   */
-class PropertyCheckTest extends UniTest with PropertyCheck:
+class PropertyCheckTest extends UniTest:
 
   // Reduce sample count to keep the suite snappy.
   override protected def propertyConfig: PropertyConfig = PropertyConfig
@@ -183,6 +183,14 @@ class PropertyCheckTest extends UniTest with PropertyCheck:
     // Without discard this would fail the moment we draw 0; with discard it simply skips 0.
     forAll { (n: Int) =>
       (n != 0) ==> {
+        (n * 0 == 0) shouldBe true
+      }
+    }
+  }
+
+  test("implies is the English alias of ==>") {
+    forAll { (n: Int) =>
+      (n != 0) implies {
         (n * 0 == 0) shouldBe true
       }
     }

--- a/uni/src/test/scala/wvlet/uni/msgpack/spi/RoundTripTest.scala
+++ b/uni/src/test/scala/wvlet/uni/msgpack/spi/RoundTripTest.scala
@@ -17,10 +17,10 @@ import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Gen
 import wvlet.uni.msgpack.impl.ByteArrayBuffer
 import wvlet.uni.test.PropertyCheck
+import wvlet.uni.test.check.Arbitrary.arbitrary
+import wvlet.uni.test.check.Gen
 import wvlet.uni.test.UniTest
 import wvlet.uni.test.empty
 import wvlet.uni.test.defined

--- a/uni/src/test/scala/wvlet/uni/msgpack/spi/RoundTripTest.scala
+++ b/uni/src/test/scala/wvlet/uni/msgpack/spi/RoundTripTest.scala
@@ -18,7 +18,6 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 
 import wvlet.uni.msgpack.impl.ByteArrayBuffer
-import wvlet.uni.test.PropertyCheck
 import wvlet.uni.test.check.Arbitrary.arbitrary
 import wvlet.uni.test.check.Gen
 import wvlet.uni.test.UniTest
@@ -27,7 +26,7 @@ import wvlet.uni.test.defined
 
 /**
   */
-class RoundTripTest extends UniTest with PropertyCheck:
+class RoundTripTest extends UniTest:
   val buf = ByteArrayBuffer.newBuffer(1024)
 
   protected def rawRoundtrip[A, B](v: A)(pack: (WriteCursor, A) => Unit)(

--- a/uni/src/test/scala/wvlet/uni/msgpack/spi/ValueTest.scala
+++ b/uni/src/test/scala/wvlet/uni/msgpack/spi/ValueTest.scala
@@ -19,7 +19,6 @@ import java.util.Base64
 import wvlet.uni.msgpack.impl.ByteArrayBuffer
 import wvlet.uni.msgpack.spi.Value.*
 import wvlet.uni.msgpack.spi.ValueFactory.*
-import wvlet.uni.test.PropertyCheck
 import wvlet.uni.test.check.Gen
 import wvlet.uni.test.UniTest
 import wvlet.uni.test.empty
@@ -27,7 +26,7 @@ import wvlet.uni.test.defined
 
 /**
   */
-class ValueTest extends UniTest with PropertyCheck:
+class ValueTest extends UniTest:
   private def rankOf(mf: MessageFormat): Int =
     val order = Seq(
       MessageFormat.INT8,

--- a/uni/src/test/scala/wvlet/uni/msgpack/spi/ValueTest.scala
+++ b/uni/src/test/scala/wvlet/uni/msgpack/spi/ValueTest.scala
@@ -16,11 +16,11 @@ package wvlet.uni.msgpack.spi
 import java.math.BigInteger
 import java.util.Base64
 
-import org.scalacheck.Gen
 import wvlet.uni.msgpack.impl.ByteArrayBuffer
 import wvlet.uni.msgpack.spi.Value.*
 import wvlet.uni.msgpack.spi.ValueFactory.*
 import wvlet.uni.test.PropertyCheck
+import wvlet.uni.test.check.Gen
 import wvlet.uni.test.UniTest
 import wvlet.uni.test.empty
 import wvlet.uni.test.defined

--- a/uni/src/test/scala/wvlet/uni/util/CrockfordBase32Test.scala
+++ b/uni/src/test/scala/wvlet/uni/util/CrockfordBase32Test.scala
@@ -17,11 +17,10 @@ import wvlet.uni.util.CrockfordBase32
 import wvlet.uni.test.UniTest
 import wvlet.uni.test.empty
 import wvlet.uni.test.defined
-import wvlet.uni.test.PropertyCheck
 
 /**
   */
-class CrockfordBase32Test extends UniTest with PropertyCheck:
+class CrockfordBase32Test extends UniTest:
   test("Encode long pairs") {
     forAll { (hi: Long, low: Long) =>
       val encoded       = CrockfordBase32.encode128bits(hi, low)

--- a/uni/src/test/scala/wvlet/uni/util/PrefixedULIDTest.scala
+++ b/uni/src/test/scala/wvlet/uni/util/PrefixedULIDTest.scala
@@ -18,9 +18,8 @@ import wvlet.uni.util.ULID
 import wvlet.uni.test.UniTest
 import wvlet.uni.test.empty
 import wvlet.uni.test.defined
-import wvlet.uni.test.PropertyCheck
 
-class PrefixedULIDTest extends UniTest with PropertyCheck:
+class PrefixedULIDTest extends UniTest:
 
   test("basic") {
     val ulid = ULID.newULID

--- a/uni/src/test/scala/wvlet/uni/util/ULIDTest.scala
+++ b/uni/src/test/scala/wvlet/uni/util/ULIDTest.scala
@@ -18,11 +18,10 @@ import wvlet.uni.util.ULID
 import wvlet.uni.test.UniTest
 import wvlet.uni.test.empty
 import wvlet.uni.test.defined
-import wvlet.uni.test.PropertyCheck
 
 /**
   */
-class ULIDTest extends UniTest with PropertyCheck:
+class ULIDTest extends UniTest:
 
   test("generate ULID") {
     for i <- 0 to 10 do


### PR DESCRIPTION
## Summary

- `uni-test` no longer depends on ScalaCheck. The commonly-used property-testing surface is ported into `wvlet.uni.test.check.*` — uni keeps its "minimal dependencies" promise.
- Property-based testing is now part of the `UniTest` base class: any suite gets `forAll` / `==>` / `implies` / `classify` / `collect` with no mix-in required.
- Full toolkit: `Gen`, `Arbitrary` (with Scala 3 `derives` for product and sum types), `Shrink`, `PropertyConfig` with seeded reproducibility, counter-example shrinking.

## What's included

### Generators (`wvlet.uni.test.check.Gen`)
- Core: `map`, `flatMap`, `filter`, `zip`, `const`
- Numeric: `chooseNum[T]` for `Byte`/`Short`/`Int`/`Long`/`Double` (overflow-safe rejection sampling for wide `Long` ranges), `posNum[T]`
- Size-aware: `sized`, `resize`
- Choice: `oneOf`, `oneOfGen`, `frequency` (Long weight sum, overflow-safe)
- Containers: `listOf`, `listOfN`, `nonEmptyListOf`, `setOf`, `mapOf`, `option`
- Characters: `alphaChar`, `alphaLowerChar`, `alphaUpperChar`, `numChar`, `alphaNumChar`, `asciiChar`, `asciiPrintableChar`
- Strings: `stringOf`, `stringOfN`, `alphaStr`, `numStr`, `alphaNumStr`, `asciiStr`, `identifier`

### Arbitrary (`wvlet.uni.test.check.Arbitrary`)
- Defaults: primitives, `String`, `Array[Byte]`, `List`, `Vector`, `Option`, Tuple2/3
- Scala 3 `Arbitrary.derived` using `Mirror`, recursively summoning-or-deriving for subtypes (so `derives Arbitrary` on a sealed trait works without per-case givens)

### Shrink (`wvlet.uni.test.check.Shrink`)
- Defaults for primitives, `Char`, `String`, `Array[Byte]`, `List`, `Option`, Tuple2..5
- Low-priority fallback so user types compile with no explicit shrinker
- Runner greedily minimises counter-examples, bounded by `maxShrinks`

### Runner (`wvlet.uni.test.PropertyCheck`, auto-mixed into `UniTest`)
- `PropertyConfig` with `withMinSuccessful`, `withMaxDiscarded`, `withSize`, `withMaxShrinks`, `withSeed`
- Failure messages embed the RNG seed → reproducible replays via `propertyConfig.withSeed(...)`
- `==>` / `implies`: English-readable precondition/discard, bounded by `maxDiscarded`
- `classify(cond, trueLabel, falseLabel?)`, `collect(label: String)`: per-run counts printed on success
- Per-thread stats stack so parallel `forAll` calls on the same suite don't race

## Out of scope (documented in the plan)

- ScalaCheck's stateful `Commands` framework — rarely used; port on demand.
- Full `Prop`/`Properties` combinator tree (`prop && prop`, etc.) — imperative test bodies cover the common case.

## Migration

- `org.scalacheck.Gen` → `wvlet.uni.test.check.Gen`
- `org.scalacheck.Arbitrary.arbitrary` → `wvlet.uni.test.check.Arbitrary.arbitrary`
- `with PropertyCheck` can be dropped (still compiles as a no-op for backward compatibility)
- `scalacheck` dependency removed from `build.sbt`

## Docs

`docs/core/unitest.md` rewritten with full examples of generators, derivation, shrinking, discard, `classify`/`collect`, and `PropertyConfig`.

## Test plan

- [x] `testJVM/test` passes (54 tests — new `PropertyCheckTest` covers chooseNum bounds + wide-Long overflow, posNum, sized/resize, frequency, listOf/mapOf/option, char/string gens, `==>` / `implies` discard, shrink minimisation, seeded reproducibility, classify, product and sum derivation, failure-message format)
- [x] `uniJVM/test` passes (1489 tests, 4 pending) — existing ScalaCheck-backed tests migrated (`RoundTripTest`, `ValueTest`, `ULIDTest`, `CrockfordBase32Test`, `PrefixedULIDTest`)
- [x] `testJS/compile`, `testJS/Test/compile`, `testNative/compile`, `testNative/Test/compile`
- [x] `npm run docs:build`

## Review cycle

- `/simplify` pass: dropped duplicate tuple-shrink helpers, collapsed explicit-Gen `forAll` overloads via `zip`, eliminated `.distinct` LazyList forcing, used Vector-backed shrinking for lists, fixed `Shrink[Option]` to not emit the original `Some(a)`.
- Gemini PR review: thread-local stats stack, Long intermediate in size ramp, Array[Byte] display truncation, `sizeBound` guard for `Int.MaxValue`, Long weight sum in `Gen.frequency`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)