### PR TITLE
feature: Add @RPC scripted test + extend Object filter (#498 Gap 4 Part 2)

### DIFF
--- a/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/api/src/main/scala/example/api/GreetingService.scala
+++ b/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/api/src/main/scala/example/api/GreetingService.scala
@@ -1,0 +1,15 @@
+package example.api
+
+import wvlet.uni.http.router.RxRouter
+import wvlet.uni.http.router.RxRouterProvider
+import wvlet.uni.http.rpc.RPC
+
+case class Greeting(message: String)
+
+@RPC
+trait GreetingService:
+  def hello(name: String): Greeting
+  def goodbye(name: String): Greeting
+
+object GreetingService extends RxRouterProvider:
+  override def router: RxRouter = RxRouter.of[GreetingService]

--- a/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/app/src/main/scala/example/app/Main.scala
+++ b/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/app/src/main/scala/example/app/Main.scala
@@ -1,0 +1,15 @@
+package example.app
+
+// Verifies that the codegen works for an @RPC-annotated trait whose companion extends
+// RxRouterProvider. The generated GreetingServiceClient should be available in the
+// example.client package, just like the unannotated case.
+object Main:
+  val clientClass = classOf[example.client.GreetingServiceClient.SyncClient]
+
+  // RxRouter.of[GreetingService] is wired through the API project's companion. Use a forSome
+  // reference so this compiles whether or not the codegen also produces a router stub.
+  val routerExists = example.api.GreetingService.router != null
+
+  def main(args: Array[String]): Unit =
+    println(s"Generated client class: ${clientClass.getName}")
+    println(s"Router available: ${routerExists}")

--- a/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/build.sbt
+++ b/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/build.sbt
@@ -1,0 +1,15 @@
+val uniVersion = sys.props.getOrElse("uni.version", "0.0.1-SNAPSHOT")
+
+lazy val api = project
+  .in(file("api"))
+  .settings(scalaVersion := "3.8.3", libraryDependencies += "org.wvlet.uni" %% "uni" % uniVersion)
+
+lazy val app = project
+  .in(file("app"))
+  .enablePlugins(UniPlugin)
+  .settings(
+    scalaVersion                           := "3.8.3",
+    uniHttpClients                         := Seq("example.api.GreetingService:rpc:example.client"),
+    libraryDependencies += "org.wvlet.uni" %% "uni" % uniVersion
+  )
+  .dependsOn(api)

--- a/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/project/build.properties
+++ b/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.0-RC10

--- a/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/project/plugins.sbt
+++ b/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/project/plugins.sbt
@@ -1,0 +1,11 @@
+sys.props.get("plugin.version") match {
+  case Some(v) =>
+    addSbtPlugin("org.wvlet.uni" % "sbt-uni" % v)
+  case _ =>
+    sys.error("""|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+
+val uniVersion = sys.props.getOrElse("uni.version", "0.0.1-SNAPSHOT")
+// uni runtime dependency for generated client code
+libraryDependencies += "org.wvlet.uni" %% "uni" % uniVersion

--- a/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/test
+++ b/sbt-uni/src/sbt-test/codegen/rpc-client-annotated/test
@@ -1,0 +1,3 @@
+# Verify that codegen + compilation works end-to-end for an @RPC-annotated trait whose
+# companion extends RxRouterProvider — the wvlet-lang migration target shape.
+> app/compile

--- a/uni/.jvm/src/main/scala/wvlet/uni/http/codegen/ServiceScanner.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/http/codegen/ServiceScanner.scala
@@ -37,6 +37,7 @@ object ServiceScanner extends LogSupport:
     val simpleName  = clazz.getSimpleName
 
     val excludedNames = Set(
+      // java.lang.Object / scala.Any
       "hashCode",
       "equals",
       "toString",
@@ -46,6 +47,14 @@ object ServiceScanner extends LogSupport:
       "wait",
       "clone",
       "finalize",
+      // scala.Product (case classes)
+      "canEqual",
+      "productArity",
+      "productElement",
+      "productElementName",
+      "productIterator",
+      "productPrefix",
+      // Scala synthetic
       "$init$"
     )
 

--- a/uni/src/main/scala/wvlet/uni/http/router/RouterMacros.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/RouterMacros.scala
@@ -187,7 +187,11 @@ object RouterMacros:
       case None =>
         extractRoutes(controllerSurface, methodSurfaces)
 
+  // Members inherited from java.lang.Object / scala.Any / scala.Product. Surface.methodsOf
+  // already filters them by owner, but we also exclude by name as belt-and-suspenders against
+  // unusual user-supplied method surfaces and future Surface changes.
   private val ObjectMethodNames: Set[String] = Set(
+    // java.lang.Object / scala.Any
     "toString",
     "hashCode",
     "equals",
@@ -196,7 +200,14 @@ object RouterMacros:
     "notify",
     "notifyAll",
     "clone",
-    "finalize"
+    "finalize",
+    // scala.Product (case classes)
+    "canEqual",
+    "productArity",
+    "productElement",
+    "productElementName",
+    "productIterator",
+    "productPrefix"
   )
 
 end RouterMacros


### PR DESCRIPTION
## Summary

Wraps up #498 Gap 4. The runtime API surface (\`@RPC\`, \`RxRouter\`,
\`RxRouterProvider\`) landed in #501 and the existing \`uniHttpClients\`
codegen pipeline (\`HttpCodeGenerator\` + \`ServiceScanner\`) already
produces the same \`POST\` routes that an \`@RPC\`-annotated trait expects.
This PR adds the missing test + polish:

- A second sbt-uni scripted test (\`codegen/rpc-client-annotated\`) that
  drives codegen against an \`@RPC\`-annotated trait whose companion
  extends \`RxRouterProvider\` — the exact migration shape used by
  wvlet-api's \`FrontendApi\`. Verifies end-to-end that the annotation
  doesn't break the codegen pipeline and that the generated client
  class compiles.
- Extends \`ObjectMethodNames\` in \`RouterMacros\` to also exclude
  \`scala.Product\` members (\`canEqual\`, \`productArity\`, \`productElement\`,
  \`productElementName\`, \`productIterator\`, \`productPrefix\`).
  \`Surface.methodsOf\` already filters them by owner; this is
  belt-and-suspenders, addressing Gemini's medium-priority follow-up
  on #502.
- Mirrors the same Product-method exclusion in \`ServiceScanner\`'s
  \`excludedNames\` so codegen output stays consistent with router output
  when applied to case-class-flavored services.

## Why this closes Gap 4

Issue #498 Gap 4 lists three deliverables:

1. \`@RPC\` annotation — landed in #501.
2. \`RxRouter\` API in \`wvlet.uni.http.router\` — landed in #501.
3. \`sbt-uni\` codegen task equivalent to \`airframeHttpClients\` —
   already present as \`uniHttpClients\` (\`UniPlugin.scala\`), which the
   new scripted test exercises against an \`@RPC\` trait.

After this PR merges, wvlet-api's \`FrontendApi\` / \`FileApi\`-style
\`@RPC\` trait + \`RxRouterProvider\` companion shape compiles against
uni and \`uniHttpClients\` generates the typed RPC client.

## Test plan

- [x] \`uniJVM/testOnly wvlet.uni.http.router.RxRouterTest\` — 10 tests pass
- [x] \`sbt plugin scripted test\` runs \`codegen/rpc-client\` (existing
      backward-compat coverage) and \`codegen/rpc-client-annotated\`
      (new \`@RPC\` coverage) in the same CI step.

Refs #498 Gap 4 Part 2 (final).