### PR TITLE
fix: Run sbt-uni publishSigned and sonaRelease in one sbt session

### DIFF
--- a/.github/workflows/release-sbt-plugin.yml
+++ b/.github/workflows/release-sbt-plugin.yml
@@ -34,16 +34,16 @@ jobs:
           UNI_VERSION=$(./sbt "print uniJVM/version" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | grep -E '^[0-9]' | tail -1 | tr -d '[:space:]')
           echo "UNI_VERSION=${UNI_VERSION}"
           echo "UNI_VERSION=${UNI_VERSION}" >> "$GITHUB_OUTPUT"
-      - name: Build bundle
+      - name: Publish sbt-uni to Sonatype
         working-directory: sbt-uni
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          UNI_VERSION: ${{ steps.publish_local.outputs.UNI_VERSION }}
-        run: sbt "publishSigned"
-      - name: Release to Sonatype
-        working-directory: sbt-uni
-        env:
           SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'
           SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASS }}'
           UNI_VERSION: ${{ steps.publish_local.outputs.UNI_VERSION }}
-        run: sbt sonaRelease
+        # Run publishSigned and sonaRelease in one sbt invocation so they share
+        # the same server process. sbt 2.x keeps a persistent server and routes
+        # subsequent `sbt <cmd>` calls through a thin client, which means env vars
+        # set only on a later step are invisible to the server and sonaRelease
+        # cannot see SONATYPE_USERNAME/PASSWORD.
+        run: sbt "publishSigned; sonaRelease"


### PR DESCRIPTION
## Summary

The `Release sbt-uni plugin` workflow failed on `v2026.1.1` ([run 24641889595](https://github.com/wvlet/uni/actions/runs/24641889595)) with `sonaRelease` exiting immediately after the env listing:

```
[error] elapsed time: 0 s
##[error]Process completed with exit code 1.
```

**Root cause:** `sbt-uni/` is an sbt 2.x build. The system `sbt` launcher (installed via `sbt/setup-sbt@v1`) is a thin client that starts a persistent server on the first invocation and forwards subsequent commands to it. The previous workflow ran `sbt "publishSigned"` and `sbt sonaRelease` as two separate steps, so the server was started with step 2's env (which had `PGP_PASSPHRASE` but not `SONATYPE_*`). When step 3 forwarded `sonaRelease` to the already-running server, the server could not see the Sonatype credentials that step 3 had set on itself, and the command failed silently.

The other three release workflows (`release.yml`, `release-js.yml`, `release-native.yml`) do not hit this issue because they use `./sbt` (sbt-extras, sbt 1.x), which spawns a fresh JVM per invocation.

**Fix:** collapse the two steps into a single `sbt "publishSigned; sonaRelease"` invocation, attaching all required secrets to that one step.

## Test plan

- [ ] Re-trigger via `gh workflow run release-sbt-plugin.yml` (workflow_dispatch) or the next tagged release and confirm the sbt-uni artifact appears at <https://central.sonatype.com/search?q=org.wvlet.uni>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)