### PR TITLE
feature: Add UniTest lifecycle hooks (#498 Gap 5)

### DIFF
--- a/uni-test/src/main/scala/wvlet/uni/test/UniTest.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/UniTest.scala
@@ -86,6 +86,34 @@ trait UniTest
     _tests += TestDef(name, () => body, _context, isFlaky = flaky)
 
   /**
+    * Lifecycle hook invoked once before any test in this spec runs. Override to perform setup work
+    * that should be shared across the test class instance.
+    */
+  protected def beforeAll: Unit = {}
+
+  /**
+    * Lifecycle hook invoked once after all tests in this spec finish. Override to release resources
+    * allocated in [[beforeAll]].
+    */
+  protected def afterAll: Unit = {}
+
+  /**
+    * Lifecycle hook invoked before each individual test. Override for per-test setup.
+    */
+  protected def before: Unit = {}
+
+  /**
+    * Lifecycle hook invoked after each individual test. Override for per-test teardown.
+    */
+  protected def after: Unit = {}
+
+  // Internal accessors used by the test runner.
+  private[test] def runBeforeAll(): Unit = beforeAll
+  private[test] def runAfterAll(): Unit  = afterAll
+  private[test] def runBefore(): Unit    = before
+  private[test] def runAfter(): Unit     = after
+
+  /**
     * Get all registered tests. Used by the test framework.
     */
   private[test] def registeredTests: Seq[TestDef] = _tests.toSeq

--- a/uni-test/src/main/scala/wvlet/uni/test/spi/UniTestTask.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/spi/UniTestTask.scala
@@ -217,57 +217,130 @@ class UniTestTask(
             val beforeCount = testInstance.registeredTests.size
             val testStart   = System.nanoTime()
 
-            testInstance
-              .executeTest(testDef)
-              .flatMap { result =>
+            // Per-test `before` hook. A failure here is reported as a test error.
+            val beforeFailure: Option[Throwable] =
+              try
+                testInstance.runBefore()
+                None
+              catch
+                case e: Throwable =>
+                  Some(e)
+
+            beforeFailure match
+              case Some(e) =>
                 val testElapsed = System.nanoTime() - testStart
-                val isContainer = testInstance.registeredTests.size > beforeCount
-
-                if result.isFailure || !isContainer then
-                  val event = createEvent(testDef.fullName, result, testElapsed)
-                  eventHandler.handle(event)
-                  logResult(result, testElapsed, loggers)
-                  stats.addResult(result)
-                  result match
-                    case _: TestResult.Success =>
-                      classPassed += 1
-                    case _: TestResult.Failure | _: TestResult.Error =>
-                      classFailed += 1
-                    case _: TestResult.Skipped =>
-                      classSkipped += 1
-                    case _: TestResult.Pending | _: TestResult.Cancelled | _: TestResult.Ignored =>
-                      classPending += 1
-
-                if !result.isFailure && isContainer then
-                  testInstance
-                    .registeredTests
-                    .foreach { t =>
-                      if !executedTests.contains(t.fullName) then
-                        testQueue.enqueue(t)
-                    }
-
+                val errorResult = TestResult.Error(
+                  testDef.fullName,
+                  s"before hook failed: ${e.getMessage}",
+                  e
+                )
+                val event = createEvent(testDef.fullName, errorResult, testElapsed)
+                eventHandler.handle(event)
+                logResult(errorResult, testElapsed, loggers)
+                stats.addResult(errorResult)
+                classFailed += 1
                 processQueue()
-              }
+              case None =>
+                testInstance
+                  .executeTest(testDef)
+                  .flatMap { result =>
+                    val testElapsed = System.nanoTime() - testStart
+                    val isContainer = testInstance.registeredTests.size > beforeCount
+
+                    // Per-test `after` hook. Always runs, even when the body fails.
+                    val afterError: Option[Throwable] =
+                      try
+                        testInstance.runAfter()
+                        None
+                      catch
+                        case e: Throwable =>
+                          Some(e)
+
+                    val finalResult: TestResult =
+                      afterError match
+                        case Some(e) if !result.isFailure =>
+                          TestResult.Error(
+                            testDef.fullName,
+                            s"after hook failed: ${e.getMessage}",
+                            e
+                          )
+                        case _ =>
+                          result
+
+                    if finalResult.isFailure || !isContainer then
+                      val event = createEvent(testDef.fullName, finalResult, testElapsed)
+                      eventHandler.handle(event)
+                      logResult(finalResult, testElapsed, loggers)
+                      stats.addResult(finalResult)
+                      finalResult match
+                        case _: TestResult.Success =>
+                          classPassed += 1
+                        case _: TestResult.Failure | _: TestResult.Error =>
+                          classFailed += 1
+                        case _: TestResult.Skipped =>
+                          classSkipped += 1
+                        case _: TestResult.Pending | _: TestResult.Cancelled |
+                            _: TestResult.Ignored =>
+                          classPending += 1
+
+                    if !finalResult.isFailure && isContainer then
+                      testInstance
+                        .registeredTests
+                        .foreach { t =>
+                          if !executedTests.contains(t.fullName) then
+                            testQueue.enqueue(t)
+                        }
+
+                    processQueue()
+                  }
+            end match
           end if
 
-      processQueue().map { _ =>
-        val classElapsed = System.nanoTime() - classStartTime
-        stats.addTime(classElapsed)
-        val classSummary = TestStats.formatSummary(
-          classPassed,
-          classFailed,
-          classSkipped,
-          classPending
-        )
-        val classTimeStr = TestStats.formatTime(classElapsed)
-        val summaryLine  = s"  ${classSummary} (${classTimeStr})"
-        val summaryColor =
-          if classFailed > 0 then
-            Tint.red(summaryLine)
-          else
-            Tint.green(summaryLine)
-        loggers.foreach(_.info(summaryColor))
-      }
+      // Run `beforeAll` once before processing the test queue. If it throws, abort the spec.
+      val beforeAllError: Option[Throwable] =
+        try
+          testInstance.runBeforeAll()
+          None
+        catch
+          case e: Throwable =>
+            Some(e)
+
+      val testsFuture: Future[Unit] =
+        beforeAllError match
+          case Some(e) =>
+            handleSpecLevelError(className, e, eventHandler, loggers)
+            Future.unit
+          case None =>
+            processQueue()
+
+      testsFuture
+        .transform { tryValue =>
+          // Always run `afterAll`, even on failure. Surface any teardown error.
+          try
+            testInstance.runAfterAll()
+          catch
+            case e: Throwable =>
+              handleSpecLevelError(className, e, eventHandler, loggers)
+          tryValue
+        }
+        .map { _ =>
+          val classElapsed = System.nanoTime() - classStartTime
+          stats.addTime(classElapsed)
+          val classSummary = TestStats.formatSummary(
+            classPassed,
+            classFailed,
+            classSkipped,
+            classPending
+          )
+          val classTimeStr = TestStats.formatTime(classElapsed)
+          val summaryLine  = s"  ${classSummary} (${classTimeStr})"
+          val summaryColor =
+            if classFailed > 0 then
+              Tint.red(summaryLine)
+            else
+              Tint.green(summaryLine)
+          loggers.foreach(_.info(summaryColor))
+        }
     end if
 
   end runTests

--- a/uni-test/src/test/scala/wvlet/uni/test/LifecycleTest.scala
+++ b/uni-test/src/test/scala/wvlet/uni/test/LifecycleTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.test
+
+/**
+  * Verifies that the lifecycle hooks (beforeAll/afterAll/before/after) fire in the expected order
+  * around test bodies. Each hook records a marker on a class-level mutable list and the tests
+  * assert against the running trace.
+  *
+  * The runner invokes `beforeAll` once before the test queue, `afterAll` once after it, and
+  * `before` / `after` around every individual `test(...)` body. We can verify the per-test hooks by
+  * reading the trace inside the test body itself.
+  */
+class LifecycleTest extends UniTest:
+  private val trace = scala.collection.mutable.ListBuffer.empty[String]
+
+  override protected def beforeAll: Unit = trace += "beforeAll"
+  override protected def afterAll: Unit  = trace += "afterAll"
+  override protected def before: Unit    = trace += "before"
+  override protected def after: Unit     = trace += "after"
+
+  test("beforeAll has already fired before the first test") {
+    trace.toList shouldBe List("beforeAll", "before")
+  }
+
+  test("before fires again for subsequent tests") {
+    // Trace from the previous test: beforeAll, before, after; then before fires again.
+    trace.toList shouldBe List("beforeAll", "before", "after", "before")
+  }
+
+  test("after has fired between tests") {
+    // Confirms the previous test's `after` ran before this one's `before`.
+    val expected = List("beforeAll", "before", "after", "before", "after", "before")
+    trace.toList shouldBe expected
+  }
+
+end LifecycleTest


### PR DESCRIPTION
## Summary

Closes #498 Gap 5's main blocker. UniTest was missing the per-spec /
per-test lifecycle hooks that AirSpec exposes (\`beforeAll\`, \`afterAll\`,
\`before\`, \`after\`), which prevented ~9 wvlet-lang test files from
migrating off AirSpec without restructuring.

Add the four hooks as no-op \`protected def\` overrides on \`UniTest\`,
and wire them into \`UniTestTask.runTests\`:

- \`beforeAll\` runs once before the test queue starts. A failure aborts
  the spec via \`handleSpecLevelError\`.
- \`before\` runs before each test body. A failure is reported as a
  test \`Error\` so users see broken setup quickly.
- \`after\` runs after each test body, even when the body fails. A
  failure is surfaced as a test \`Error\` when the body itself succeeded
  so cleanup problems aren't silently swallowed.
- \`afterAll\` runs once after the queue, even when earlier work failed.
  A failure is surfaced via \`handleSpecLevelError\`.

## What's still gap-y

DI / \`Design\`-based constructor injection from AirSpec is the remaining
delta. Most of wvlet-lang's AirSpec usage relies on lifecycle hooks
rather than DI (8 of 9 surveyed test files use only \`afterAll\` /
\`initDesign\` lifecycle, not constructor injection), so this single PR
unblocks the bulk of the migration. A future PR can add a
\`Design\`-aware test runner if/when the remaining DI-using suites need
to migrate.

Command-line filter syntax (the \`*RunnerSpecBasic -- spec:basic:hello.wv\`
pattern) is unaffected — UniTest already exposes \`config.testFilter\`
and the existing sbt \`testOnly ... -- pattern\` syntax works.

## Test plan

- [x] \`testJVM/test; testJS/test; testNative/test\` — 57 tests pass on
      JVM, JS-Node, and Scala Native (3 new \`LifecycleTest\` cases).

Refs #498 Gap 5.