### PR TITLE
feature: Add RxComponent for content-receiving migration shape (#527)

### DIFF
--- a/plans/2026-05-03-issue-527-rx-component.md
+++ b/plans/2026-05-03-issue-527-rx-component.md
@@ -1,0 +1,79 @@
+# #527 — `RxComponent` for content-receiving components
+
+## Problem
+
+airframe-rx-html had an `RxComponent` trait whose `render` took the
+child content as a parameter:
+
+```scala
+object MainFrame extends RxComponent:
+  override def render(content: RxElement) = div(
+    cls -> "h-screen max-h-screen",
+    NavBar,
+    content,
+    URLParamManager()
+  )
+
+// At call sites:
+MainFrame(editor).renderTo("main")  // outer chrome wraps `editor`
+MainFrame()                          // standalone with no inner content
+```
+
+uni's `RxElement` only has `def render: RxElement` (no content
+parameter), so this "outer chrome wraps inner content" pattern doesn't
+have a direct uni equivalent. A hand-rolled `apply(content)` that
+addModifies works for one-offs but breaks the
+`object MyFrame extends RxComponent` ergonomics that callers rely on.
+
+## Approach (issue's option 1)
+
+Add `wvlet.uni.dom.RxComponent` mirroring airframe's API:
+
+```scala
+abstract class RxComponent:
+  /** Render this component, wrapping the given content. */
+  def render(content: RxElement): RxElement
+
+  /** Wrap content using this component's chrome. */
+  def apply(content: RxElement): RxElement = render(content)
+
+  /** Render with empty content (standalone form). */
+  def apply(): RxElement = render(RxElement.empty)
+```
+
+`RxElement.empty` already exists (`RxElement.scala`). Both `apply`
+overloads return an `RxElement`, so the result chains cleanly into
+the existing `renderTo` extension method.
+
+Export `RxComponent` from `wvlet.uni.dom.all` so a single
+`import wvlet.uni.dom.all.*` matches the airframe import shape.
+
+## Files to change
+
+- `uni/.js/src/main/scala/wvlet/uni/dom/RxComponent.scala` — new file
+  with the abstract class.
+- `uni/.js/src/main/scala/wvlet/uni/dom/all.scala` — add an
+  `export wvlet.uni.dom.RxComponent` next to the existing `RxElement`
+  re-export.
+- `uni-dom-test/src/test/scala/wvlet/uni/dom/RxComponentTest.scala` —
+  unit tests covering `apply(content)`, `apply()`, the `render` hook,
+  and a worked "MainFrame wraps inner content" scenario from the issue.
+
+## Why not also subclass `RxElement`
+
+Tempting (would let `RxComponent` instances be embedded as children
+directly), but `RxElement` requires `def render: RxElement` (no
+parameter). Forcing `RxComponent` to satisfy both signatures would
+either pick an arbitrary default for the no-arg form (lock-in) or
+require the subclass to implement two `render` methods (boilerplate).
+Keep `RxComponent` separate; users who want an embeddable element
+call `.apply(...)` to convert.
+
+## Out of scope
+
+- Lifecycle hooks (`onMount`, `beforeUnmount`, etc.) — airframe's
+  `RxComponent` didn't have them in the issue's example, and the
+  inner `RxElement` returned from `render(content)` already supports
+  them. Add only if a concrete migration use case shows up.
+- A typed-content variant `RxComponent[A]`. The migration target uses
+  `RxElement` content; promoting to a generic API is premature.

--- a/plans/2026-05-03-issue-527-rx-component.md
+++ b/plans/2026-05-03-issue-527-rx-component.md
@@ -30,7 +30,7 @@ addModifies works for one-offs but breaks the
 Add `wvlet.uni.dom.RxComponent` mirroring airframe's API:
 
 ```scala
-abstract class RxComponent:
+trait RxComponent:
   /** Render this component, wrapping the given content. */
   def render(content: RxElement): RxElement
 
@@ -40,6 +40,10 @@ abstract class RxComponent:
   /** Render with empty content (standalone form). */
   def apply(): RxElement = render(RxElement.empty)
 ```
+
+A `trait` (not `abstract class`) — airframe's was a trait, and migrating
+code that does `class Foo extends SomeBase with RxComponent` would not
+compile against an `abstract class` form. Per codex review on PR #533.
 
 `RxElement.empty` already exists (`RxElement.scala`). Both `apply`
 overloads return an `RxElement`, so the result chains cleanly into

