### PR TITLE
feature: Add @RPC, RxRouter, and RxRouterProvider (#498 Gap 4 Part 1)

### DIFF
--- a/uni/src/main/scala/wvlet/uni/http/router/RouterMacros.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/RouterMacros.scala
@@ -43,6 +43,72 @@ object RouterMacros:
     }
 
   /**
+    * Build an [[RxRouter]] from a controller type at compile-time. If the type is annotated with
+    * `@RPC`, every public method becomes an RPC endpoint (POST). Otherwise, methods annotated with
+    * `@Endpoint` are picked up just like [[buildRouter]].
+    */
+  inline def buildRxRouter[T]: RxRouter =
+    ${
+      buildRxRouterImpl[T]
+    }
+
+  private def buildRxRouterImpl[T: Type](using Quotes): Expr[RxRouter] =
+    import quotes.reflect.*
+
+    val rpcAnnot = TypeRepr
+      .of[T]
+      .typeSymbol
+      .annotations
+      .find { a =>
+        a.tpe.typeSymbol == TypeRepr.of[wvlet.uni.http.rpc.RPC].typeSymbol
+      }
+
+    val rpcPathExpr: Expr[Option[String]] =
+      rpcAnnot match
+        case Some(annot) =>
+          // Extract the `path` argument literal from `@RPC(path = "/v1")` if present.
+          val applyArgs =
+            annot match
+              case Apply(_, args) =>
+                args
+              case _ =>
+                Nil
+          val literalPath = applyArgs
+            .collectFirst {
+              case NamedArg("path", Literal(StringConstant(p))) =>
+                p
+              case Literal(StringConstant(p)) =>
+                p
+            }
+            .getOrElse("")
+          '{
+            Some(
+              ${
+                Expr(literalPath)
+              }
+            )
+          }
+        case None =>
+          '{
+            None
+          }
+
+    '{
+      val surface        = Surface.of[T]
+      val methodSurfaces = Surface.methodsOf[T]
+      val routes         = RouterMacros.extractRoutesForRx(
+        surface,
+        methodSurfaces,
+        ${
+          rpcPathExpr
+        }
+      )
+      RxRouter.EndpointNode(surface, methodSurfaces, routes)
+    }
+
+  end buildRxRouterImpl
+
+  /**
     * Extract routes from method surfaces at runtime. This method filters methods annotated with
     * `@Endpoint` and creates Route instances.
     */
@@ -69,5 +135,27 @@ object RouterMacros:
               None
         }
     }
+
+  /**
+    * Extract routes for an [[RxRouter]]. When `rpcPathPrefix` is `Some(_)`, the controller was
+    * annotated with `@RPC` and every public method becomes an RPC endpoint (HTTP POST, path
+    * `{rpcPathPrefix}/{controllerFullName}/{method}`). Otherwise, falls back to the
+    * `@Endpoint`-driven scan used by [[buildRouter]].
+    */
+  def extractRoutesForRx(
+      controllerSurface: Surface,
+      methodSurfaces: Seq[MethodSurface],
+      rpcPathPrefix: Option[String]
+  ): Seq[Route] =
+    rpcPathPrefix match
+      case Some(rawPrefix) =>
+        val prefix = rawPrefix.stripSuffix("/")
+        methodSurfaces.map { ms =>
+          val rpcPath        = s"${prefix}/${controllerSurface.fullName}/${ms.name}"
+          val pathComponents = PathComponent.parse(rpcPath)
+          Route(HttpMethod.POST, rpcPath, pathComponents, controllerSurface, ms)
+        }
+      case None =>
+        extractRoutes(controllerSurface, methodSurfaces)
 
 end RouterMacros

--- a/uni/src/main/scala/wvlet/uni/http/router/RouterMacros.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/RouterMacros.scala
@@ -66,25 +66,44 @@ object RouterMacros:
     val rpcPathExpr: Expr[Option[String]] =
       rpcAnnot match
         case Some(annot) =>
