### PR TITLE
feature: Publish sbt-uni plugin via Sonatype release pipeline

### DIFF
--- a/.github/workflows/release-sbt-plugin.yml
+++ b/.github/workflows/release-sbt-plugin.yml
@@ -1,0 +1,49 @@
+name: Release sbt-uni plugin
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  publish_sbt_plugin:
+    name: Publish sbt-uni plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Fetch all tags so that sbt-dynver can find the previous release version
+          fetch-depth: 0
+      - run: git fetch --tags -f
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '23'
+          cache: sbt
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+      - name: Setup GPG
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: echo $PGP_SECRET | base64 --decode | gpg --import --batch --yes
+      - name: Publish uni locally for plugin dependency
+        id: publish_local
+        run: |
+          ./sbt "coreJVM/publishLocal; uniJVM/publishLocal"
+          UNI_VERSION=$(./sbt "print uniJVM/version" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep -E '^[0-9]' | tail -1 | tr -d '[:space:]')
+          echo "UNI_VERSION=${UNI_VERSION}"
+          echo "UNI_VERSION=${UNI_VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Build bundle
+        working-directory: sbt-uni
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          UNI_VERSION: ${{ steps.publish_local.outputs.UNI_VERSION }}
+        run: sbt "publishSigned"
+      - name: Release to Sonatype
+        working-directory: sbt-uni
+        env:
+          SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'
+          SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASS }}'
+          UNI_VERSION: ${{ steps.publish_local.outputs.UNI_VERSION }}
+        run: sbt sonaRelease

--- a/plans/2026-04-18-sbt-uni-release.md
+++ b/plans/2026-04-18-sbt-uni-release.md
@@ -1,0 +1,39 @@
+# Publish sbt-uni plugin to Maven Central
+
+## Problem
+
+The Sonatype release pipeline currently ships only the main library artifacts:
+
+- `.github/workflows/release.yml` — publishes `projectJVM/publishSigned` and calls `sonaRelease`
+- `.github/workflows/release-js.yml` — publishes `projectJS/publishSigned`
+- `.github/workflows/release-native.yml` — publishes `projectNative/publishSigned`
+
+The `sbt-uni` plugin (in `sbt-uni/`) is a separate sbt 2.x build that is **never** published on release. It only runs as a scripted test in `test.yml` (`test_sbt_plugin` job). Consumers cannot declare `addSbtPlugin("org.wvlet.uni" % "sbt-uni" % "...")` today because no artifact is uploaded to Central.
+
+## Plan
+
+Add a new workflow `release-sbt-plugin.yml` that:
+
+1. Triggers on `v*` tags (matching the other three release workflows) and `workflow_dispatch`.
+2. Imports the GPG key and uses the existing `PGP_SECRET` / `PGP_PASSPHRASE` secrets.
+3. Runs `./sbt "coreJVM/publishLocal; uniJVM/publishLocal"` from the root so `sbt-uni` can resolve the just-built library (the Central sync for the library finishes asynchronously in `release.yml`; we avoid a race by using `publishLocal` on the same runner).
+4. Extracts `UNI_VERSION` from `uniJVM/version` (mirroring how `test.yml` does it) and passes it to the sbt-uni metabuild via the `UNI_VERSION` env var — `sbt-uni/build.sbt` already honours this.
+5. From `sbt-uni/`, runs `sbt "publishSigned"` then `sbt sonaRelease` using `SONATYPE_USER` / `SONATYPE_PASS` secrets, identical to the other three workflows.
+
+The `sbt-uni/build.sbt` already has the Maven Central metadata (organization, licenses, homepage, scmInfo, developers, `publishTo` with `localStaging`), so no changes to that file are required.
+
+## Why a separate workflow (vs. chaining into release.yml)
+
+- Matches the existing split (`release-js.yml`, `release-native.yml`).
+- Keeps Scala Native tooling out of the sbt-plugin job (and vice versa).
+- Runs in parallel with the main JVM publish; neither depends on the other's network upload because the plugin uses the locally-published library artifact.
+
+## Non-goals
+
+- Snapshot publishing for the plugin (matches current behaviour: snapshots are a local-only concern).
+- Rewriting the sbt 2.x sbt-uni build. Its Maven metadata already matches the root.
+
+## Verification
+
+- `gh workflow run release-sbt-plugin.yml` manually after merge to dry-run.
+- Next `v2026.x.y` tag should produce `sbt-uni_3_2.0.0-RC10` artefact on `https://central.sonatype.com/search?q=org.wvlet.uni`.


### PR DESCRIPTION
## Summary
- The existing `release*.yml` workflows only publish the main library (JVM/JS/Native); the `sbt-uni` plugin is scripted-tested but never shipped to Maven Central.
- New `release-sbt-plugin.yml` mirrors the other three release flows: imports GPG, `publishLocal`s the uni library so the sbt-uni metabuild can resolve it, threads the resolved version through `UNI_VERSION`, then `publishSigned` + `sonaRelease` from `sbt-uni/`.
- No changes to `sbt-uni/build.sbt` — it already declares the required Maven Central metadata.

## Test plan
- [ ] Manually trigger via `gh workflow run release-sbt-plugin.yml` after merge to dry-run the pipeline.
- [ ] On next `v2026.x.y` tag, confirm `sbt-uni` artefact appears at https://central.sonatype.com/search?q=org.wvlet.uni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)