### PR TITLE
docs: Focus README on uni and uni-test, add Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # Uni
 
+[![Maven Central](https://img.shields.io/maven-central/v/org.wvlet.uni/uni_3.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.wvlet.uni/uni_3)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 **Essential Scala Utilities** — Refined for Scala 3 with minimal dependencies.
@@ -12,22 +13,72 @@
 
 **[https://wvlet.org/uni/](https://wvlet.org/uni/)**
 
-## Getting Started
-
-```scala
-// build.sbt
-libraryDependencies += "org.wvlet.uni" %% "uni" % "(version)"
-```
-
 ## Modules
 
 | Module | Description |
 |--------|-------------|
-| `uni` | Core utilities: Design, logging, JSON, MessagePack, HTTP, Rx |
+| `uni` | Core utilities: Design (DI), logging, JSON, MessagePack, Rx, HTTP client, control flow |
 | `uni-test` | Lightweight testing framework with cross-platform support |
 | `uni-netty` | Netty-based HTTP server |
-| `uni-agent` | LLM agent framework with tool integration |
-| `uni-bedrock` | AWS Bedrock chat model integration |
+
+Cross-platform: JVM, Scala.js, and Scala Native.
+
+## Using `uni`
+
+Add the dependency to your `build.sbt` (replace `<version>` with the
+version shown in the Maven Central badge above):
+
+```scala
+libraryDependencies += "org.wvlet.uni" %% "uni" % "<version>"
+```
+
+For Scala.js or Scala Native, use `%%%`:
+
+```scala
+libraryDependencies += "org.wvlet.uni" %%% "uni" % "<version>"
+```
+
+A minimal example using the logging API:
+
+```scala
+import wvlet.uni.log.LogSupport
+
+class MyService extends LogSupport:
+  def greet(name: String): String =
+    info(s"Greeting ${name}")
+    s"Hello, ${name}!"
+
+@main def hello =
+  val service = MyService()
+  println(service.greet("World"))
+```
+
+See the [reference docs](https://wvlet.org/uni/) for Design, Rx,
+JSON/MessagePack, HTTP, and more.
+
+## Using `uni-test`
+
+`uni-test` is a lightweight test framework. Add it as a test
+dependency and register the framework:
+
+```scala
+libraryDependencies += "org.wvlet.uni" %% "uni-test" % "<version>" % Test
+testFrameworks += new TestFramework("wvlet.uni.test.Framework")
+```
+
+Write a test by extending `UniTest`:
+
+```scala
+import wvlet.uni.test.UniTest
+
+class MyTest extends UniTest:
+  test("addition works") {
+    (1 + 1) shouldBe 2
+  }
+```
+
+Run with `sbt test`. See the [UniTest guide](https://wvlet.org/uni/core/unitest)
+for assertions, property-based testing, and more.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ libraryDependencies += "org.wvlet.uni" %% "uni-test" % "<version>" % Test
 testFrameworks += new TestFramework("wvlet.uni.test.Framework")
 ```
 
+For Scala.js or Scala Native projects, use `%%%`:
+
+```scala
+libraryDependencies += "org.wvlet.uni" %%% "uni-test" % "<version>" % Test
+```
+
 Write a test by extending `UniTest`:
 
 ```scala

--- a/plans/2026-04-20-readme-uni-unitest.md
+++ b/plans/2026-04-20-readme-uni-unitest.md
@@ -1,0 +1,46 @@
+# README: Focus on uni and uni-test, add version badge
+
+Date: 2026-04-20
+
+## Goal
+
+Rework the top-level `README.md` so a newcomer can quickly understand
+what `uni` and `uni-test` offer and how to use them. Also surface the
+latest released version so users don't have to guess.
+
+The `uni-agent` and `uni-bedrock` modules are still evolving and are
+not ready to be highlighted on the landing page — they should be hidden
+from the README for now (the docs site still covers them for anyone
+who needs them).
+
+## Changes
+
+1. **Version indicator**: Add a Maven Central badge
+   (`shields.io/maven-central/v/org.wvlet.uni/uni_3`) alongside the
+   existing license badge so the current release is visible at a
+   glance.
+2. **Quick-start for `uni`**: Show the sbt coordinate plus a minimal
+   `LogSupport` snippet mirroring `docs/index.md`, so the two landing
+   pages tell the same story.
+3. **Quick-start for `uni-test`**: Show the sbt coordinate (including
+   the `testFrameworks` line, which is easy to miss) and a minimal
+   `UniTest` snippet.
+4. **Trim the module table**: Drop the `uni-agent` and `uni-bedrock`
+   rows. Keep `uni`, `uni-test`, and `uni-netty` since those are the
+   stable surface.
+5. **Point to docs for depth**: Keep the docs link prominent — the
+   README is a doorway, not a substitute for the reference site.
+
+## Non-goals
+
+- No changes to `docs/` — the site already documents all modules,
+  and `__UNI_VERSION__` substitution only runs there.
+- No module code changes.
+
+## Verification
+
+- Render the README locally (GitHub preview or `glow`) and confirm
+  badges load and code fences are syntactically valid.
+- `./sbt scalafmtCheckAll` isn't relevant (markdown only), but run
+  `./sbt compile` to confirm nothing Scala-side regressed when the
+  worktree is touched.


### PR DESCRIPTION
## Summary

- Rework the top-level `README.md` to quickly show a newcomer how to use the two stable modules — `uni` and `uni-test` — with working sbt snippets for each.
- Add a Maven Central badge so the current release version is visible at a glance.
- Hide `uni-agent` and `uni-bedrock` from the README while they continue to evolve; the docs site still covers them for anyone who needs them.
- Mention `%%%` for both modules so Scala.js / Scala Native users pick the right coordinates.

## Test plan

- [x] Verify the Maven Central badge resolves (`img.shields.io/maven-central/v/org.wvlet.uni/uni_3.svg` returns the current v2026.1.1 SVG).
- [x] Render README locally to confirm both code fences are syntactically valid Scala 3.
- [ ] Reviewer: preview README on the PR page; confirm badge renders and layout reads well on mobile/desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)