-          // Extract the `path` argument literal from `@RPC(path = "/v1")` if present.
+          // Extract the `path` argument from `@RPC(path = ...)` if present. Accept both inline
+          // string literals and references to constant `final val`s by asking the compiler for
+          // the term's constant-folded value.
           val applyArgs =
             annot match
               case Apply(_, args) =>
                 args
               case _ =>
                 Nil
-          val literalPath = applyArgs
+
+          def constantString(term: Term): Option[String] =
+            term.tpe.widenTermRefByName match
+              case ConstantType(StringConstant(s)) =>
+                Some(s)
+              case _ =>
+                term match
+                  case Literal(StringConstant(s)) =>
+                    Some(s)
+                  case Inlined(_, _, inner) =>
+                    constantString(inner)
+                  case Typed(inner, _) =>
+                    constantString(inner)
+                  case _ =>
+                    None
+
+          val resolvedPath = applyArgs
             .collectFirst {
-              case NamedArg("path", Literal(StringConstant(p))) =>
-                p
-              case Literal(StringConstant(p)) =>
-                p
+              case NamedArg("path", t) =>
+                constantString(t)
+              case t: Term if constantString(t).isDefined =>
+                constantString(t)
             }
+            .flatten
             .getOrElse("")
           '{
             Some(
               ${
-                Expr(literalPath)
+                Expr(resolvedPath)
               }
             )
           }
@@ -149,7 +168,13 @@ object RouterMacros:
   ): Seq[Route] =
     rpcPathPrefix match
       case Some(rawPrefix) =>
