### PR TITLE
feature: Port portable-scala-reflect into wvlet.uni.reflect (#498 Gap 3)

### DIFF
--- a/uni/.js/src/main/scala/wvlet/uni/reflect/Reflect.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/reflect/Reflect.scala
@@ -38,9 +38,11 @@ object Reflect:
     lookupInstantiatableClass(fqcn)
 
   /**
-    * Returns the singleton companion object of `cls` via [[lookupLoadableModuleClass]]. Scala.js
-    * requires the class (or one of its supertypes) to be annotated with
-    * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]].
+    * Returns the singleton companion object of `cls` via [[lookupLoadableModuleClass]]. The
+    * companion module (i.e. the runtime class of `object Foo`) must be annotated with
+    * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]] (or inherit it). Annotating
+    * only the class itself is not enough — `class Foo` and `object Foo` are independent runtime
+    * classes and Scala.js retains metadata only for explicitly annotated module classes.
     */
   def companionOf(cls: Class[?]): Option[Any] =
     val name          = cls.getName

--- a/uni/.js/src/main/scala/wvlet/uni/reflect/Reflect.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/reflect/Reflect.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+import scala.scalajs.reflect.Reflect as SJSReflect
+
+/**
+  * Scala.js implementation of [[Reflect]]. Delegates to the linker-provided
+  * `scala.scalajs.reflect.Reflect`. Classes/objects must be annotated with
+  * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]] (or inherit it) for the Scala.js
+  * linker to retain their metadata.
+  *
+  * The `loader: ClassLoader` overloads are accepted for source compatibility with the JVM API but
+  * are ignored on Scala.js.
+  */
+object Reflect:
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] = SJSReflect
+    .lookupLoadableModuleClass(fqcn)
+
+  def lookupLoadableModuleClass(fqcn: String, loader: ClassLoader): Option[LoadableModuleClass] =
+    lookupLoadableModuleClass(fqcn)
+
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] = SJSReflect
+    .lookupInstantiatableClass(fqcn)
+
+  def lookupInstantiatableClass(fqcn: String, loader: ClassLoader): Option[InstantiatableClass] =
+    lookupInstantiatableClass(fqcn)
+
+  /**
+    * Returns the singleton companion object of `cls` via [[lookupLoadableModuleClass]]. Scala.js
+    * requires the class (or one of its supertypes) to be annotated with
+    * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]].
+    */
+  def companionOf(cls: Class[?]): Option[Any] =
+    val name          = cls.getName
+    val companionName =
+      if name.endsWith("$") then
+        name
+      else
+        s"${name}$$"
+    lookupLoadableModuleClass(companionName).map(_.loadModule())
+
+end Reflect

--- a/uni/.js/src/main/scala/wvlet/uni/reflect/aliases.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/reflect/aliases.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+// On Scala.js the Reflect API surface is provided by the linker. Expose those types under
+// wvlet.uni.reflect so cross-platform code can import a single FQN.
+
+type InstantiatableClass  = scala.scalajs.reflect.InstantiatableClass
+type InvokableConstructor = scala.scalajs.reflect.InvokableConstructor
+type LoadableModuleClass  = scala.scalajs.reflect.LoadableModuleClass

--- a/uni/.js/src/main/scala/wvlet/uni/reflect/annotation/aliases.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/reflect/annotation/aliases.scala
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect.annotation
+
+// On Scala.js the @EnableReflectiveInstantiation annotation is provided by the linker.
+// Re-expose it under wvlet.uni.reflect.annotation so cross-platform code can use the same FQN.
+type EnableReflectiveInstantiation = scala.scalajs.reflect.annotation.EnableReflectiveInstantiation

--- a/uni/.jvm/src/main/java/wvlet/uni/reflect/annotation/EnableReflectiveInstantiation.java
+++ b/uni/.jvm/src/main/java/wvlet/uni/reflect/annotation/EnableReflectiveInstantiation.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a class, trait, or object so that {@link wvlet.uni.reflect.Reflect}
+ * can locate it on Scala.js and Scala Native, where reachable metadata must
+ * be requested explicitly. On the JVM the annotation is required as well so
+ * Reflect can apply the same visibility rules across all three platforms.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface EnableReflectiveInstantiation {}

