### PR TITLE
fix: Filter Object methods and prefix StemNode names (#501 follow-up)

### DIFF
--- a/uni/src/main/scala/wvlet/uni/http/router/RouterMacros.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/RouterMacros.scala
@@ -168,19 +168,35 @@ object RouterMacros:
   ): Seq[Route] =
     rpcPathPrefix match
       case Some(rawPrefix) =>
-        val prefix     = rawPrefix.stripSuffix("/")
-        val duplicates = methodSurfaces.groupBy(_.name).filter(_._2.size > 1).keys.toSeq.sorted
+        val prefix = rawPrefix.stripSuffix("/")
+        // Surface.methodsOf already filters out methods owned by Any / java.lang.Object /
+        // scala.Product, but defend against future changes (and against unusual user-supplied
+        // method surfaces) by excluding methods named identically to those base members.
+        val rpcMethods = methodSurfaces.filterNot(ms => ObjectMethodNames.contains(ms.name))
+        val duplicates = rpcMethods.groupBy(_.name).filter(_._2.size > 1).keys.toSeq.sorted
         if duplicates.nonEmpty then
           throw IllegalArgumentException(
             s"Overloaded RPC methods are not supported in @RPC trait '${controllerSurface
                 .fullName}': " + duplicates.mkString(", ")
           )
-        methodSurfaces.map { ms =>
+        rpcMethods.map { ms =>
           val rpcPath        = s"${prefix}/${controllerSurface.fullName}/${ms.name}"
           val pathComponents = PathComponent.parse(rpcPath)
           Route(HttpMethod.POST, rpcPath, pathComponents, controllerSurface, ms)
         }
       case None =>
         extractRoutes(controllerSurface, methodSurfaces)
+
+  private val ObjectMethodNames: Set[String] = Set(
+    "toString",
+    "hashCode",
+    "equals",
+    "getClass",
+    "wait",
+    "notify",
+    "notifyAll",
+    "clone",
+    "finalize"
+  )
 
 end RouterMacros

--- a/uni/src/main/scala/wvlet/uni/http/router/RxRouter.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/RxRouter.scala
@@ -96,7 +96,7 @@ object RxRouter:
 
   /** A composition of multiple child routers. */
   case class StemNode(override val children: List[RxRouter]) extends RxRouter:
-    override def name: String         = f"${this.hashCode()}%08x"
+    override def name: String         = f"stem-${this.hashCode()}%08x"
     override def isLeaf: Boolean      = false
     override def toRoutes: Seq[Route] = children.flatMap(_.toRoutes)
   end StemNode

--- a/uni/src/test/scala/wvlet/uni/http/router/RxRouterTest.scala
+++ b/uni/src/test/scala/wvlet/uni/http/router/RxRouterTest.scala
@@ -49,6 +49,13 @@ object RxRouterTestFixtures:
     def hello(name: String): String
     def hello(name: String, greeting: String): String
 
+  // For the Any/Object filter test: a class (not just a trait) so toString/hashCode/equals are
+  // visible on the receiver. Surface.methodsOf already filters Any/Object methods, but we also
+  // apply a defensive filter in extractRoutesForRx.
+  @RPC
+  class WithObjectMethods:
+    def greet(name: String): String = s"hi ${name}"
+
 end RxRouterTestFixtures
 
 class RxRouterTest extends UniTest:
@@ -116,6 +123,21 @@ class RxRouterTest extends UniTest:
     }
     ex.getMessage.contains("Overloaded RPC methods are not supported") shouldBe true
     ex.getMessage.contains("hello") shouldBe true
+  }
+
+  test("RxRouter.of[T] does not expose Any / Object methods") {
+    val router = RxRouter.of[WithObjectMethods]
+    val names  = router.toRoutes.map(_.methodSurface.name).toSet
+    names shouldBe Set("greet")
+    names.contains("toString") shouldBe false
+    names.contains("hashCode") shouldBe false
+    names.contains("equals") shouldBe false
+    names.contains("getClass") shouldBe false
+  }
+
+  test("StemNode names include a stem- prefix for log readability") {
+    val combined = RxRouter.of(RxRouter.of[FrontendApi], RxRouter.of[FileApi])
+    combined.name.startsWith("stem-") shouldBe true
   }
 
 end RxRouterTest


### PR DESCRIPTION
## Summary

Follow-up addressing Gemini's review feedback on #501:

- **Defensive Object-method filter** in \`extractRoutesForRx\`. \`Surface.methodsOf\` already
  filters methods owned by \`scala.Any\` / \`java.lang.Object\` / \`scala.Product\`, so the
  reported bug isn't actually present today, but apply a name-based filter as belt-and-suspenders
  against unusual user-supplied method surfaces and future \`Surface\` changes. Skipped names:
  \`toString, hashCode, equals, getClass, wait, notify, notifyAll, clone, finalize\`.
- **\`StemNode.name\` prefix.** Now reads \`stem-{hash}\` rather than the bare hash, which makes
  router trees easier to read in logs.

## Test plan

- [x] \`uniJVM/testOnly wvlet.uni.http.router.RxRouterTest\` — 10 tests pass
- [x] \`uniJS/testOnly wvlet.uni.http.router.RxRouterTest\` — 10 tests pass on Node.js
- [x] \`uniNative/testOnly wvlet.uni.http.router.RxRouterTest\` — 10 tests pass

Refs #498 (Gap 4 polish), follow-up to #501.