-        val prefix = rawPrefix.stripSuffix("/")
+        val prefix     = rawPrefix.stripSuffix("/")
+        val duplicates = methodSurfaces.groupBy(_.name).filter(_._2.size > 1).keys.toSeq.sorted
+        if duplicates.nonEmpty then
+          throw IllegalArgumentException(
+            s"Overloaded RPC methods are not supported in @RPC trait '${controllerSurface
+                .fullName}': " + duplicates.mkString(", ")
+          )
         methodSurfaces.map { ms =>
           val rpcPath        = s"${prefix}/${controllerSurface.fullName}/${ms.name}"
           val pathComponents = PathComponent.parse(rpcPath)

--- a/uni/src/main/scala/wvlet/uni/http/router/RxRouter.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/RxRouter.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http.router
+
+import wvlet.uni.surface.{MethodSurface, Surface}
+
+/**
+  * Declarative router built from a Scala trait/class annotated with [[wvlet.uni.http.rpc.RPC]]
+  * (every public method becomes an RPC endpoint) or [[Endpoint]] (per-method endpoints).
+  *
+  * Mirrors the API surface of `wvlet.airframe.http.RxRouter` so code being migrated from airframe
+  * can change imports without restructuring.
+  *
+  * Example:
+  * {{{
+  *   import wvlet.uni.http.rpc.RPC
+  *   import wvlet.uni.http.router.{RxRouter, RxRouterProvider}
+  *
+  *   @RPC
+  *   trait MyApi:
+  *     def hello(name: String): String
+  *
+  *   object MyApi extends RxRouterProvider:
+  *     override def router: RxRouter = RxRouter.of[MyApi]
+  * }}}
+  */
+trait RxRouter:
+  /** Display name for this router node (typically the controller's simple class name). */
+  def name: String
+
+  /** Child routers (empty for leaf nodes). */
+  def children: List[RxRouter]
+
+  /** True if this is a leaf node (a single endpoint group). */
+  def isLeaf: Boolean
+
+  /** Underlying flat list of routes that this RxRouter contributes. */
+  def toRoutes: Seq[Route]
+
+  override def toString: String = printNode(0)
+
+  private def printNode(indentLevel: Int): String =
+    val ws  = "  " * indentLevel
+    val out = Seq.newBuilder[String]
+    out += s"${ws}- Router[${name}]"
+    if isLeaf then
+      for r <- toRoutes do
+        out += s"${ws}  + ${r.description}"
+    for c <- children do
+      out += c.printNode(indentLevel + 1)
+    out.result().mkString("\n")
+
+end RxRouter
+
+object RxRouter:
+
+  /**
+    * Build a router from the given controller type at compile time. `T` should be annotated with
+    * [[wvlet.uni.http.rpc.RPC]] (every public method becomes an RPC endpoint) or have one or more
+    * [[Endpoint]]-annotated methods.
+    */
+  inline def of[T]: RxRouter = RouterMacros.buildRxRouter[T]
+
+  /**
+    * Combine multiple routers into a single router. Returns a single-child stem when a single
+    * router is passed.
+    */
+  def of(routers: RxRouter*): RxRouter =
+    if routers.size == 1 then
+      routers.head
+    else
+      StemNode(routers.toList)
+
+  /** A leaf RxRouter wrapping a controller surface and its method surfaces. */
+  case class EndpointNode(
+      controllerSurface: Surface,
+      methodSurfaces: Seq[MethodSurface],
+      routes: Seq[Route]
+  ) extends RxRouter:
+    override def name: String             = controllerSurface.name
+    override def children: List[RxRouter] = Nil
+    override def isLeaf: Boolean          = true
+    override def toRoutes: Seq[Route]     = routes
+  end EndpointNode
+
+  /** A composition of multiple child routers. */
+  case class StemNode(override val children: List[RxRouter]) extends RxRouter:
+    override def name: String         = f"${this.hashCode()}%08x"
+    override def isLeaf: Boolean      = false
+    override def toRoutes: Seq[Route] = children.flatMap(_.toRoutes)
+  end StemNode
+
+end RxRouter

--- a/uni/src/main/scala/wvlet/uni/http/router/RxRouterProvider.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/RxRouterProvider.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http.router
+
+/**
+  * Marker trait that exposes the default [[RxRouter]] for an RPC interface. Typically extended by
+  * the companion object of an `@RPC`-annotated trait so that codegen tooling (e.g. `sbt-uni`'s
+  * `uniHttpClients` task) can discover the router without runtime configuration.
+  *
+  * Mirrors `wvlet.airframe.http.RxRouterProvider` for porting compatibility.
+  *
+  * Example:
+  * {{{
+  *   import wvlet.uni.http.rpc.RPC
+  *   import wvlet.uni.http.router.{RxRouter, RxRouterProvider}
+  *
+  *   @RPC
+  *   trait MyApi:
+  *     def hello(name: String): String
+  *
+  *   object MyApi extends RxRouterProvider:
+  *     override def router: RxRouter = RxRouter.of[MyApi]
+  * }}}
+  */
+trait RxRouterProvider:
+  def router: RxRouter

--- a/uni/src/main/scala/wvlet/uni/http/rpc/RPC.scala
+++ b/uni/src/main/scala/wvlet/uni/http/rpc/RPC.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http.rpc
+
+import scala.annotation.StaticAnnotation
+
+/**
+  * Marks a Scala trait/class as an RPC interface. Every public method declared on the annotated
+  * type is exposed as an HTTP endpoint when the type is registered with
+  * [[wvlet.uni.http.router.RxRouter]] via `RxRouter.of[T]`.
+  *
+  * @param path
+  *   Optional URI prefix beginning with `/`. When empty, the endpoint path is
+  *   `/{fully-qualified-class-name}/{methodName}`. When set (e.g. `/v1`), the endpoint path is
+  *   `/v1/{className}/{methodName}`.
+  * @param description
+  *   Optional human-readable description used by codegen tooling.
+  *
+  * Mirrors `wvlet.airframe.http.RPC` so callers porting from airframe can swap their imports.
+  */
+case class RPC(path: String = "", description: String = "") extends StaticAnnotation

--- a/uni/src/test/scala/wvlet/uni/http/router/RxRouterTest.scala
+++ b/uni/src/test/scala/wvlet/uni/http/router/RxRouterTest.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http.router
+
+import wvlet.uni.http.HttpMethod
+import wvlet.uni.http.rpc.RPC
+import wvlet.uni.test.UniTest
+
+object RxRouterTestFixtures:
+
+  @RPC
+  trait FrontendApi:
+    def status: String
+    def submitQuery(request: String): String
+
+  object FrontendApi extends RxRouterProvider:
+    override def router: RxRouter = RxRouter.of[FrontendApi]
+
+  @RPC(path = "/v1")
+  trait FileApi:
+    def upload(name: String): String
+    def download(id: String): Array[Byte]
+
+  trait NotAnRpcTrait:
+    @Endpoint(HttpMethod.GET, "/health")
+    def health: String
+
+end RxRouterTestFixtures
+
+class RxRouterTest extends UniTest:
+  import RxRouterTestFixtures.*
+
+  test("RxRouter.of[T] exposes every public method when T is @RPC-annotated") {
+    val router = RxRouter.of[FrontendApi]
+    router.isLeaf shouldBe true
+    val routes = router.toRoutes
+    routes.size shouldBe 2
+    routes.map(_.methodSurface.name).toSet shouldBe Set("status", "submitQuery")
+    routes.foreach { r =>
+      r.method shouldBe HttpMethod.POST
+    }
+  }
+
+  test("RxRouter.of[T] uses controller fullName as the path namespace by default") {
+    val router = RxRouter.of[FrontendApi]
+    router.toRoutes.map(_.pathPattern).toSet shouldBe
+      Set(
+        "/wvlet.uni.http.router.RxRouterTestFixtures.FrontendApi/status",
+        "/wvlet.uni.http.router.RxRouterTestFixtures.FrontendApi/submitQuery"
+      )
+  }
+
+  test("RxRouter.of[T] honors @RPC(path = ...) prefix") {
+    val router = RxRouter.of[FileApi]
+    router.toRoutes.map(_.pathPattern).toSet shouldBe
+      Set(
+        "/v1/wvlet.uni.http.router.RxRouterTestFixtures.FileApi/upload",
+        "/v1/wvlet.uni.http.router.RxRouterTestFixtures.FileApi/download"
+      )
+  }
+
+  test("RxRouter.of[T] falls back to @Endpoint scan when @RPC is absent") {
+    val router = RxRouter.of[NotAnRpcTrait]
+    val routes = router.toRoutes
+    routes.size shouldBe 1
+    routes.head.method shouldBe HttpMethod.GET
+    routes.head.pathPattern shouldBe "/health"
+  }
+
+  test("RxRouter.of(routers*) composes child routers") {
+    val combined = RxRouter.of(RxRouter.of[FrontendApi], RxRouter.of[FileApi])
+    combined.isLeaf shouldBe false
+    combined.toRoutes.size shouldBe 4
+    combined.children.size shouldBe 2
+  }
+
+  test("RxRouterProvider exposes the default router for an RPC interface") {
+    FrontendApi.router shouldMatch { case _: RxRouter =>
+    }
+    FrontendApi.router.toRoutes.size shouldBe 2
+  }
+
+end RxRouterTest

--- a/uni/src/test/scala/wvlet/uni/http/router/RxRouterTest.scala
+++ b/uni/src/test/scala/wvlet/uni/http/router/RxRouterTest.scala
@@ -36,6 +36,19 @@ object RxRouterTestFixtures:
     @Endpoint(HttpMethod.GET, "/health")
     def health: String
 
+  // For the constant-prefix test: `@RPC(path = ApiPrefix)` rather than a string literal.
+  final val ApiPrefix = "/v2"
+
+  @RPC(path = ApiPrefix)
+  trait ConstantPrefixApi:
+    def ping: String
+
+  // For the overload-rejection test: two methods with the same name.
+  @RPC
+  trait OverloadedApi:
+    def hello(name: String): String
+    def hello(name: String, greeting: String): String
+
 end RxRouterTestFixtures
 
 class RxRouterTest extends UniTest:
@@ -89,6 +102,20 @@ class RxRouterTest extends UniTest:
     FrontendApi.router shouldMatch { case _: RxRouter =>
     }
     FrontendApi.router.toRoutes.size shouldBe 2
+  }
+
+  test("RxRouter.of[T] resolves a constant-reference @RPC(path = ApiPrefix)") {
+    val router = RxRouter.of[ConstantPrefixApi]
+    router.toRoutes.map(_.pathPattern).toSet shouldBe
+      Set("/v2/wvlet.uni.http.router.RxRouterTestFixtures.ConstantPrefixApi/ping")
+  }
+
+  test("RxRouter.of[T] rejects overloaded @RPC methods") {
+    val ex = intercept[IllegalArgumentException] {
+      RxRouter.of[OverloadedApi]
+    }
+    ex.getMessage.contains("Overloaded RPC methods are not supported") shouldBe true
+    ex.getMessage.contains("hello") shouldBe true
   }
 
 end RxRouterTest