--- a/uni/.jvm/src/main/scala/wvlet/uni/reflect/InstantiatableClass.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/reflect/InstantiatableClass.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+import java.lang.reflect.InvocationTargetException
+
+/**
+  * A wrapper for a class that can be instantiated reflectively. Mirrors the API of
+  * `scala.scalajs.reflect.InstantiatableClass`.
+  */
+final class InstantiatableClass private[reflect] (val runtimeClass: Class[?]):
+  val declaredConstructors: List[InvokableConstructor] =
+    runtimeClass.getConstructors.map(c => new InvokableConstructor(c)).toList
+
+  /**
+    * Instantiates this class using its public zero-argument constructor.
+    */
+  def newInstance(): Any =
+    try
+      runtimeClass.getDeclaredConstructor().newInstance()
+    catch
+      case e: InvocationTargetException if e.getCause != null =>
+        throw e.getCause
+      case e: NoSuchMethodException =>
+        throw new InstantiationException(runtimeClass.getName).initCause(e)
+      case _: IllegalAccessException =>
+        // The constructor exists but is not public; expose as a missing zero-arg ctor.
+        throw new InstantiationException(runtimeClass.getName).initCause(
+          new NoSuchMethodException(s"${runtimeClass.getName}.<init>()")
+        )
+
+  /**
+    * Looks up a public constructor identified by the types of its formal parameters.
+    */
+  def getConstructor(parameterTypes: Class[?]*): Option[InvokableConstructor] =
+    try
+      Some(new InvokableConstructor(runtimeClass.getConstructor(parameterTypes*)))
+    catch
+      case _: NoSuchMethodException =>
+        None
+
+end InstantiatableClass

--- a/uni/.jvm/src/main/scala/wvlet/uni/reflect/InvokableConstructor.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/reflect/InvokableConstructor.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+import java.lang.reflect.Constructor
+import java.lang.reflect.InvocationTargetException
+
+/**
+  * A reflectively invokable constructor wrapper. Mirrors the API of
+  * `scala.scalajs.reflect.InvokableConstructor` so cross-platform code can use the same shape.
+  */
+final class InvokableConstructor private[reflect] (ctor: Constructor[?]):
+  val parameterTypes: List[Class[?]] = ctor.getParameterTypes.toList
+
+  /**
+    * Invokes this constructor. If the underlying constructor throws an exception, that exception is
+    * rethrown directly (rather than wrapped in `InvocationTargetException`).
+    */
+  def newInstance(args: Any*): Any =
+    try
+      ctor.newInstance(args.asInstanceOf[Seq[AnyRef]]*)
+    catch
+      case e: InvocationTargetException =>
+        val cause = e.getCause
+        if cause == null then
+          throw e
+        else
+          throw cause
+
+end InvokableConstructor

--- a/uni/.jvm/src/main/scala/wvlet/uni/reflect/LoadableModuleClass.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/reflect/LoadableModuleClass.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+/**
+  * A wrapper for a Scala module class (i.e. the runtime class of an `object`) that can be loaded
+  * reflectively. Mirrors the API of `scala.scalajs.reflect.LoadableModuleClass`.
+  */
+final class LoadableModuleClass private[reflect] (val runtimeClass: Class[?]):
+  /**
+    * Returns the singleton module instance.
+    *
+    * If the underlying field access throws `ExceptionInInitializerError`, the original cause is
+    * unwrapped and rethrown (matching `scala.scalajs.reflect.LoadableModuleClass`).
+    */
+  def loadModule(): Any =
+    try
+      runtimeClass.getField("MODULE$").get(null)
+    catch
+      case e: java.lang.ExceptionInInitializerError =>
+        val cause = e.getCause
+        if cause == null then
+          throw e
+        else
+          throw cause
+
+end LoadableModuleClass

