### PR TITLE
fix: Validate version input in release.sh to prevent typo-tags

### DIFF
--- a/plans/2026-04-19-release-version-validation.md
+++ b/plans/2026-04-19-release-version-validation.md
@@ -1,0 +1,33 @@
+# Release script version validation
+
+## Problem
+
+`project/release.sh` prompts for the next release version but performs no
+validation. If the user presses the wrong key and hits Enter, any string is
+accepted and immediately becomes a git tag. This is not hypothetical — the
+repository already contains a stray tag `vy` from such an incident.
+
+## Expected version format
+
+The script comment (`# Versioning scheme: YYYY.(milestone).patch`) and recent
+tags (`v2026.1.0`, `v2026.1.1`) show the expected shape:
+
+- `YYYY` — 4-digit year
+- `milestone` — one or more digits
+- `patch` — one or more digits
+
+Regex: `^[0-9]{4}\.[0-9]+\.[0-9]+$`
+
+## Fix
+
+After reading `next_version` (including when the default was accepted), check
+the value against the regex. On mismatch, print the expected format and exit
+non-zero before any tag is created or pushed.
+
+## Out of scope
+
+- Cleaning up the existing `vy` tag — that is a separate decision for the
+  maintainer; this PR only prevents future occurrences.
+- Stricter rules (e.g. monotonic version, year must match current year). The
+  default already handles the common case; validation only needs to catch
+  obvious typos.

--- a/project/release.sh
+++ b/project/release.sh
@@ -28,6 +28,11 @@ default_version="${current_year}.${milestone}.${patch}"
 read -p "next version (default: ${default_version})? " next_version
 next_version=${next_version:-${default_version}}
 
+if [[ ! "${next_version}" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
+  echo "invalid version: '${next_version}' (expected YYYY.milestone.patch, e.g. ${default_version})"
+  exit 1
+fi
+
 set -x
 git tag -a -m "uni ${next_version}" "v${next_version}"
 git push --follow-tags


### PR DESCRIPTION
## Summary

- `project/release.sh` used to tag whatever the user typed at the prompt. A stray keystroke once produced a `vy` tag in this very repo.
- Validate the version against `^[0-9]{4}\.[0-9]+\.[0-9]+$` (matching the `YYYY.milestone.patch` scheme already documented in the script) before creating or pushing the tag.
- Out of scope: cleaning up the existing stray tag — that's a separate decision for the maintainer.

## Test plan

- [x] `bash -n project/release.sh` — syntax OK
- [x] Sanity-checked regex: accepts `2026.1.2`, `2026.10.100`; rejects `y`, `vy`, `2026.1`, `2026.1.2.3`, `abc`, `2026..1`, `2026.1.2 ` (trailing space)
- [ ] Maintainer dry-runs the script on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)