### PR DESCRIPTION
## Summary

First slice of #498 Gap 4. Adds the runtime API surface needed for
wvlet-lang to declare RPC interfaces using uni instead of airframe-http.
Specifically, the wvlet-api migration target

\`\`\`scala
@RPC
trait FrontendApi:
  def status: ServerStatus
  def submitQuery(request: QueryRequest): QueryResponse

object FrontendApi extends RxRouterProvider:
  override def router = RxRouter.of[FrontendApi]
\`\`\`

now compiles against \`wvlet.uni.http.rpc.RPC\` /
\`wvlet.uni.http.router.{RxRouter, RxRouterProvider}\`.

## What's in this PR

- **\`wvlet.uni.http.rpc.RPC\`** — Scala 3 annotation marking a trait/class as
  an RPC interface (path + description), mirroring \`wvlet.airframe.http.RPC\`.
- **\`wvlet.uni.http.router.RxRouter\`** — declarative router built from a
  Scala type at compile time via \`RxRouter.of[T]\`. When \`T\` is annotated with
  \`@RPC\`, every public method becomes an HTTP POST endpoint at
  \`{rpcPathPrefix}/{controllerFullName}/{method}\`. When \`T\` is not
  \`@RPC\`-annotated, the existing \`@Endpoint\` scan is used so existing
  controllers keep working.
- **\`wvlet.uni.http.router.RxRouterProvider\`** — companion-side trait that
  exposes the default router for an RPC interface.

The macro inspects \`T\`'s class-level annotations directly via
\`quotes.reflect\` because \`Surface\` does not yet expose class
annotations. The \`@RPC\` literal \`path\` argument is lifted into the
generated routes at compile time.

## What's NOT in this PR

This is part 1 of 2-3 sub-PRs for Gap 4. Deferred:

- wiring \`ServiceScanner\` / \`HttpCodeGenerator\` / \`sbt-uni\`'s
  \`uniHttpClients\` task to recognize \`@RPC\` and generate typed clients
  for \`@RPC\` interfaces (right now they only know about \`@Endpoint\`);
- filter-chain parity with airframe's \`RxRouter.FilterNode\` (only the
  \`StemNode\` / \`EndpointNode\` shape is implemented);
- runtime route resolution (matching incoming requests to RPC routes —
  the existing \`RPCRouter\` / \`RPCRoute\` already handle that path,
  but they're not yet wired through \`RxRouter\`).

## Test plan

- [x] \`uniJVM/testOnly wvlet.uni.http.router.RxRouterTest\` — 6 tests pass
- [x] \`uniJS/testOnly wvlet.uni.http.router.RxRouterTest\` — 6 tests pass on Node.js
- [x] \`uniNative/testOnly wvlet.uni.http.router.RxRouterTest\` — 6 tests pass

Refs #498 (Gap 4 Part 1).