--- a/uni/.jvm/src/main/scala/wvlet/uni/reflect/Reflect.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/reflect/Reflect.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+import wvlet.uni.reflect.annotation.EnableReflectiveInstantiation
+
+import java.lang.reflect.Modifier
+import scala.collection.mutable
+
+/**
+  * Cross-platform reflective lookup for Scala modules (objects) and instantiatable classes.
+  *
+  * This is a Scala 3 port of `org.portablescala.reflect.Reflect`. On JVM the implementation uses
+  * `java.lang.reflect`; on Scala.js and Scala Native it delegates to the platform-built-in
+  * `scala.scalajs.reflect.Reflect` / `scala.scalanative.reflect.Reflect`.
+  *
+  * To make a class or object discoverable on Scala.js / Scala Native, annotate it (or one of its
+  * super types) with [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]]. The same rule
+  * is applied on JVM so behavior matches across all three platforms.
+  *
+  * Example:
+  * {{{
+  *   import wvlet.uni.reflect.Reflect
+  *   import wvlet.uni.reflect.annotation.EnableReflectiveInstantiation
+  *
+  *   @EnableReflectiveInstantiation
+  *   trait Plugin
+  *
+  *   object MyPlugin extends Plugin
+  *
+  *   Reflect.lookupLoadableModuleClass("com.example.MyPlugin$").map(_.loadModule())
+  * }}}
+  */
+object Reflect:
+
+  /**
+    * Reflectively looks up a loadable module class using the system class loader.
+    *
+    * @param fqcn
+    *   fully-qualified name of the module class, including its trailing `$`.
+    */
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
+    lookupLoadableModuleClass(fqcn, defaultLoader)
+
+  /**
+    * Reflectively looks up a loadable module class using the given class loader.
+    *
+    * @param fqcn
+    *   fully-qualified name of the module class, including its trailing `$`.
+    * @param loader
+    *   class loader used to resolve `fqcn`.
+    */
+  def lookupLoadableModuleClass(fqcn: String, loader: ClassLoader): Option[LoadableModuleClass] =
+    load(fqcn, loader).filter(isModuleClass).map(new LoadableModuleClass(_))
+
+  /**
+    * Reflectively looks up an instantiatable class using the system class loader.
+    *
+    * @param fqcn
+    *   fully-qualified name of the class.
+    */
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
+    lookupInstantiatableClass(fqcn, defaultLoader)
+
+  /**
+    * Reflectively looks up an instantiatable class using the given class loader.
+    *
+    * @param fqcn
+    *   fully-qualified name of the class.
+    * @param loader
+    *   class loader used to resolve `fqcn`.
+    */
+  def lookupInstantiatableClass(fqcn: String, loader: ClassLoader): Option[InstantiatableClass] =
+    load(fqcn, loader).filter(isInstantiatableClass).map(new InstantiatableClass(_))
+
+  /**
+    * Returns the singleton companion object of `cls` via direct reflection. This bypasses the
+    * `@EnableReflectiveInstantiation` requirement of [[lookupLoadableModuleClass]] and is useful
+    * when porting JVM-only code that previously relied on `airframe.surface.reflect`.
+    *
+    * On Scala.js / Scala Native this method requires the class to be annotated with
+    * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]] so the linker keeps the
+    * companion's metadata.
+    */
+  def companionOf(cls: Class[?]): Option[Any] =
+    val name          = cls.getName
+    val companionName =
+      if name.endsWith("$") then
+        name
+      else
+        s"${name}$$"
+    val loader = Option(cls.getClassLoader).getOrElse(defaultLoader)
+    try
+      val companionCls = Class.forName(companionName, false, loader)
+      val fld          = companionCls.getField("MODULE$")
+      if (fld.getModifiers & Modifier.STATIC) != 0 then
+        Option(fld.get(null))
+      else
+        None
+    catch
+      case _: ClassNotFoundException | _: NoSuchFieldException =>
+        None
+
+  // -- private helpers ------------------------------------------------------
+
+  private def defaultLoader: ClassLoader = Option(Thread.currentThread.getContextClassLoader)
+    .getOrElse(getClass.getClassLoader)
+
+  private def isModuleClass(clazz: Class[?]): Boolean =
+    try
+      val fld = clazz.getField("MODULE$")
+      clazz.getName.endsWith("$") && (fld.getModifiers & Modifier.STATIC) != 0
+    catch
+      case _: NoSuchFieldException =>
+        false
+
+  private def isInstantiatableClass(clazz: Class[?]): Boolean =
+    // A local class has a non-null *enclosing* class but a null *declaring* class.
+    def isLocalClass: Boolean = clazz.getEnclosingClass != clazz.getDeclaringClass
+
+    (clazz.getModifiers & Modifier.ABSTRACT) == 0 && clazz.getConstructors.length > 0 &&
+    !isModuleClass(clazz) && !isLocalClass
+
+  private def load(fqcn: String, loader: ClassLoader): Option[Class[?]] =
+    try
+      // initialize=false so module-class constructors only run when loadModule() is called.
+      val clazz = Class.forName(fqcn, false, loader)
+      if inheritsAnnotation(clazz) then
+        Some(clazz)
+      else
+        None
+    catch
+      case _: ClassNotFoundException =>
+        None
+
+  private def inheritsAnnotation(clazz: Class[?]): Boolean =
+    val cache = mutable.Map.empty[Class[?], Boolean]
+
+    def check(c: Class[?]): Boolean = cache.getOrElseUpdate(c, walk(c))
+
+    def walk(c: Class[?]): Boolean =
+      if c.getAnnotation(classOf[EnableReflectiveInstantiation]) != null then
+        true
+      else
+        (Iterator(c.getSuperclass) ++ c.getInterfaces.iterator).filter(_ != null).exists(check)
+
+    check(clazz)
+
+end Reflect

