### PR TITLE
docs: Document styleAttr / titleAttr migration path on `all` (#524)

### DIFF
--- a/plans/2026-05-03-issue-524-style-attr.md
+++ b/plans/2026-05-03-issue-524-style-attr.md
@@ -1,0 +1,57 @@
+# #524 — `style` attribute vs `<style>` tag collision in `all`
+
+## Findings
+
+The migration path the issue asks for already exists, just not
+discoverably:
+
+- `wvlet.uni.dom.HtmlAttrs.styleAttr` is defined as
+  `attr("style")` (HtmlAttrs.scala line 49).
+- `wvlet.uni.dom.HtmlAttrs.titleAttr` is the same pattern for `title`
+  (line 50).
+- `all.scala` line 42 has a half-line comment: `// Use styleAttr and
+  titleAttr for the attribute versions`.
+
+So `import wvlet.uni.dom.all.*` then `div(styleAttr -> "height: 64px;")`
+already works today — the migration just needs to know the rename.
+
+## Approach (issue's option 2: "Provide an alternative attribute name")
+
+Take the path uni already chose, just make it findable:
+
+1. **Document the migration shape** on `all`'s scaladoc, so a reader
+   doesn't need to discover the rename from a one-line code comment.
+2. **Pin a regression test** in `package example.dom` (so the test
+   actually goes through `import wvlet.uni.dom.all.*`) that exercises
+   `styleAttr -> "..."` and `titleAttr -> "..."`. If a future refactor
+   drops or renames either attribute, the test fails to compile.
+3. Don't rename the `<style>` tag (issue's option 1) — that would
+   break `style("body { ... }")` call sites.
+
+## Why option 2 over option 1
+
+The issue lists both. Option 1 (rename tag to `styleTag`, expose
+`style` as the attribute) is closer to airframe-rx-html's split, but
+in this codebase `style` is already an *object* (`CssStyles.scala:50`)
+that supports both `style("body { … }")` (as `<style>` tag) *and*
+`style(display := "flex")` (as a CSS-rule builder). Renaming it would
+break the second form too.
+
+`styleAttr` / `titleAttr` is the additive, non-breaking path. The only
+gap is that migrating code doesn't know to look for it.
+
+## Files to change
+
+- `uni/.js/src/main/scala/wvlet/uni/dom/all.scala` — expand the
+  scaladoc on `object all` to show both `style` (tag/CSS) and
+  `styleAttr` (attribute) usage and name them as the airframe-rx-html
+  migration shape.
+- `uni-dom-test/src/test/scala/example/dom/StyleAttrTest.scala` — new
+  test in a sibling package that pins the migration contract.
+
+## Out of scope
+
+- Renaming the `<style>` tag (issue's option 1).
+- Compile-error help text for users who try `style -> "..."` — would
+  need a custom `@implicitNotFound`-style message and is a bigger
+  surface change.

--- a/uni-dom-test/src/test/scala/example/dom/StyleAttrTest.scala
+++ b/uni-dom-test/src/test/scala/example/dom/StyleAttrTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.dom
+
+import wvlet.uni.test.UniTest
+import wvlet.uni.dom.{DomAttribute, DomElement}
+import wvlet.uni.dom.all.*
+import wvlet.uni.dom.all.given
+import scala.language.implicitConversions
+
+/**
+  * Pins the airframe-rx-html migration contract for the `style` / `title` attribute names. In uni's
+  * `all`, `style` and `title` resolve to the corresponding HTML *elements* (the `<style>` and
+  * `<title>` tags), so the migration uses `styleAttr` / `titleAttr` for the attribute form. See
+  * issue #524.
+  *
+  * Lives in `package example.dom` so the import goes through `import wvlet.uni.dom.all.*` only — a
+  * sibling under `package wvlet.uni.dom` would see `styleAttr` via package-level visibility even if
+  * the `all` mixin dropped the attribute.
+  */
+class StyleAttrTest extends UniTest:
+
+  test("styleAttr produces an inline CSS attribute through `import all.*`"):
+    val d = div(styleAttr -> "height: 64px; color: red;")
+    d.modifiers.flatten.head shouldMatch { case a: DomAttribute =>
+      a.name shouldBe "style"
+      a.v shouldBe "height: 64px; color: red;"
+    }
+
+  test("titleAttr produces a tooltip attribute through `import all.*`"):
+    val b = button(titleAttr -> "Save changes")
+    b.modifiers.flatten.head shouldMatch { case a: DomAttribute =>
+      a.name shouldBe "title"
+      a.v shouldBe "Save changes"
+    }
+
+  test("`style` in scope is the <style> tag, not an attribute"):
+    // Plain `style` is the `<style>` element in `wvlet.uni.dom.all` — verify it resolves to
+    // a `DomElement` (and so accepts CSS rule text as a child), not a `DomAttributeOf`.
+    val s = style("body { margin: 0; }")
+    s shouldMatch { case e: DomElement =>
+      e.name shouldBe "style"
+    }
+
+  test("`title` in scope is the <title> tag, not an attribute"):
+    val t = title("Page Title")
+    t shouldMatch { case e: DomElement =>
+      e.name shouldBe "title"
+    }
+
+end StyleAttrTest

--- a/uni-dom-test/src/test/scala/example/dom/StyleAttrTest.scala
+++ b/uni-dom-test/src/test/scala/example/dom/StyleAttrTest.scala
@@ -32,16 +32,30 @@ import scala.language.implicitConversions
 class StyleAttrTest extends UniTest:
 
   test("styleAttr produces an inline CSS attribute through `import all.*`"):
-    val d = div(styleAttr -> "height: 64px; color: red;")
-    d.modifiers.flatten.head shouldMatch { case a: DomAttribute =>
-      a.name shouldBe "style"
+    // Search by name rather than .head — `.head` would silently break if a future change adds a
+    // default modifier to `div` (default class, ARIA attributes, etc.) before our explicit one.
+    val d      = div(styleAttr -> "height: 64px; color: red;")
+    val styled = d
+      .modifiers
+      .flatten
+      .collectFirst {
+        case a: DomAttribute if a.name == "style" =>
+          a
+      }
+    styled shouldMatch { case Some(a) =>
       a.v shouldBe "height: 64px; color: red;"
     }
 
   test("titleAttr produces a tooltip attribute through `import all.*`"):
-    val b = button(titleAttr -> "Save changes")
-    b.modifiers.flatten.head shouldMatch { case a: DomAttribute =>
-      a.name shouldBe "title"
+    val b      = button(titleAttr -> "Save changes")
+    val titled = b
+      .modifiers
+      .flatten
+      .collectFirst {
+        case a: DomAttribute if a.name == "title" =>
+          a
+      }
+    titled shouldMatch { case Some(a) =>
       a.v shouldBe "Save changes"
     }
 

--- a/uni/.js/src/main/scala/wvlet/uni/dom/all.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/all.scala
@@ -35,11 +35,25 @@ package wvlet.uni.dom
   * SVG elements inside an `svg` tag automatically inherit the SVG namespace during rendering. Tags
   * that exist in both HTML and SVG (like `title`, `a`, `style`) will use the appropriate namespace
   * based on their parent context.
+  *
+  * ==Migrating from airframe-rx-html==
+  *
+  * Where airframe used the same name for a tag and an attribute, uni picks the *tag* and exposes
+  * the attribute under a `*Attr` suffix:
+  *
+  *   - `style` is the `<style>` element (and the CSS-rule builder, see `wvlet.uni.dom.style`). Use
+  *     [[HtmlAttrs.styleAttr]] for the inline-CSS attribute:
+  *     {{{div(styleAttr -> s"height: 64px;")}}}
+  *   - `title` is the `<title>` element. Use [[HtmlAttrs.titleAttr]] for the tooltip attribute:
+  *     {{{button(titleAttr -> "Save changes")}}}
+  *
+  * Both `*Attr` symbols come in via the same `import wvlet.uni.dom.all.*` — no extra import needed.
   */
 object all extends HtmlTags with HtmlAttrs with SvgTags with SvgAttrs:
 
-  // Resolve conflicts between HtmlTags and HtmlAttrs by preferring tags
-  // Use styleAttr and titleAttr for the attribute versions
+  // Resolve conflicts between HtmlTags and HtmlAttrs by preferring tags.
+  // Use `styleAttr` (HtmlAttrs.scala:49) for inline CSS and `titleAttr` (line 50) for tooltips —
+  // see the migration note on this object's scaladoc.
   override lazy val title: DomElement = HtmlTags.tag("title")
   override lazy val form: DomElement  = HtmlTags.tag("form")
   override lazy val span: DomElement  = HtmlTags.tag("span")

--- a/uni/.js/src/main/scala/wvlet/uni/dom/all.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/all.scala
@@ -43,7 +43,7 @@ package wvlet.uni.dom
   *
   *   - `style` is the `<style>` element (and the CSS-rule builder, see `wvlet.uni.dom.style`). Use
   *     [[HtmlAttrs.styleAttr]] for the inline-CSS attribute:
-  *     {{{div(styleAttr -> s"height: 64px;")}}}
+  *     {{{div(styleAttr -> "height: 64px;")}}}
   *   - `title` is the `<title>` element. Use [[HtmlAttrs.titleAttr]] for the tooltip attribute:
   *     {{{button(titleAttr -> "Save changes")}}}
   *
@@ -52,8 +52,8 @@ package wvlet.uni.dom
 object all extends HtmlTags with HtmlAttrs with SvgTags with SvgAttrs:
 
   // Resolve conflicts between HtmlTags and HtmlAttrs by preferring tags.
-  // Use `styleAttr` (HtmlAttrs.scala:49) for inline CSS and `titleAttr` (line 50) for tooltips —
-  // see the migration note on this object's scaladoc.
+  // Use `styleAttr` for inline CSS and `titleAttr` for tooltips — see the migration note on
+  // this object's scaladoc.
   override lazy val title: DomElement = HtmlTags.tag("title")
   override lazy val form: DomElement  = HtmlTags.tag("form")
   override lazy val span: DomElement  = HtmlTags.tag("span")


### PR DESCRIPTION
## Summary

Closes #524.

`styleAttr` and `titleAttr` already exist in `HtmlAttrs` (lines 49-50) as the attribute counterparts of the `<style>` and `<title>` elements. But the migration shape was a one-line code comment buried in `all.scala`, so airframe-rx-html migrators trying `style -> "..."` hit a compile error without a clear next step.

This PR takes the issue's *option 2* (\"Provide an alternative attribute name. Keep `all.style` as the tag, but also export `styleAttr` ... Documented migration path: rewrite `style -> \"…\"` as `styleAttr -> \"…\"`\"):

1. Expand the scaladoc on `object all` to spell out the migration shape — where airframe used one name for both, uni keeps the *tag* and exposes the attribute under a `*Attr` suffix. Show worked examples for both `styleAttr` and `titleAttr`.
2. Pin the contract with `example.dom.StyleAttrTest`, in a sibling package so the whole flow goes through `import wvlet.uni.dom.all.*` only.

Option 1 (rename the tag to `styleTag`) was rejected because in this codebase `style` is already an *object* (see `CssStyles.scala:50`) supporting both `style(\"body { ... }\")` *and* `style(display := \"flex\")`. Renaming it would break both call-site forms.

## Test plan

- [x] `./sbt domTest/test` — 346/346 pass (was 342, +4 `StyleAttrTest` cases).
- [x] `./sbt scalafmtAll` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)