### PR TITLE
fix: Align scala-native test-interface version with plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ val AIRFRAME_VERSION                    = "2026.1.6"
 val AWS_SDK_VERSION                     = "2.42.41"
 val JS_JAVA_LOGGING_VERSION             = "1.0.0"
 val JUNIT_PLATFORM_VERSION              = "6.0.3"
-val SCALA_NATIVE_TEST_INTERFACE_VERSION = "0.5.8"
+val SCALA_NATIVE_TEST_INTERFACE_VERSION = "0.5.11"
 val SBT_TEST_INTERFACE_VERSION          = "1.0"
 
 // Common build settings


### PR DESCRIPTION
## Summary
- Bump `SCALA_NATIVE_TEST_INTERFACE_VERSION` from `0.5.8` to `0.5.11` so it matches the `sbt-scala-native` plugin already configured in `project/plugin.sbt`.
- This unblocks #514 (sbt 1.12.9 → 1.12.10), where stricter eviction in sbt 1.12.10 turns the pre-existing mismatch into a hard failure on the Scala Native CI job:

  ```
  * org.scala-native:test-interface_native0.5_3:0.5.11 (strict) is selected over 0.5.8 for test
      +- org.wvlet.uni:uni-test_native0.5_3 (depends on 0.5.11)
      +- org.scala-native:test-interface_native0.5_3:0.5.8  (depends on 0.5.8)
  ```

## Test plan
- [ ] CI: Scala Native job passes
- [ ] After merge, rebase #514 to confirm the sbt 1.12.10 bump goes green