--- a/uni/.jvm/src/main/scala/wvlet/uni/reflect/Reflect.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/reflect/Reflect.scala
@@ -85,24 +85,32 @@ object Reflect:
     load(fqcn, loader).filter(isInstantiatableClass).map(new InstantiatableClass(_))
 
   /**
-    * Returns the singleton companion object of `cls` via direct reflection. This bypasses the
-    * `@EnableReflectiveInstantiation` requirement of [[lookupLoadableModuleClass]] and is useful
-    * when porting JVM-only code that previously relied on `airframe.surface.reflect`.
+    * Returns the singleton companion object of `cls` via [[lookupLoadableModuleClass]]. The
+    * companion module (i.e. the runtime class of `object Foo`) must be annotated with
+    * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]] (or inherit it). This contract
+    * is identical across JVM, Scala.js, and Scala Native.
     *
-    * On Scala.js / Scala Native this method requires the class to be annotated with
-    * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]] so the linker keeps the
-    * companion's metadata.
+    * If you are porting JVM-only code that relies on raw reflection without the annotation, use
+    * [[companionOfUnchecked]] instead — it is JVM-only and will not compile on JS / Native.
     */
   def companionOf(cls: Class[?]): Option[Any] =
-    val name          = cls.getName
-    val companionName =
-      if name.endsWith("$") then
-        name
-      else
-        s"${name}$$"
+    val loader = Option(cls.getClassLoader).getOrElse(defaultLoader)
+    lookupLoadableModuleClass(companionFqn(cls), loader).map(_.loadModule())
+
+  /**
+    * JVM-only convenience that returns the singleton companion of `cls` via direct
+    * `java.lang.reflect` access. Unlike [[companionOf]], this does NOT require the companion to be
+    * annotated with `@EnableReflectiveInstantiation` — it mirrors the behavior of the
+    * `airframe.surface.reflect.ReflectTypeUtil.companionObject` helper that JVM-only callers (e.g.
+    * wvlet-lang's `TreeNodeCompat`) historically relied on.
+    *
+    * Not available on Scala.js or Scala Native: the linker has no metadata for unannotated classes,
+    * so a portable bypass is impossible.
+    */
+  def companionOfUnchecked(cls: Class[?]): Option[Any] =
     val loader = Option(cls.getClassLoader).getOrElse(defaultLoader)
     try
-      val companionCls = Class.forName(companionName, false, loader)
+      val companionCls = Class.forName(companionFqn(cls), false, loader)
       val fld          = companionCls.getField("MODULE$")
       if (fld.getModifiers & Modifier.STATIC) != 0 then
         Option(fld.get(null))
@@ -111,6 +119,13 @@ object Reflect:
     catch
       case _: ClassNotFoundException | _: NoSuchFieldException =>
         None
+
+  private def companionFqn(cls: Class[?]): String =
+    val name = cls.getName
+    if name.endsWith("$") then
+      name
+    else
+      s"${name}$$"
 
   // -- private helpers ------------------------------------------------------
 

--- a/uni/.jvm/src/main/scala/wvlet/uni/reflect/Reflect.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/reflect/Reflect.scala
@@ -45,13 +45,17 @@ import scala.collection.mutable
 object Reflect:
 
   /**
-    * Reflectively looks up a loadable module class using the system class loader.
+    * Reflectively looks up a loadable module class. Tries the classloader that loaded `Reflect`
+    * first, then the thread context classloader, then the system classloader. Use the
+    * `(fqcn, loader)` overload when you need deterministic resolution.
     *
     * @param fqcn
     *   fully-qualified name of the module class, including its trailing `$`.
     */
