### PR TITLE
fix: Avoid POSIX localtime_r in Scala Native log formatter on Windows

### DIFF
--- a/uni-core/.native/src/main/scala/wvlet/uni/log/LogTimestampFormatter.scala
+++ b/uni-core/.native/src/main/scala/wvlet/uni/log/LogTimestampFormatter.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.uni.log
 
+import scala.scalanative.meta.LinktimeInfo
 import scalanative.posix.time.*
 import scalanative.unsafe.*
 import scalanative.unsigned.*
@@ -20,11 +21,28 @@ import scalanative.libc.stdio.*
 import scalanative.libc.string.*
 
 /**
-  * Use strftime to format timestamps in Scala Native
+  * Format timestamps in Scala Native.
+  *
+  * On POSIX targets we delegate to `strftime` + `localtime_r` so the system timezone offset (e.g.
+  * `+0900`) is preserved. MSVC's CRT does not provide `localtime_r`, so on Windows we fall back to
+  * a pure-Scala UTC formatter (suffix `Z`). `LinktimeInfo.isWindows` is resolved at link time, so
+  * the unused branch is dead-code-eliminated and the POSIX path keeps its existing behavior.
   */
 object LogTimestampFormatter:
 
-  private def format(pattern: CString, timeMillis: Long): String = Zone {
+  def formatTimestamp(timeMillis: Long): String =
+    if LinktimeInfo.isWindows then
+      formatUtc(timeMillis, withSpace = true)
+    else
+      formatPosix(c"%Y-%m-%d %H:%M:%S.", timeMillis)
+
+  def formatTimestampWithoutSpace(timeMillis: Long): String =
+    if LinktimeInfo.isWindows then
+      formatUtc(timeMillis, withSpace = false)
+    else
+      formatPosix(c"%Y-%m-%dT%H:%M:%S.", timeMillis)
+
+  private def formatPosix(pattern: CString, timeMillis: Long): String = Zone {
     val ttPtr = alloc[time_t]()
     !ttPtr = (timeMillis / 1000).toSize
     val tmPtr = alloc[tm]()
@@ -48,11 +66,53 @@ object LogTimestampFormatter:
     fromCString(buf)
   }
 
-  def formatTimestamp(timeMillis: Long): String = format(c"%Y-%m-%d %H:%M:%S.", timeMillis)
+  // Pure-Scala UTC formatter used on Windows. Howard Hinnant's
+  // civil-from-days algorithm gives correct year/month/day for any epoch
+  // millis without leaning on POSIX-only C symbols.
+  private def formatUtc(timeMillis: Long, withSpace: Boolean): String =
+    val seconds        = Math.floorDiv(timeMillis, 1000L)
+    val millis         = Math.floorMod(timeMillis, 1000L)
+    val daysSinceEpoch = Math.floorDiv(seconds, 86400L)
+    val secondsInDay   = Math.floorMod(seconds, 86400L)
 
-  def formatTimestampWithoutSpace(timeMillis: Long): String = format(
-    c"%Y-%m-%dT%H:%M:%S.",
-    timeMillis
-  )
+    val hour   = (secondsInDay / 3600L).toInt
+    val minute = ((secondsInDay % 3600L) / 60L).toInt
+    val second = (secondsInDay  % 60L).toInt
+
+    val z   = daysSinceEpoch + 719468L
+    val era =
+      (
+        if z >= 0 then
+          z
+        else
+          z - 146096L
+      ) / 146097L
+    val doe   = (z - era * 146097L).toInt
+    val yoe   = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365
+    val y0    = yoe.toLong + era * 400L
+    val doy   = doe - (365 * yoe + yoe / 4 - yoe / 100)
+    val mp    = (5 * doy + 2) / 153
+    val day   = doy - (153 * mp + 2) / 5 + 1
+    val month =
+      if mp < 10 then
+        mp + 3
+      else
+        mp - 9
+    val year =
+      (
+        if month <= 2 then
+          y0 + 1
+        else
+          y0
+      ).toInt
+
+    val sep =
+      if withSpace then
+        ' '
+      else
+        'T'
+    f"$year%04d-$month%02d-$day%02d$sep$hour%02d:$minute%02d:$second%02d.$millis%03dZ"
+
+  end formatUtc
 
 end LogTimestampFormatter


### PR DESCRIPTION
## Summary

- MSVC's CRT does not export POSIX `localtime_r`, so downstream Scala
  Native consumers of `uni-core` that build for Windows hit a linker
  error (`unresolved external symbol localtime_r`). wvlet caught this
  while producing `wvlet.dll` on `windows-2022`:
  https://github.com/wvlet/wvlet/actions/runs/25133797459/job/73666762135
- Gate the existing `localtime_r` + `strftime` path on
  `scala.scalanative.meta.LinktimeInfo.isWindows`, and fall back to a
  pure-Scala UTC formatter on Windows (Howard Hinnant's civil-from-days
  algorithm). `LinktimeInfo.isWindows` is a link-time constant, so
  POSIX targets keep their existing behavior unchanged via DCE.
- The Windows path drops the system timezone offset (emits `Z`), which
  matches what the Scala.js path already does (`Date.toISOString()`).

## Test plan

- [x] `coreNative/test` passes locally on macOS (`./sbt uniNative/test` — 1330 passed)
- [x] `scalafmtCheckAll`
- [ ] Verified end-to-end by bumping `UNI_VERSION` in
      [`wvlet/wvlet`](https://github.com/wvlet/wvlet/blob/main/build.sbt)
      after this lands and is published, and re-running the
      `Build native on Windows (x64)` job that originally caught it.

## Follow-up

Add a `windows-latest` Scala Native job to `uni`'s `test.yml` so this
class of regression is caught at the source rather than by downstream
projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)