### PR TITLE
fix: Surface UniTest lifecycle errors in summary + log (#504 follow-up)

### DIFF
--- a/uni-test/src/main/scala/wvlet/uni/test/spi/UniTestTask.scala
+++ b/uni-test/src/main/scala/wvlet/uni/test/spi/UniTestTask.scala
@@ -264,7 +264,20 @@ class UniTestTask(
                             s"after hook failed: ${e.getMessage}",
                             e
                           )
-                        case _ =>
+                        case Some(e) =>
+                          // The body already failed; we can't replace its result, but log the
+                          // teardown error so it doesn't disappear.
+                          loggers.foreach(
+                            _.error(
+                              Tint.red(
+                                s"  x after hook also failed for ${testDef.fullName}: ${e
+                                    .getMessage}"
+                              )
+                            )
+                          )
+                          loggers.foreach(_.trace(e))
+                          result
+                        case None =>
                           result
 
                     if finalResult.isFailure || !isContainer then
@@ -309,6 +322,8 @@ class UniTestTask(
         beforeAllError match
           case Some(e) =>
             handleSpecLevelError(className, e, eventHandler, loggers)
+            // Reflect the spec-level failure in the class summary so it renders red.
+            classFailed += 1
             Future.unit
           case None =>
             processQueue()
@@ -321,6 +336,7 @@ class UniTestTask(
           catch
             case e: Throwable =>
               handleSpecLevelError(className, e, eventHandler, loggers)
+              classFailed += 1
           tryValue
         }
         .map { _ =>


### PR DESCRIPTION
## Summary

Addresses Gemini's three medium-priority post-merge comments on #504:

- When the test body fails AND the \`after\` hook also fails, log the
  cleanup error in red instead of silently swallowing it. The test
  result still reflects the body's failure (standard practice), but
  the teardown problem is now visible to the developer.
- \`beforeAll\` failure now increments \`classFailed\`, so the class
  summary line renders red and reflects the abort. Previously the
  summary showed a misleading "0 tests, 0 passed" green line.
- \`afterAll\` failure does the same, ensuring teardown problems are
  reflected in the summary.

## Test plan

- [x] \`testJVM/test\` — 57 tests pass (existing \`LifecycleTest\` covers
      the happy paths; failure paths are exercised in CI via the
      existing spec-level error tests).

Refs #498 Gap 5 polish.