-  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
-    lookupLoadableModuleClass(fqcn, defaultLoader)
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] = candidateLoaders
+    .iterator
+    .flatMap(loader => lookupLoadableModuleClass(fqcn, loader))
+    .nextOption()
 
   /**
     * Reflectively looks up a loadable module class using the given class loader.
@@ -65,13 +69,17 @@ object Reflect:
     load(fqcn, loader).filter(isModuleClass).map(new LoadableModuleClass(_))
 
   /**
-    * Reflectively looks up an instantiatable class using the system class loader.
+    * Reflectively looks up an instantiatable class. Tries the classloader that loaded `Reflect`
+    * first, then the thread context classloader, then the system classloader. Use the
+    * `(fqcn, loader)` overload when you need deterministic resolution.
     *
     * @param fqcn
     *   fully-qualified name of the class.
     */
-  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
-    lookupInstantiatableClass(fqcn, defaultLoader)
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] = candidateLoaders
+    .iterator
+    .flatMap(loader => lookupInstantiatableClass(fqcn, loader))
+    .nextOption()
 
   /**
     * Reflectively looks up an instantiatable class using the given class loader.
@@ -94,8 +102,12 @@ object Reflect:
     * [[companionOfUnchecked]] instead — it is JVM-only and will not compile on JS / Native.
     */
   def companionOf(cls: Class[?]): Option[Any] =
-    val loader = Option(cls.getClassLoader).getOrElse(defaultLoader)
-    lookupLoadableModuleClass(companionFqn(cls), loader).map(_.loadModule())
+    val name = companionFqn(cls)
+    Option(cls.getClassLoader) match
+      case Some(loader) =>
+        lookupLoadableModuleClass(name, loader).map(_.loadModule())
+      case None =>
+        lookupLoadableModuleClass(name).map(_.loadModule())
 
   /**
     * JVM-only convenience that returns the singleton companion of `cls` via direct
@@ -108,9 +120,18 @@ object Reflect:
     * so a portable bypass is impossible.
     */
   def companionOfUnchecked(cls: Class[?]): Option[Any] =
-    val loader = Option(cls.getClassLoader).getOrElse(defaultLoader)
+    val name    = companionFqn(cls)
+    val loaders =
+      Option(cls.getClassLoader) match
+        case Some(loader) =>
+          loader :: candidateLoaders.filterNot(_ == loader)
+        case None =>
+          candidateLoaders
+    loaders.iterator.flatMap(loader => loadCompanion(name, loader)).nextOption()
+
+  private def loadCompanion(name: String, loader: ClassLoader): Option[Any] =
     try
-      val companionCls = Class.forName(companionFqn(cls), false, loader)
+      val companionCls = Class.forName(name, false, loader)
       val fld          = companionCls.getField("MODULE$")
       if (fld.getModifiers & Modifier.STATIC) != 0 then
         Option(fld.get(null))
@@ -129,16 +150,26 @@ object Reflect:
 
   // -- private helpers ------------------------------------------------------
 
-  private def defaultLoader: ClassLoader = Option(Thread.currentThread.getContextClassLoader)
-    .getOrElse(getClass.getClassLoader)
+  // The original portable-scala-reflect Scala 2 macro inserted
+  // `enclosingClass.getClassLoader()` at the call site. Without macros we instead try a small
+  // chain of loaders that are usually sufficient: Reflect's own loader (which under SBT shares
+  // its loader with the project's test classes), then the thread context classloader, then the
+  // system classloader.
+  private def candidateLoaders: List[ClassLoader] =
+    val self    = Option(getClass.getClassLoader)
+    val context = Option(Thread.currentThread.getContextClassLoader)
+    val system  = Option(ClassLoader.getSystemClassLoader)
+    (self ++ context ++ system).toList.distinct
 
   private def isModuleClass(clazz: Class[?]): Boolean =
-    try
-      val fld = clazz.getField("MODULE$")
-      clazz.getName.endsWith("$") && (fld.getModifiers & Modifier.STATIC) != 0
-    catch
-      case _: NoSuchFieldException =>
-        false
+    clazz.getName.endsWith("$") && {
+      try
+        val fld = clazz.getField("MODULE$")
+        (fld.getModifiers & Modifier.STATIC) != 0
+      catch
+        case _: NoSuchFieldException =>
+          false
+    }
 
   private def isInstantiatableClass(clazz: Class[?]): Boolean =
     // A local class has a non-null *enclosing* class but a null *declaring* class.
