### PR TITLE
fix: Support self-recursive types in Weaver.fromSurface (#515)

### DIFF
--- a/plans/2026-04-28-weaver-recursive-types.md
+++ b/plans/2026-04-28-weaver-recursive-types.md
@@ -24,53 +24,83 @@ and recursively calls `fromSurface(DataType)` while the outer
 
 ## Why airframe-codec doesn't hit this
 
-`MessageCodecFactory.ofSurface` (airframe-codec) takes a `seen: Set[Surface]`
-parameter. When recursion sees the same surface twice, it returns a
-`LazyCodec` placeholder. The placeholder's `ref` is `lazy val`, so the actual
-codec lookup happens only when `pack`/`unpack` is called — by which point
-the cache has been populated by the outer call. Crucially the cache there is
-a plain `Map`, populated *after* `generateObjectSurface` returns — so cache
-writes never nest.
+`MessageCodecFactory.ofSurface` threads a `seen: Set[Surface]` and returns a
+`LazyCodec` placeholder when recursion sees the same surface twice. The
+placeholder's `ref` is `lazy val` and looks up the per-factory cache only
+when `pack`/`unpack` is called. Crucially that cache is a *plain `Map`
+private to the factory instance*, so it is single-threaded — no other
+thread ever observes a partial weaver tree.
 
-## Fix
+uni's `Weaver.fromSurface` uses a single global cache, so adapting the
+airframe approach has to be more careful about cross-thread visibility.
 
-Mirror the airframe-codec design:
+## Final design
 
-1. **Drop `getOrElseUpdate`** on `ConcurrentHashMap`. Use explicit `get` /
-   `putIfAbsent` so cache writes don't nest.
-2. **Thread a `seen: Set[Surface]`** through `fromSurface` /
-   `buildWeaver` / each `WeaverFactory`. When a recursive request comes in
-   for a surface already on the stack, return a `LazyWeaver` placeholder
-   instead of recursing.
-3. **`LazyWeaver`** holds the surface and resolves to the cached weaver
-   lazily on first `pack`/`unpack`.
+1. **Drop `getOrElseUpdate` / nested `computeIfAbsent`.** Use direct
+   `ConcurrentHashMap.get` + `putIfAbsent` so cache writes never nest
+   (which is what Java's CHM blocks for recursive computations on the
+   same key).
+2. **Per-thread pending-build map.** Each top-level `fromSurface`
+   accumulates its sub-builds in a `ThreadLocal[LinkedHashMap]`. Entries
+   are committed to the shared cache only after the outer-most call
+   returns — concurrent readers never observe a partial weaver tree.
+3. **`LazyWeaver` placeholder with direct resolution.** When recursion
+   re-enters a surface still on the build stack, we return a
+   `LazyWeaver`. After that surface's `buildWeaver` finishes, we wire the
+   placeholder's target in directly via `resolve(...)` — *not* via cache
+   lookup at use time. So visibility to other threads is independent of
+   commit order.
+4. **Track recursion by `Surface.fullName`** (not the Surface instance).
+   `LazySurface` (uni's compile-time recursive-surface placeholder) and
+   the corresponding `GenericSurface` have different equality, so a
+   Set-of-Surface guard would miss the cycle in the common
+   `Node(next: Option[Node])` case.
 
-`fromSurface(surface: Surface)` keeps its public single-arg signature for
-back-compat; recursive callers use a private `fromSurface(surface, seen)`.
+`WeaverFactory` and the rest of the public surface of `Weaver` are
+unchanged: factories don't need a `seen` parameter because recursion is
+handled inside `fromSurface` itself.
 
-## Worked sketch
+## Iterations and lessons (from codex review)
 
-```scala
-private def fromSurface(surface: Surface, seen: Set[Surface]): Weaver[?] =
-  surfaceWeaverCache.get(surface.fullName) match
-    case Some(w) => w
-    case None    =>
-      if seen.contains(surface) then LazyWeaver(surface)
-      else
-        val w = buildWeaver(surface, seen + surface)
-        surfaceWeaverCache.putIfAbsent(surface.fullName, w).getOrElse(w)
-```
+The fix went through three drafts. Each round revealed a subtler issue:
 
-`LazyWeaver` defers to `fromSurface(surface, Set.empty)` on first use; by
-that point the outer build has populated the cache, so the recursion is
-broken safely.
+1. **Draft 1** — `seen: Set[Surface]` threaded through factories; cache
+   committed entry-by-entry.
+   - codex: `seen.contains(surface)` misses `LazySurface` because
+     `LazySurface` and `GenericSurface` have different case-class
+     equality even when they describe the same type.
+   - codex: a sub-weaver containing a `LazyWeaver` is published to the
+     shared cache mid-build, so a parallel reader can grab it before
+     the LazyWeaver's target is in the cache.
+
+2. **Draft 2** — atomic commit at outer-most return; key recursion by
+   `fullName` via per-thread pending map.
+   - codex: when the outer-most surface is a *wrapper* around the
+     recursive type (e.g. `case class Wrap(node: Node)`), insertion-order
+     commit publishes Wrap before Node. Wrap's structure embeds
+     CaseClassWeaver(Node) inline, which embeds `LazyWeaver("Node")`. A
+     parallel reader hits IllegalStateException before Node is published.
+
+3. **Draft 3** (final) — `LazyWeaver` holds a directly-set reference,
+   wired in by the outer build before commit. Use-time no longer touches
+   the cache, so commit order is irrelevant for correctness.
+
+**Lesson:** when adapting a known design (airframe-codec's `LazyCodec`)
+into a different concurrency model (single-instance cache → globally
+shared cache), the original cache-lookup pattern stops being safe. The
+fix is to *eliminate* the cache lookup at use time, not to engineer the
+commit order around it.
 
 ## Test
 
-Add a test that reproduces the crash with an abstract class whose
-`typeParams: List[Self]`. Without the fix this throws
-`IllegalStateException`; with it, deriving completes and a round-trip on a
-non-abstract subtype works.
+`RecursiveSurfaceWeaverTest` covers:
+- self-recursive abstract class with `List[Self]` (the `DataType` shape),
+- abstract field embedded in a concrete case class,
+- self-recursive case class via `Option`,
+- mutually recursive case classes,
+- round-trip through the `LazyWeaver` path,
+- a 64-task concurrent stress test on the same recursive type — the
+  regression test for the cross-thread race that draft 2 still had.
 
 ## Out of scope
 

--- a/plans/2026-04-28-weaver-recursive-types.md
+++ b/plans/2026-04-28-weaver-recursive-types.md
@@ -1,0 +1,79 @@
+# Weaver: Support self-recursive types in `fromSurface`
+
+Tracking: https://github.com/wvlet/uni/issues/515
+
+## Problem
+
+`Weaver.fromSurface` (added in #513) crashes on self-recursive types with:
+
+```
+java.lang.IllegalStateException: Recursive update
+  at java.util.concurrent.ConcurrentHashMap.computeIfAbsent
+```
+
+Reproducer (wvlet's `DataType` is the canonical case):
+
+```scala
+abstract class DataType(val typeName: TypeName, val typeParams: List[DataType])
+```
+
+Building `Weaver[DataType]` walks its fields, hits `typeParams: List[DataType]`,
+and recursively calls `fromSurface(DataType)` while the outer
+`computeIfAbsent` for that key is still on the stack — which Java's
+`ConcurrentHashMap` explicitly disallows.
+
+## Why airframe-codec doesn't hit this
+
+`MessageCodecFactory.ofSurface` (airframe-codec) takes a `seen: Set[Surface]`
+parameter. When recursion sees the same surface twice, it returns a
+`LazyCodec` placeholder. The placeholder's `ref` is `lazy val`, so the actual
+codec lookup happens only when `pack`/`unpack` is called — by which point
+the cache has been populated by the outer call. Crucially the cache there is
+a plain `Map`, populated *after* `generateObjectSurface` returns — so cache
+writes never nest.
+
+## Fix
+
+Mirror the airframe-codec design:
+
+1. **Drop `getOrElseUpdate`** on `ConcurrentHashMap`. Use explicit `get` /
+   `putIfAbsent` so cache writes don't nest.
+2. **Thread a `seen: Set[Surface]`** through `fromSurface` /
+   `buildWeaver` / each `WeaverFactory`. When a recursive request comes in
+   for a surface already on the stack, return a `LazyWeaver` placeholder
+   instead of recursing.
+3. **`LazyWeaver`** holds the surface and resolves to the cached weaver
+   lazily on first `pack`/`unpack`.
+
+`fromSurface(surface: Surface)` keeps its public single-arg signature for
+back-compat; recursive callers use a private `fromSurface(surface, seen)`.
+
+## Worked sketch
+
+```scala
+private def fromSurface(surface: Surface, seen: Set[Surface]): Weaver[?] =
+  surfaceWeaverCache.get(surface.fullName) match
+    case Some(w) => w
+    case None    =>
+      if seen.contains(surface) then LazyWeaver(surface)
+      else
+        val w = buildWeaver(surface, seen + surface)
+        surfaceWeaverCache.putIfAbsent(surface.fullName, w).getOrElse(w)
+```
+
+`LazyWeaver` defers to `fromSurface(surface, Set.empty)` on first use; by
+that point the outer build has populated the cache, so the recursion is
+broken safely.
+
+## Test
+
+Add a test that reproduces the crash with an abstract class whose
+`typeParams: List[Self]`. Without the fix this throws
+`IllegalStateException`; with it, deriving completes and a round-trip on a
+non-abstract subtype works.
+
+## Out of scope
+
+- Surface caching itself (a separate concern).
+- Sealed-trait dispatch on the abstract base — the field stays lossy
+  (empty-object fallback) per #511 / #513.

--- a/plans/2026-04-28-weaver-recursive-types.md
+++ b/plans/2026-04-28-weaver-recursive-types.md
@@ -60,6 +60,51 @@ airframe approach has to be more careful about cross-thread visibility.
 unchanged: factories don't need a `seen` parameter because recursion is
 handled inside `fromSurface` itself.
 
+## Worked sketch
+
+```scala
+// Each pending entry holds the placeholder that recursive callers see, plus
+// the final weaver once buildWeaver completes for that surface.
+private final class PendingEntry(val placeholder: LazyWeaver):
+  var built: Weaver[?] = null
+
+private val pendingBuild
+    : ThreadLocal[mutable.LinkedHashMap[String, PendingEntry]] = ...
+
+def fromSurface(surface: Surface): Weaver[?] =
+  val key    = surface.fullName
+  val cached = surfaceWeaverCache.get(key)
+  if cached != null then return cached
+
+  val pending = pendingBuild.get()
+  pending.get(key) match
+    case Some(entry) if entry.built != null => entry.built
+    case Some(entry)                        => entry.placeholder // cycle
+    case None =>
+      val isOuterMost = pending.isEmpty
+      val entry       = PendingEntry(LazyWeaver())
+      pending(key) = entry
+      try
+        val built = buildWeaver(surface)
+        // Wire any captured placeholder *before* the weaver escapes the build.
+        entry.placeholder.resolve(built)
+        entry.built = built
+        if isOuterMost then
+          for (k, e) <- pending do surfaceWeaverCache.putIfAbsent(k, e.built)
+        built
+      finally
+        if isOuterMost then pending.clear()
+
+// LazyWeaver holds a directly-set ref. By the time the build returns, every
+// placeholder has been resolved — so consumers never see an unresolved one,
+// regardless of what order entries land in surfaceWeaverCache.
+private final class LazyWeaver extends Weaver[Any]:
+  @volatile private var ref: Weaver[Any] = null
+  def resolve(w: Weaver[?]): Unit = ref = w.asInstanceOf[Weaver[Any]]
+  override def pack(...)   = ref.pack(...)
+  override def unpack(...) = ref.unpack(...)
+```
+
 ## Iterations and lessons (from codex review)
 
 The fix went through three drafts. Each round revealed a subtler issue:

--- a/uni/.jvm/src/test/scala/wvlet/uni/weaver/ConcurrentRecursiveSurfaceWeaverTest.scala
+++ b/uni/.jvm/src/test/scala/wvlet/uni/weaver/ConcurrentRecursiveSurfaceWeaverTest.scala
@@ -1,0 +1,31 @@
+package wvlet.uni.weaver
+
+import wvlet.uni.surface.Surface
+import wvlet.uni.test.UniTest
+
+object ConcurrentRecursiveSurfaceWeaverTest:
+  case class Node(value: Int, next: Option[Node])
+
+class ConcurrentRecursiveSurfaceWeaverTest extends UniTest:
+  import ConcurrentRecursiveSurfaceWeaverTest.*
+
+  test("concurrent fromSurface for the same recursive type never observes a partial tree") {
+    // Regression: an earlier draft committed sub-weavers (e.g. Option[Node]) to the
+    // shared cache mid-build, so a parallel reader could grab one whose embedded
+    // LazyWeaver(Node) had no cache target yet → IllegalStateException at pack time.
+    // JVM-only because java.util.concurrent isn't available on Scala.js.
+    val pool = java.util.concurrent.Executors.newFixedThreadPool(8)
+    try
+      val task: Runnable =
+        () =>
+          val w    = Weaver.fromSurface(Surface.of[Node]).asInstanceOf[Weaver[Any]]
+          val node = Node(1, Some(Node(2, None)))
+          // Round-trip exercises every embedded LazyWeaver.
+          w.fromJson(w.toJson(node)) shouldBe node
+      val futures = (1 to 64).map(_ => pool.submit(task))
+      futures.foreach(_.get())
+    finally
+      pool.shutdown()
+  }
+
+end ConcurrentRecursiveSurfaceWeaverTest

--- a/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
@@ -16,7 +16,6 @@ import wvlet.uni.weaver.codec.PrimitiveWeaver
 import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import scala.jdk.CollectionConverters.*
 
 trait Weaver[A]:
   def weave(v: A, config: WeaverConfig = WeaverConfig()): MsgPack         = toMsgPack(v, config)
@@ -177,7 +176,7 @@ object Weaver:
   export PrimitiveWeaver.{emptyTupleElementWeaver, nonEmptyTupleElementWeaver}
 
   // Cache for weavers created from Surface
-  private val surfaceWeaverCache = ConcurrentHashMap[String, Weaver[?]]().asScala
+  private val surfaceWeaverCache = ConcurrentHashMap[String, Weaver[?]]()
 
   /**
     * Create a Weaver from Surface at runtime. Uses Surface type information to look up or build
@@ -185,23 +184,44 @@ object Weaver:
     *
     * This is used by RPC framework to derive weavers for method parameters and return types without
     * requiring compile-time type information.
+    *
+    * Self-recursive types (e.g. `class T(children: List[T])`) are supported via [[LazyWeaver]]:
+    * when a recursive request is made for a surface that is still being built on the current stack,
+    * a placeholder is returned that resolves to the cached weaver lazily on first use.
     */
-  def fromSurface(surface: Surface): Weaver[?] = surfaceWeaverCache.getOrElseUpdate(
-    surface.fullName,
-    buildWeaver(surface)
-  )
+  def fromSurface(surface: Surface): Weaver[?] = fromSurface(surface, Set.empty)
+
+  private def fromSurface(surface: Surface, seen: Set[Surface]): Weaver[?] =
+    val cached = surfaceWeaverCache.get(surface.fullName)
+    if cached != null then
+      cached
+    else if seen.contains(surface) then
+      // Break the cycle: defer resolution until the outer build populates the cache.
+      LazyWeaver(surface)
+    else
+      val w = buildWeaver(surface, seen + surface)
+      // putIfAbsent guards against a concurrent build winning the race.
+      val existing = surfaceWeaverCache.putIfAbsent(surface.fullName, w)
+      if existing == null then
+        w
+      else
+        existing
 
   /**
-    * Extensible weaver factories for runtime weaver construction. Each factory is a partial
-    * function that maps a Surface to a Weaver. Factories are tried in order until one matches.
+    * Extensible weaver factories for runtime weaver construction. Each factory takes the current
+    * `seen` set (surfaces being built on the recursion stack) and returns a partial function from
+    * Surface to Weaver. Factories are tried in order until one matches.
+    *
+    * Recursive factories must thread `seen` through their `fromSurface` calls so that
+    * self-recursive types resolve to a [[LazyWeaver]] placeholder instead of looping.
     *
     * This can be extended by platform-specific code to add support for additional types.
     */
-  type WeaverFactory = PartialFunction[Surface, Weaver[?]]
+  type WeaverFactory = Set[Surface] => PartialFunction[Surface, Weaver[?]]
 
   private val primitiveFactory: WeaverFactory =
     import PrimitiveWeaver.given
-    {
+    _ => {
       case s if s.rawType == classOf[Unit] || s.fullName == "Unit" =>
         unitWeaver
       case s if s.rawType == classOf[Int] =>
@@ -234,52 +254,55 @@ object Weaver:
 
   end primitiveFactory
 
-  private val collectionFactory: WeaverFactory = {
-    // Option[A]
-    case s: OptionSurface =>
-      OptionWeaver(fromSurface(s.elementSurface))
+  private val collectionFactory: WeaverFactory =
+    seen => {
+      // Option[A]
+      case s: OptionSurface =>
+        OptionWeaver(fromSurface(s.elementSurface, seen))
 
-    // Seq/List/Vector/IndexedSeq
-    case s if s.isSeq && s.typeArgs.nonEmpty =>
-      SeqWeaver(fromSurface(s.typeArgs.head), s.rawType)
+      // Seq/List/Vector/IndexedSeq
+      case s if s.isSeq && s.typeArgs.nonEmpty =>
+        SeqWeaver(fromSurface(s.typeArgs.head, seen), s.rawType)
 
-    // Set (Scala)
-    case s if classOf[Set[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
-      SetWeaver(fromSurface(s.typeArgs.head))
+      // Set (Scala)
+      case s if classOf[Set[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
+        SetWeaver(fromSurface(s.typeArgs.head, seen))
 
-    // Map (Scala)
-    case s if s.isMap && s.typeArgs.size >= 2 =>
-      MapWeaver(fromSurface(s.typeArgs(0)), fromSurface(s.typeArgs(1)))
+      // Map (Scala)
+      case s if s.isMap && s.typeArgs.size >= 2 =>
+        MapWeaver(fromSurface(s.typeArgs(0), seen), fromSurface(s.typeArgs(1), seen))
 
-    // Array
-    case s: ArraySurface =>
-      ArrayWeaver(fromSurface(s.elementSurface), s.elementSurface.rawType)
-  }
+      // Array
+      case s: ArraySurface =>
+        ArrayWeaver(fromSurface(s.elementSurface, seen), s.elementSurface.rawType)
+    }
 
-  private val javaCollectionFactory: WeaverFactory = {
-    // java.util.List
-    case s if classOf[java.util.List[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
-      JavaListWeaver(fromSurface(s.typeArgs.head))
+  private val javaCollectionFactory: WeaverFactory =
+    seen => {
+      // java.util.List
+      case s if classOf[java.util.List[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
+        JavaListWeaver(fromSurface(s.typeArgs.head, seen))
 
-    // java.util.Set
-    case s if classOf[java.util.Set[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
-      JavaSetWeaver(fromSurface(s.typeArgs.head))
+      // java.util.Set
+      case s if classOf[java.util.Set[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
+        JavaSetWeaver(fromSurface(s.typeArgs.head, seen))
 
-    // java.util.Map
-    case s if classOf[java.util.Map[?, ?]].isAssignableFrom(s.rawType) && s.typeArgs.size >= 2 =>
-      JavaMapWeaver(fromSurface(s.typeArgs(0)), fromSurface(s.typeArgs(1)))
-  }
+      // java.util.Map
+      case s if classOf[java.util.Map[?, ?]].isAssignableFrom(s.rawType) && s.typeArgs.size >= 2 =>
+        JavaMapWeaver(fromSurface(s.typeArgs(0), seen), fromSurface(s.typeArgs(1), seen))
+    }
 
-  private val complexTypeFactory: WeaverFactory = {
-    // Enum
-    case s: EnumSurface =>
-      EnumWeaver(s)
+  private val complexTypeFactory: WeaverFactory =
+    seen => {
+      // Enum
+      case s: EnumSurface =>
+        EnumWeaver(s)
 
-    // Case class (has objectFactory)
-    case s if s.objectFactory.isDefined =>
-      val fieldWeavers = s.params.map(p => fromSurface(p.surface)).toIndexedSeq
-      CaseClassWeaver(s, fieldWeavers)
-  }
+      // Case class (has objectFactory)
+      case s if s.objectFactory.isDefined =>
+        val fieldWeavers = s.params.map(p => fromSurface(p.surface, seen)).toIndexedSeq
+        CaseClassWeaver(s, fieldWeavers)
+    }
 
   // Fallback for surfaces with no objectFactory (open abstract types). Lossy by design:
   // a custom `given Weaver[A]` is required to preserve subtype data on round-trip.
@@ -299,10 +322,11 @@ object Weaver:
             u.skipValue
             context.setNull
 
-  private val emptyObjectFallbackFactory: WeaverFactory = {
-    case s if !s.isPrimitive && s.objectFactory.isEmpty =>
-      emptyObjectWeaver
-  }
+  private val emptyObjectFallbackFactory: WeaverFactory =
+    _ => {
+      case s if !s.isPrimitive && s.objectFactory.isEmpty =>
+        emptyObjectWeaver
+    }
 
   private val defaultFactories: Seq[WeaverFactory] = Seq(
     primitiveFactory,
@@ -312,14 +336,30 @@ object Weaver:
     emptyObjectFallbackFactory
   )
 
-  private def buildWeaver(surface: Surface): Weaver[?] = defaultFactories
-    .collectFirst {
-      case f if f.isDefinedAt(surface) =>
-        f(surface)
-    }
+  private def buildWeaver(surface: Surface, seen: Set[Surface]): Weaver[?] = defaultFactories
+    .iterator
+    .flatMap(_(seen).lift(surface))
+    .nextOption()
     .getOrElse(
       throw IllegalArgumentException(s"Cannot create Weaver for type: ${surface.fullName}")
     )
+
+  /**
+    * Placeholder Weaver used to break cycles when deriving weavers for self-recursive types. The
+    * actual Weaver is looked up from [[surfaceWeaverCache]] lazily on first use, by which point the
+    * outer build has finished populating the cache.
+    */
+  private class LazyWeaver(surface: Surface) extends Weaver[Any]:
+    private lazy val ref: Weaver[Any] =
+      val w = surfaceWeaverCache.get(surface.fullName)
+      if w == null then
+        throw IllegalStateException(
+          s"LazyWeaver for ${surface.fullName} resolved before its target was cached"
+        )
+      w.asInstanceOf[Weaver[Any]]
+
+    override def pack(p: Packer, v: Any, config: WeaverConfig): Unit = ref.pack(p, v, config)
+    override def unpack(u: Unpacker, context: WeaverContext): Unit   = ref.unpack(u, context)
 
   // Weaver factory methods for composing weavers at runtime
 

--- a/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
@@ -175,8 +175,24 @@ object Weaver:
   export PrimitiveWeaver.TupleElementWeaver
   export PrimitiveWeaver.{emptyTupleElementWeaver, nonEmptyTupleElementWeaver}
 
-  // Cache for weavers created from Surface
+  // Cache for weavers created from Surface. Only fully-resolved weaver trees are committed.
   private val surfaceWeaverCache = ConcurrentHashMap[String, Weaver[?]]()
+
+  // Per-thread accumulator for the current top-level fromSurface call. Each entry holds
+  // the LazyWeaver placeholder that was returned for recursive requests at that key, plus
+  // the final built weaver once the build completes. Entries are published to
+  // surfaceWeaverCache only after the outer-most fromSurface call returns, by which time
+  // every LazyWeaver placeholder has had its target set directly via `resolve`. This
+  // means consumers reading the cache never have to look up a placeholder's target — it's
+  // already wired in — so concurrent threads observing a sub-weaver in cache cannot see
+  // an unresolved LazyWeaver, regardless of commit order.
+  private final class PendingEntry(val placeholder: LazyWeaver):
+    var built: Weaver[?] = null
+
+  private val pendingBuild
+      : ThreadLocal[scala.collection.mutable.LinkedHashMap[String, PendingEntry]] =
+    new ThreadLocal[scala.collection.mutable.LinkedHashMap[String, PendingEntry]]:
+      override def initialValue() = scala.collection.mutable.LinkedHashMap.empty
 
   /**
     * Create a Weaver from Surface at runtime. Uses Surface type information to look up or build
@@ -186,42 +202,62 @@ object Weaver:
     * requiring compile-time type information.
     *
     * Self-recursive types (e.g. `class T(children: List[T])`) are supported via [[LazyWeaver]]:
-    * when a recursive request is made for a surface that is still being built on the current stack,
-    * a placeholder is returned that resolves to the cached weaver lazily on first use.
+    * when a recursive request is made for a surface still on the current build stack, a placeholder
+    * is returned. The placeholder's target is wired in directly once the surface's weaver is built,
+    * so it never depends on cache lookups at use time.
     */
-  def fromSurface(surface: Surface): Weaver[?] = fromSurface(surface, Set.empty)
-
-  private def fromSurface(surface: Surface, seen: Set[Surface]): Weaver[?] =
-    val cached = surfaceWeaverCache.get(surface.fullName)
+  def fromSurface(surface: Surface): Weaver[?] =
+    val key    = surface.fullName
+    val cached = surfaceWeaverCache.get(key)
     if cached != null then
-      cached
-    else if seen.contains(surface) then
-      // Break the cycle: defer resolution until the outer build populates the cache.
-      LazyWeaver(surface)
-    else
-      val w = buildWeaver(surface, seen + surface)
-      // putIfAbsent guards against a concurrent build winning the race.
-      val existing = surfaceWeaverCache.putIfAbsent(surface.fullName, w)
-      if existing == null then
-        w
-      else
-        existing
+      return cached
+
+    val pending = pendingBuild.get()
+    pending.get(key) match
+      case Some(entry) if entry.built != null =>
+        // Already finished within this build — return the same instance for sibling references.
+        entry.built
+      case Some(entry) =>
+        // Recursive request: parent is still being built. Return its placeholder; it will be
+        // resolved when the parent's buildWeaver call returns, before any consumer sees it.
+        entry.placeholder
+      case None =>
+        val isOuterMost = pending.isEmpty
+        val entry       = PendingEntry(LazyWeaver())
+        pending(key) = entry
+        try
+          val built = buildWeaver(surface)
+          // Wire the placeholder directly to the built weaver so any structures that
+          // captured the placeholder during recursion now have a working target.
+          entry.placeholder.resolve(built)
+          entry.built = built
+          if isOuterMost then
+            val it = pending.iterator
+            while it.hasNext do
+              val (k, e) = it.next()
+              surfaceWeaverCache.putIfAbsent(k, e.built)
+          built
+        finally
+          if isOuterMost then
+            pending.clear()
+
+  end fromSurface
 
   /**
-    * Extensible weaver factories for runtime weaver construction. Each factory takes the current
-    * `seen` set (surfaces being built on the recursion stack) and returns a partial function from
-    * Surface to Weaver. Factories are tried in order until one matches.
+    * Extensible weaver factories for runtime weaver construction. Each factory is a partial
+    * function that maps a Surface to a Weaver. Factories are tried in order until one matches.
     *
-    * Recursive factories must thread `seen` through their `fromSurface` calls so that
-    * self-recursive types resolve to a [[LazyWeaver]] placeholder instead of looping.
+    * Recursion is handled transparently via [[fromSurface]]: factories may call it directly when
+    * descending into child surfaces; cycle detection is keyed on `Surface.fullName` so a
+    * `LazySurface` placeholder resolves to the same key as the corresponding `GenericSurface`.
     *
     * This can be extended by platform-specific code to add support for additional types.
     */
-  type WeaverFactory = Set[Surface] => PartialFunction[Surface, Weaver[?]]
+  type WeaverFactory = PartialFunction[Surface, Weaver[?]]
 
   private val primitiveFactory: WeaverFactory =
     import PrimitiveWeaver.given
-    _ => {
+    {
       case s if s.rawType == classOf[Unit] || s.fullName == "Unit" =>
         unitWeaver
       case s if s.rawType == classOf[Int] =>
@@ -254,55 +290,52 @@ object Weaver:
 
   end primitiveFactory
 
-  private val collectionFactory: WeaverFactory =
-    seen => {
-      // Option[A]
-      case s: OptionSurface =>
-        OptionWeaver(fromSurface(s.elementSurface, seen))
+  private val collectionFactory: WeaverFactory = {
+    // Option[A]
+    case s: OptionSurface =>
+      OptionWeaver(fromSurface(s.elementSurface))
 
-      // Seq/List/Vector/IndexedSeq
-      case s if s.isSeq && s.typeArgs.nonEmpty =>
-        SeqWeaver(fromSurface(s.typeArgs.head, seen), s.rawType)
+    // Seq/List/Vector/IndexedSeq
+    case s if s.isSeq && s.typeArgs.nonEmpty =>
+      SeqWeaver(fromSurface(s.typeArgs.head), s.rawType)
 
-      // Set (Scala)
-      case s if classOf[Set[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
-        SetWeaver(fromSurface(s.typeArgs.head, seen))
+    // Set (Scala)
+    case s if classOf[Set[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
+      SetWeaver(fromSurface(s.typeArgs.head))
 
-      // Map (Scala)
-      case s if s.isMap && s.typeArgs.size >= 2 =>
-        MapWeaver(fromSurface(s.typeArgs(0), seen), fromSurface(s.typeArgs(1), seen))
+    // Map (Scala)
+    case s if s.isMap && s.typeArgs.size >= 2 =>
+      MapWeaver(fromSurface(s.typeArgs(0)), fromSurface(s.typeArgs(1)))
 
-      // Array
-      case s: ArraySurface =>
-        ArrayWeaver(fromSurface(s.elementSurface, seen), s.elementSurface.rawType)
-    }
+    // Array
+    case s: ArraySurface =>
+      ArrayWeaver(fromSurface(s.elementSurface), s.elementSurface.rawType)
+  }
 
-  private val javaCollectionFactory: WeaverFactory =
-    seen => {
-      // java.util.List
-      case s if classOf[java.util.List[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
-        JavaListWeaver(fromSurface(s.typeArgs.head, seen))
+  private val javaCollectionFactory: WeaverFactory = {
+    // java.util.List
+    case s if classOf[java.util.List[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
+      JavaListWeaver(fromSurface(s.typeArgs.head))
 
-      // java.util.Set
-      case s if classOf[java.util.Set[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
-        JavaSetWeaver(fromSurface(s.typeArgs.head, seen))
+    // java.util.Set
+    case s if classOf[java.util.Set[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
+      JavaSetWeaver(fromSurface(s.typeArgs.head))
 
-      // java.util.Map
-      case s if classOf[java.util.Map[?, ?]].isAssignableFrom(s.rawType) && s.typeArgs.size >= 2 =>
-        JavaMapWeaver(fromSurface(s.typeArgs(0), seen), fromSurface(s.typeArgs(1), seen))
-    }
+    // java.util.Map
+    case s if classOf[java.util.Map[?, ?]].isAssignableFrom(s.rawType) && s.typeArgs.size >= 2 =>
+      JavaMapWeaver(fromSurface(s.typeArgs(0)), fromSurface(s.typeArgs(1)))
+  }
 
-  private val complexTypeFactory: WeaverFactory =
-    seen => {
-      // Enum
-      case s: EnumSurface =>
-        EnumWeaver(s)
+  private val complexTypeFactory: WeaverFactory = {
+    // Enum
+    case s: EnumSurface =>
+      EnumWeaver(s)
 
-      // Case class (has objectFactory)
-      case s if s.objectFactory.isDefined =>
-        val fieldWeavers = s.params.map(p => fromSurface(p.surface, seen)).toIndexedSeq
-        CaseClassWeaver(s, fieldWeavers)
-    }
+    // Case class (has objectFactory)
+    case s if s.objectFactory.isDefined =>
+      val fieldWeavers = s.params.map(p => fromSurface(p.surface)).toIndexedSeq
+      CaseClassWeaver(s, fieldWeavers)
+  }
 
   // Fallback for surfaces with no objectFactory (open abstract types). Lossy by design:
   // a custom `given Weaver[A]` is required to preserve subtype data on round-trip.
@@ -322,11 +355,10 @@ object Weaver:
             u.skipValue
             context.setNull
 
-  private val emptyObjectFallbackFactory: WeaverFactory =
-    _ => {
-      case s if !s.isPrimitive && s.objectFactory.isEmpty =>
-        emptyObjectWeaver
-    }
+  private val emptyObjectFallbackFactory: WeaverFactory = {
+    case s if !s.isPrimitive && s.objectFactory.isEmpty =>
+      emptyObjectWeaver
+  }
 
   private val defaultFactories: Seq[WeaverFactory] = Seq(
     primitiveFactory,
@@ -336,30 +368,39 @@ object Weaver:
     emptyObjectFallbackFactory
   )
 
-  private def buildWeaver(surface: Surface, seen: Set[Surface]): Weaver[?] = defaultFactories
-    .iterator
-    .flatMap(_(seen).lift(surface))
-    .nextOption()
+  private def buildWeaver(surface: Surface): Weaver[?] = defaultFactories
+    .collectFirst {
+      case f if f.isDefinedAt(surface) =>
+        f(surface)
+    }
     .getOrElse(
       throw IllegalArgumentException(s"Cannot create Weaver for type: ${surface.fullName}")
     )
 
   /**
-    * Placeholder Weaver used to break cycles when deriving weavers for self-recursive types. The
-    * actual Weaver is looked up from [[surfaceWeaverCache]] lazily on first use, by which point the
-    * outer build has finished populating the cache.
+    * Placeholder Weaver used to break cycles when deriving weavers for self-recursive types. Its
+    * target is wired in by the outer build via [[resolve]] before any consumer can use it; pack and
+    * unpack delegate directly to the resolved weaver. Holding a direct reference (rather than
+    * re-looking up a global cache) means visibility to other threads doesn't depend on commit order
+    * — the placeholder is always fully wired by the time it escapes the build.
     */
-  private class LazyWeaver(surface: Surface) extends Weaver[Any]:
-    private lazy val ref: Weaver[Any] =
-      val w = surfaceWeaverCache.get(surface.fullName)
-      if w == null then
-        throw IllegalStateException(
-          s"LazyWeaver for ${surface.fullName} resolved before its target was cached"
-        )
-      w.asInstanceOf[Weaver[Any]]
+  private final class LazyWeaver extends Weaver[Any]:
+    @volatile
+    private var ref: Weaver[Any] = null
 
-    override def pack(p: Packer, v: Any, config: WeaverConfig): Unit = ref.pack(p, v, config)
-    override def unpack(u: Unpacker, context: WeaverContext): Unit   = ref.unpack(u, context)
+    def resolve(w: Weaver[?]): Unit = ref = w.asInstanceOf[Weaver[Any]]
+
+    override def pack(p: Packer, v: Any, config: WeaverConfig): Unit =
+      val w = ref
+      if w == null then
+        throw IllegalStateException("LazyWeaver used before its target was resolved")
+      w.pack(p, v, config)
+
+    override def unpack(u: Unpacker, context: WeaverContext): Unit =
+      val w = ref
+      if w == null then
+        throw IllegalStateException("LazyWeaver used before its target was resolved")
+      w.unpack(u, context)
 
   // Weaver factory methods for composing weavers at runtime
 

--- a/uni/src/test/scala/wvlet/uni/weaver/RecursiveSurfaceWeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/RecursiveSurfaceWeaverTest.scala
@@ -40,11 +40,16 @@ class RecursiveSurfaceWeaverTest extends UniTest:
     w shouldNotBe null
   }
 
-  test("fromSurface for mutually recursive case classes") {
-    val w1 = Weaver.fromSurface(Surface.of[Branch])
-    val w2 = Weaver.fromSurface(Surface.of[Leaf])
+  test("fromSurface for mutually recursive case classes round-trips") {
+    val w1 = Weaver.fromSurface(Surface.of[Branch]).asInstanceOf[Weaver[Any]]
+    val w2 = Weaver.fromSurface(Surface.of[Leaf]).asInstanceOf[Weaver[Any]]
     w1 shouldNotBe null
     w2 shouldNotBe null
+
+    val data     = Branch("root", Some(Leaf(1, Some(Branch("child", None)))))
+    val json     = w1.toJson(data)
+    val restored = w1.fromJson(json)
+    restored shouldBe data
   }
 
   test("LazyWeaver round-trips data through self-recursive case class") {

--- a/uni/src/test/scala/wvlet/uni/weaver/RecursiveSurfaceWeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/RecursiveSurfaceWeaverTest.scala
@@ -1,0 +1,60 @@
+package wvlet.uni.weaver
+
+import wvlet.uni.surface.Surface
+import wvlet.uni.test.UniTest
+
+object RecursiveSurfaceWeaverTest:
+  // Self-recursive abstract class — mirrors wvlet's `DataType` shape that triggered #515:
+  // building Weaver[TypeNode] needs Weaver[List[TypeNode]] needs Weaver[TypeNode]…
+  abstract class TypeNode(val name: String, val children: List[TypeNode])
+
+  // Concrete subtype to exercise round-trip on a non-abstract field that itself
+  // contains the recursive abstract type.
+  case class TypeColumn(label: String, node: TypeNode) derives Weaver
+
+  // Self-recursive concrete case class via Option to break the compile-time cycle.
+  case class Node(value: Int, next: Option[Node])
+
+  // Mutually recursive case classes via Option (avoids divergent implicit search at derive time).
+  case class Branch(name: String, child: Option[Leaf])
+  case class Leaf(value: Int, parent: Option[Branch])
+end RecursiveSurfaceWeaverTest
+
+class RecursiveSurfaceWeaverTest extends UniTest:
+  import RecursiveSurfaceWeaverTest.*
+
+  test("fromSurface does not throw for self-recursive abstract class with self-typed children") {
+    // Without the LazyWeaver fix this throws java.lang.IllegalStateException: Recursive update
+    // from ConcurrentHashMap.computeIfAbsent during the recursive build of Weaver[TypeNode].
+    val w = Weaver.fromSurface(Surface.of[TypeNode])
+    w shouldNotBe null
+  }
+
+  test("fromSurface for surface containing a self-recursive abstract field") {
+    val w = Weaver.fromSurface(Surface.of[TypeColumn])
+    w shouldNotBe null
+  }
+
+  test("fromSurface for self-recursive case class") {
+    val w = Weaver.fromSurface(Surface.of[Node])
+    w shouldNotBe null
+  }
+
+  test("fromSurface for mutually recursive case classes") {
+    val w1 = Weaver.fromSurface(Surface.of[Branch])
+    val w2 = Weaver.fromSurface(Surface.of[Leaf])
+    w1 shouldNotBe null
+    w2 shouldNotBe null
+  }
+
+  test("LazyWeaver round-trips data through self-recursive case class") {
+    // Exercises LazyWeaver.pack/unpack: the cache is populated by the time the
+    // placeholder is touched at runtime.
+    val w    = Weaver.fromSurface(Surface.of[Node]).asInstanceOf[Weaver[Any]]
+    val node = Node(1, Some(Node(2, Some(Node(3, None)))))
+    val json = w.toJson(node)
+    val back = w.fromJson(json)
+    back shouldBe node
+  }
+
+end RecursiveSurfaceWeaverTest

--- a/uni/src/test/scala/wvlet/uni/weaver/RecursiveSurfaceWeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/RecursiveSurfaceWeaverTest.scala
@@ -57,4 +57,22 @@ class RecursiveSurfaceWeaverTest extends UniTest:
     back shouldBe node
   }
 
+  test("concurrent fromSurface for the same recursive type never observes a partial tree") {
+    // Regression: an earlier draft committed sub-weavers (e.g. Option[Node]) to the
+    // shared cache mid-build, so a parallel reader could grab one whose embedded
+    // LazyWeaver(Node) had no cache target yet → IllegalStateException at pack time.
+    val pool = java.util.concurrent.Executors.newFixedThreadPool(8)
+    try
+      val task: Runnable =
+        () =>
+          val w    = Weaver.fromSurface(Surface.of[Node]).asInstanceOf[Weaver[Any]]
+          val node = Node(1, Some(Node(2, None)))
+          // Round-trip exercises every embedded LazyWeaver.
+          w.fromJson(w.toJson(node)) shouldBe node
+      val futures = (1 to 64).map(_ => pool.submit(task))
+      futures.foreach(_.get())
+    finally
+      pool.shutdown()
+  }
+
 end RecursiveSurfaceWeaverTest

--- a/uni/src/test/scala/wvlet/uni/weaver/RecursiveSurfaceWeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/RecursiveSurfaceWeaverTest.scala
@@ -57,22 +57,4 @@ class RecursiveSurfaceWeaverTest extends UniTest:
     back shouldBe node
   }
 
-  test("concurrent fromSurface for the same recursive type never observes a partial tree") {
-    // Regression: an earlier draft committed sub-weavers (e.g. Option[Node]) to the
-    // shared cache mid-build, so a parallel reader could grab one whose embedded
-    // LazyWeaver(Node) had no cache target yet → IllegalStateException at pack time.
-    val pool = java.util.concurrent.Executors.newFixedThreadPool(8)
-    try
-      val task: Runnable =
-        () =>
-          val w    = Weaver.fromSurface(Surface.of[Node]).asInstanceOf[Weaver[Any]]
-          val node = Node(1, Some(Node(2, None)))
-          // Round-trip exercises every embedded LazyWeaver.
-          w.fromJson(w.toJson(node)) shouldBe node
-      val futures = (1 to 64).map(_ => pool.submit(task))
-      futures.foreach(_.get())
-    finally
-      pool.shutdown()
-  }
-
 end RecursiveSurfaceWeaverTest


### PR DESCRIPTION
## Summary

Fixes #515: `Weaver.fromSurface` threw `java.lang.IllegalStateException: Recursive update` from `ConcurrentHashMap.computeIfAbsent` when building a Weaver for a self-recursive type (e.g. `class T(children: List[T])`).

The fix mirrors `airframe-codec`'s `LazyCodec` design (which is why the analogous wvlet code didn't hit this bug there) and adapts it for uni's globally-shared cache.

## What changed

- **Drop `getOrElseUpdate` / nested `computeIfAbsent`.** Use direct `ConcurrentHashMap.get` + `putIfAbsent` so cache writes never nest (which is what Java's CHM blocks for recursive computations on the same key).
- **Per-thread pending-build map.** Each top-level `fromSurface` accumulates its sub-builds in a thread-local `LinkedHashMap`. Entries are committed to the shared cache only after the outer-most call returns, so concurrent readers never observe a partial weaver tree.
- **`LazyWeaver` placeholder with direct resolution.** When recursion re-enters a surface that's still on the build stack, a `LazyWeaver` is returned. Its target is wired in via `resolve(...)` *immediately* after that surface's `buildWeaver` returns — not via cache lookup at use time. So visibility to other threads is independent of commit order.
- **Track recursion by `Surface.fullName`** (not the Surface instance). `LazySurface` (uni's compile-time recursive-surface placeholder) and the corresponding `GenericSurface` have different equality, so a Set-of-Surface guard would miss the cycle in the common `Node(next: Option[Node])` case.

`WeaverFactory` and the public surface of `Weaver` are unchanged.

## Test plan

- [x] New `RecursiveSurfaceWeaverTest` covers: self-recursive abstract class with `List[Self]` (the `DataType` shape from the issue), abstract field embedded in a concrete case class, self-recursive case class via `Option`, mutually recursive case classes, a round-trip through the `LazyWeaver` path, and a 64-task concurrent stress test on the same recursive type.
- [x] `coreJVM/test` + `uniJVM/test` — 1595 tests pass (4 pre-existing pending), including all 17 existing `WeaverFromSurfaceTest` cases.
- [x] `scalafmtAll` clean.
- [x] `codex review --uncommitted` — issues identified and addressed across iterations.

Closes #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)