--- a/uni-dom-test/src/test/scala/example/dom/RxComponentImportTest.scala
+++ b/uni-dom-test/src/test/scala/example/dom/RxComponentImportTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.dom
+
+import wvlet.uni.test.UniTest
+import wvlet.uni.dom.all.*
+import wvlet.uni.dom.all.given
+import scala.language.implicitConversions
+
+/**
+  * Pins the airframe-rx-html migration shape for `RxComponent`: the migration code uses
+  * `import wvlet.uni.dom.all.*` and writes `object MyFrame extends RxComponent` directly. This test
+  * must compile *and* run from a sibling package — a regression where `RxComponent` is no longer
+  * re-exported from `all` would surface as a compile error here, not a missing-symbol error
+  * reachable only from inside `package wvlet.uni.dom` via package visibility. See #527.
+  */
+class RxComponentImportTest extends UniTest:
+
+  test("RxComponent reachable through `import wvlet.uni.dom.all.*`"):
+    object Frame extends RxComponent:
+      override def render(content: RxElement): RxElement = div(cls -> "frame", content)
+
+    val wrapped = Frame(span("inner"))
+    wrapped shouldMatch { case _: RxElement =>
+    }
+
+  test("standalone Frame() reachable through `import wvlet.uni.dom.all.*`"):
+    object Frame extends RxComponent:
+      override def render(content: RxElement): RxElement = div(cls -> "frame", content)
+
+    Frame() shouldMatch { case _: RxElement =>
+    }
+
+end RxComponentImportTest

--- a/uni-dom-test/src/test/scala/wvlet/uni/dom/RxComponentTest.scala
+++ b/uni-dom-test/src/test/scala/wvlet/uni/dom/RxComponentTest.scala
@@ -69,4 +69,20 @@ class RxComponentTest extends UniTest:
     target.textContent shouldBe "no-content-needed"
     rendered.cancelable.cancel
 
+  test("RxComponent mixes into another base — `extends Base with RxComponent`"):
+    // airframe-rx-html's `RxComponent` was a trait, so migrating code like
+    // `class Foo extends SomeBase with RxComponent` is valid. This test pins that uni's
+    // `RxComponent` keeps the trait shape so those mixin sites still compile. (Suggested by
+    // codex review on PR #533.)
+    abstract class HasName(val name: String)
+
+    class NamedFrame(name: String) extends HasName(name) with RxComponent:
+      override def render(content: RxElement): RxElement = div(cls -> name, content)
+
+    val frame: HasName & RxComponent = NamedFrame("my-frame")
+    frame.name shouldBe "my-frame"
+    val wrapped = frame(span("inner"))
+    wrapped shouldMatch { case _: RxElement =>
+    }
+
 end RxComponentTest

--- a/uni-dom-test/src/test/scala/wvlet/uni/dom/RxComponentTest.scala
+++ b/uni-dom-test/src/test/scala/wvlet/uni/dom/RxComponentTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom
+
+import wvlet.uni.test.UniTest
+import wvlet.uni.dom.all.*
+import wvlet.uni.dom.all.given
+import org.scalajs.dom
+import scala.language.implicitConversions
+
+class RxComponentTest extends UniTest:
+
+  test("apply(content) invokes render with the supplied content"):
+    object Frame extends RxComponent:
+      override def render(content: RxElement): RxElement = div(cls -> "frame", content)
+
+    val rendered = Frame(span("inner"))
+    rendered shouldMatch { case _: RxElement =>
+    }
+
+  test("apply() invokes render with RxElement.empty"):
+    var seen: RxElement = null
+    object Frame extends RxComponent:
+      override def render(content: RxElement): RxElement =
+        seen = content
+        div("standalone")
+
+    Frame()
+    // The standalone form must hand RxElement.empty to render — verify by reference identity so a
+    // future change that swaps the default for some other "empty-ish" placeholder fails this test.
+    (seen eq RxElement.empty) shouldBe true
+
+  test("MainFrame-style component wraps inner content into the DOM"):
+    // Worked example from issue #527: an outer chrome component receiving inner content.
+    object MainFrame extends RxComponent:
+      override def render(content: RxElement): RxElement = div(cls -> "main-frame", content)
+
+    val target = dom.document.createElement("div")
+    target.id = "rx-component-mount"
+    dom.document.body.appendChild(target)
+
+    val rendered = MainFrame(span("editor")).renderTo("rx-component-mount")
+    target.textContent shouldBe "editor"
+    rendered.cancelable.cancel
+
+  test("standalone component renders without inner content"):
+    object Standalone extends RxComponent:
+      override def render(content: RxElement): RxElement = div(
+        cls -> "standalone",
+        "no-content-needed"
+      )
+
+    val target = dom.document.createElement("div")
+    target.id = "rx-component-standalone-mount"
+    dom.document.body.appendChild(target)
+
+    val rendered = Standalone().renderTo("rx-component-standalone-mount")
+    target.textContent shouldBe "no-content-needed"
+    rendered.cancelable.cancel
+
+end RxComponentTest