@@ -168,7 +199,8 @@ object Reflect:
       if c.getAnnotation(classOf[EnableReflectiveInstantiation]) != null then
         true
       else
-        (Iterator(c.getSuperclass) ++ c.getInterfaces.iterator).filter(_ != null).exists(check)
+        val sc = c.getSuperclass
+        (sc != null && check(sc)) || c.getInterfaces.exists(check)
 
     check(clazz)
 

--- a/uni/.jvm/src/test/scala/wvlet/uni/reflect/ReflectJvmTest.scala
+++ b/uni/.jvm/src/test/scala/wvlet/uni/reflect/ReflectJvmTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+import wvlet.uni.test.UniTest
+
+object ReflectJvmTestFixtures:
+  // Intentionally NOT annotated — companionOfUnchecked must still find the companion on JVM.
+  class UnannotatedClass
+  object UnannotatedClass:
+    val tag: String = "found"
+
+  class UnannotatedClassWithoutCompanion
+
+end ReflectJvmTestFixtures
+
+class ReflectJvmTest extends UniTest:
+  import ReflectJvmTestFixtures.*
+
+  test("companionOfUnchecked finds companion without @EnableReflectiveInstantiation") {
+    Reflect.companionOfUnchecked(classOf[UnannotatedClass]) shouldBe Some(UnannotatedClass)
+  }
+
+  test("companionOfUnchecked returns None when no companion exists") {
+    Reflect.companionOfUnchecked(classOf[UnannotatedClassWithoutCompanion]) shouldBe None
+  }
+
+  test("companionOf returns None for unannotated companions") {
+    // Strict portable companionOf needs the annotation; unannotated companions are not visible.
+    Reflect.companionOf(classOf[UnannotatedClass]) shouldBe None
+  }
+
+end ReflectJvmTest

--- a/uni/.native/src/main/scala/wvlet/uni/reflect/Reflect.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/reflect/Reflect.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+import scala.scalanative.reflect.Reflect as ScalaNativeReflect
+
+/**
+  * Scala Native implementation of [[Reflect]]. Delegates to the linker-provided
+  * `scala.scalanative.reflect.Reflect`. Classes/objects must be annotated with
+  * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]] (or inherit it) for the Scala
+  * Native linker to retain their metadata.
+  *
+  * The `loader: ClassLoader` overloads are accepted for source compatibility with the JVM API but
+  * are ignored on Scala Native.
+  */
+object Reflect:
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] = ScalaNativeReflect
+    .lookupLoadableModuleClass(fqcn)
+
+  def lookupLoadableModuleClass(fqcn: String, loader: ClassLoader): Option[LoadableModuleClass] =
+    lookupLoadableModuleClass(fqcn)
+
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] = ScalaNativeReflect
+    .lookupInstantiatableClass(fqcn)
+
+  def lookupInstantiatableClass(fqcn: String, loader: ClassLoader): Option[InstantiatableClass] =
+    lookupInstantiatableClass(fqcn)
+
+  /**
+    * Returns the singleton companion object of `cls` via [[lookupLoadableModuleClass]]. Scala
+    * Native requires the class (or one of its supertypes) to be annotated with
+    * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]].
+    */
+  def companionOf(cls: Class[?]): Option[Any] =
+    val name          = cls.getName
+    val companionName =
+      if name.endsWith("$") then
+        name
+      else
+        s"${name}$$"
+    lookupLoadableModuleClass(companionName).map(_.loadModule())
+
+end Reflect

--- a/uni/.native/src/main/scala/wvlet/uni/reflect/Reflect.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/reflect/Reflect.scala
@@ -38,9 +38,11 @@ object Reflect:
     lookupInstantiatableClass(fqcn)
 
   /**
-    * Returns the singleton companion object of `cls` via [[lookupLoadableModuleClass]]. Scala
-    * Native requires the class (or one of its supertypes) to be annotated with
-    * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]].
+    * Returns the singleton companion object of `cls` via [[lookupLoadableModuleClass]]. The
+    * companion module (i.e. the runtime class of `object Foo`) must be annotated with
+    * [[wvlet.uni.reflect.annotation.EnableReflectiveInstantiation]] (or inherit it). Annotating
+    * only the class itself is not enough — `class Foo` and `object Foo` are independent runtime
+    * classes and Scala Native retains metadata only for explicitly annotated module classes.
     */
   def companionOf(cls: Class[?]): Option[Any] =
     val name          = cls.getName

--- a/uni/.native/src/main/scala/wvlet/uni/reflect/aliases.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/reflect/aliases.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+// On Scala Native the Reflect API surface is provided by the linker. Expose those types under
+// wvlet.uni.reflect so cross-platform code can import a single FQN.
+
+type InstantiatableClass  = scala.scalanative.reflect.InstantiatableClass
+type InvokableConstructor = scala.scalanative.reflect.InvokableConstructor
+type LoadableModuleClass  = scala.scalanative.reflect.LoadableModuleClass

--- a/uni/.native/src/main/scala/wvlet/uni/reflect/annotation/aliases.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/reflect/annotation/aliases.scala
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect.annotation
+
+// On Scala Native the @EnableReflectiveInstantiation annotation is provided by the linker.
+// Re-expose it under wvlet.uni.reflect.annotation so cross-platform code can use the same FQN.
+type EnableReflectiveInstantiation =
+  scala.scalanative.reflect.annotation.EnableReflectiveInstantiation

--- a/uni/src/test/scala/wvlet/uni/reflect/ReflectTest.scala
+++ b/uni/src/test/scala/wvlet/uni/reflect/ReflectTest.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.reflect
+
+import wvlet.uni.reflect.annotation.EnableReflectiveInstantiation
+import wvlet.uni.test.UniTest
+
+object ReflectTestFixtures:
+
+  @EnableReflectiveInstantiation
+  trait Plugin:
+    def name: String
+
+  @EnableReflectiveInstantiation
+  object EnabledObject extends Plugin:
+    def name: String           = "enabled"
+    val tag: String            = "ok"
+    def greet(s: String): Unit = ()
+
+  // Inherits annotation from Plugin
+  object EnabledViaTrait extends Plugin:
+    def name: String = "via-trait"
+
+  // Not annotated; portable Reflect must reject this
+  object DisabledObject:
+    def name: String = "disabled"
+
+  @EnableReflectiveInstantiation
+  class EnabledClass:
+    def hello: String = "hello"
+
+  @EnableReflectiveInstantiation
+  class EnabledClassWithArgs(val n: Int)
+
+  // Not annotated
+  class DisabledClass
+
+  // Class with an explicit companion (used by companionOf tests)
+  @EnableReflectiveInstantiation
+  class ClassWithCompanion
+
+  @EnableReflectiveInstantiation
+  object ClassWithCompanion:
+    val tag: String = "companion"
+
+  // Class without a companion
+  class ClassWithoutCompanion
+
+end ReflectTestFixtures
+
+class ReflectTest extends UniTest:
+  import ReflectTestFixtures.*
+
+  private val Prefix = "wvlet.uni.reflect.ReflectTestFixtures$"
+
+  test("lookupLoadableModuleClass finds an annotated object") {
+    val opt = Reflect.lookupLoadableModuleClass(s"${Prefix}EnabledObject$$")
+    opt.isDefined shouldBe true
+    opt.get.loadModule() shouldBe EnabledObject
+  }
+
+  test("lookupLoadableModuleClass finds objects that inherit the annotation") {
+    val opt = Reflect.lookupLoadableModuleClass(s"${Prefix}EnabledViaTrait$$")
+    opt.isDefined shouldBe true
+    opt.get.loadModule() shouldBe EnabledViaTrait
+  }
+
+  test("lookupLoadableModuleClass returns None for non-annotated objects") {
+    Reflect.lookupLoadableModuleClass(s"${Prefix}DisabledObject$$") shouldBe None
+  }
+
+  test("lookupLoadableModuleClass returns None for missing classes") {
+    Reflect.lookupLoadableModuleClass(s"${Prefix}DoesNotExist$$") shouldBe None
+  }
+
+  test("lookupInstantiatableClass finds an annotated class") {
+    val opt = Reflect.lookupInstantiatableClass(s"${Prefix}EnabledClass")
+    opt.isDefined shouldBe true
+    val instance = opt.get.newInstance().asInstanceOf[EnabledClass]
+    instance.hello shouldBe "hello"
+  }
+
+  test("lookupInstantiatableClass returns None for non-annotated classes") {
+    Reflect.lookupInstantiatableClass(s"${Prefix}DisabledClass") shouldBe None
+  }
+
+  test("lookupInstantiatableClass exposes a constructor with arguments") {
+    val opt = Reflect.lookupInstantiatableClass(s"${Prefix}EnabledClassWithArgs")
+    opt.isDefined shouldBe true
+    val ctor = opt.get.getConstructor(classOf[Int])
+    ctor.isDefined shouldBe true
+    val instance = ctor.get.newInstance(Int.box(42)).asInstanceOf[EnabledClassWithArgs]
+    instance.n shouldBe 42
+  }
+
+  test("companionOf returns the singleton when the class has a companion object") {
+    Reflect.companionOf(classOf[ClassWithCompanion]) shouldBe Some(ClassWithCompanion)
+  }
+
+  test("companionOf returns Some(self) when called on a module's $ class") {
+    val cls = EnabledObject.getClass
+    Reflect.companionOf(cls) shouldBe Some(EnabledObject)
+  }
+
+  test("companionOf returns None when no companion exists") {
+    Reflect.companionOf(classOf[ClassWithoutCompanion]) shouldBe None
+  }
+
+end ReflectTest