--- a/uni/.js/src/main/scala/wvlet/uni/dom/RxComponent.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/RxComponent.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom
+
+/**
+  * A component that wraps inner content with outer chrome — the airframe-rx-html `RxComponent`
+  * shape, ported so wvlet code can keep its `extends RxComponent` definitions intact.
+  *
+  * Subclasses implement `render(content: RxElement)` to describe the wrapping markup. The `apply`
+  * overloads invoke `render` with the supplied content, or with [[RxElement.empty]] for standalone
+  * use:
+  *
+  * {{{
+  *   import wvlet.uni.dom.all.*
+  *
+  *   object MainFrame extends RxComponent:
+  *     override def render(content: RxElement): RxElement = div(
+  *       cls -> "h-screen max-h-screen",
+  *       NavBar,
+  *       content,
+  *       URLParamManager()
+  *     )
+  *
+  *   MainFrame(editor).renderTo("main")  // outer chrome wraps `editor`
+  *   MainFrame()                         // standalone with no inner content
+  * }}}
+  */
+abstract class RxComponent:
+
+  /**
+    * Render this component, wrapping the given content.
+    */
+  def render(content: RxElement): RxElement
+
+  /**
+    * Wrap the given content using this component's chrome. Returns an [[RxElement]] that can be
+    * passed as a child or rendered with [[wvlet.uni.dom.all.renderTo]].
+    */
+  def apply(content: RxElement): RxElement = render(content)
+
+  /**
+    * Standalone render — equivalent to `apply(RxElement.empty)`. Useful when the component does not
+    * actually slot any inner content (or when the slot is already wired internally).
+    */
+  def apply(): RxElement = render(RxElement.empty)
+
+end RxComponent

--- a/uni/.js/src/main/scala/wvlet/uni/dom/RxComponent.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/RxComponent.scala
@@ -45,14 +45,15 @@ trait RxComponent:
 
   /**
     * Wrap the given content using this component's chrome. Returns an [[RxElement]] that can be
-    * passed as a child or rendered with [[wvlet.uni.dom.all.renderTo]].
+    * passed as a child or rendered with [[wvlet.uni.dom.all.renderTo]]. `final` so subclasses can't
+    * accidentally bypass `render` by overriding the entry point.
     */
-  def apply(content: RxElement): RxElement = render(content)
+  final def apply(content: RxElement): RxElement = render(content)
 
   /**
     * Standalone render — equivalent to `apply(RxElement.empty)`. Useful when the component does not
     * actually slot any inner content (or when the slot is already wired internally).
     */
-  def apply(): RxElement = render(RxElement.empty)
+  final def apply(): RxElement = render(RxElement.empty)
 
 end RxComponent

--- a/uni/.js/src/main/scala/wvlet/uni/dom/RxComponent.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/RxComponent.scala
@@ -36,7 +36,7 @@ package wvlet.uni.dom
   *   MainFrame()                         // standalone with no inner content
   * }}}
   */
-abstract class RxComponent:
+trait RxComponent:
 
   /**
     * Render this component, wrapping the given content.

--- a/uni/.js/src/main/scala/wvlet/uni/dom/all.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/all.scala
@@ -56,6 +56,7 @@ object all extends HtmlTags with HtmlAttrs with SvgTags with SvgAttrs:
   export wvlet.uni.dom.DomAttribute
   export wvlet.uni.dom.DomNamespace
   export wvlet.uni.dom.RxElement
+  export wvlet.uni.dom.RxComponent
   export wvlet.uni.dom.RawHtml
   export wvlet.uni.dom.EntityRef
   export wvlet.uni.dom.Embedded


### PR DESCRIPTION
## Summary

Closes #527.

uni's `RxElement` only has `def render: RxElement` (no content parameter), so airframe-rx-html's "outer chrome wraps inner content" pattern had no direct uni equivalent:

```scala
object MainFrame extends RxComponent:
  override def render(content: RxElement) = div(
    cls -> "h-screen max-h-screen",
    NavBar,
    content,
    URLParamManager()
  )

MainFrame(editor).renderTo("main")  // outer chrome wraps `editor`
MainFrame()                         // standalone with no inner content
```

Adds `wvlet.uni.dom.RxComponent` mirroring airframe's API — `abstract def render(content: RxElement): RxElement`, `apply(content)` delegating to `render`, and a no-arg `apply()` that hands `RxElement.empty` to `render` for standalone use. Re-exported from `wvlet.uni.dom.all` so the migration shape works under a single `import wvlet.uni.dom.all.*` — no extra import.

The issue's option 2 (document a class-with-content-constructor migration pattern instead of providing the type) is rejected — that would force a rewrite at every `extends RxComponent` site in migrating code, which is exactly what this issue exists to avoid.

## Test plan

- [x] `./sbt domTest/test` — 348/348 pass.
- [x] New `wvlet.uni.dom.RxComponentTest` covers `apply(content)` / `apply()` semantics + a JSDOM mount of the MainFrame worked example from the issue.
- [x] New `example.dom.RxComponentImportTest` lives in a sibling package and pins the migration import contract — a regression that drops the `all.*` re-export would surface there as a compile error.
- [x] `./sbt scalafmtAll` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)