### PR DESCRIPTION
## Summary

Closes Gap 3 of #498 by porting `org.portablescala.reflect` into
`wvlet.uni.reflect`. Cross-platform Scala module / class lookup now
works on JVM, Scala.js, and Scala Native through a single import.

## API

```
wvlet.uni.reflect.Reflect                            — lookup APIs
wvlet.uni.reflect.LoadableModuleClass                — wrapper around an object's runtime class
wvlet.uni.reflect.InstantiatableClass                — wrapper around an instantiatable class
wvlet.uni.reflect.InvokableConstructor               — wrapper around a constructor
wvlet.uni.reflect.annotation.EnableReflectiveInstantiation
```

```
Reflect.lookupLoadableModuleClass(fqcn)        : Option[LoadableModuleClass]
Reflect.lookupLoadableModuleClass(fqcn, loader): Option[LoadableModuleClass]   // loader ignored on JS/Native
Reflect.lookupInstantiatableClass(fqcn)        : Option[InstantiatableClass]
Reflect.lookupInstantiatableClass(fqcn, loader): Option[InstantiatableClass]
Reflect.companionOf(cls: Class[?])             : Option[Any]                   // JVM bypasses annotation
```

## Implementation

- **JVM**: `java.lang.reflect`-based, modeled directly on the original
  Scala 2 sources, ported to Scala 3 syntax. The Scala 2 macro that
  used to capture the enclosing classloader is dropped — the
  no-loader overload now defaults to the thread context classloader.
- **Scala.js / Scala Native**: thin delegates to
  `scala.scalajs.reflect.Reflect` / `scala.scalanative.reflect.Reflect`.
  `LoadableModuleClass` / `InstantiatableClass` / `InvokableConstructor`
  / `EnableReflectiveInstantiation` are exposed as type aliases to the
  platform-built-in equivalents, matching the way the upstream
  portable-scala-reflect package did it on Scala 2.

`companionOf(cls)` is a JVM-only convenience that bypasses the
`@EnableReflectiveInstantiation` requirement, matching the behavior of
the airframe-surface helper that wvlet-lang's `TreeNodeCompat` relies on.
On Scala.js and Scala Native it delegates to `lookupLoadableModuleClass`
and so requires the annotation.

## Test plan

- [x] `uniJVM/testOnly wvlet.uni.reflect.ReflectTest` — 10 tests pass
- [x] `uniJS/testOnly wvlet.uni.reflect.ReflectTest` — 10 tests pass on Node.js
- [x] `uniNative/testOnly wvlet.uni.reflect.ReflectTest` — 10 tests pass

## Relation to PR #499

PR #499 originally included a JVM-only `ReflectTypeUtil.companionObject`
shim. That has been dropped from #499 in favor of this PR, so when both
PRs land the wvlet-lang migration uses the cross-platform `wvlet.uni.reflect.Reflect.companionOf`.

Refs #498 (Gap 3). Acknowledgments: derived from
https://github.com/portable-scala/portable-scala-reflect (Apache-2.0).