### PR TITLE
fix: Weaver codecs for ULID/ElapsedTime + Router @Endpoint JSON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,7 @@ Save plan documents to plans/YYYY-MM-DD-(topic).md files
 
 ### Code Reviews
 Gemini reviews PRs. Address feedback before merging.
+
+## Architecture decisions
+
+- [`adr/2026-05-04-fromsurfaceopt-and-innerweavers.md`](adr/2026-05-04-fromsurfaceopt-and-innerweavers.md) — `Weaver.fromSurfaceOpt` + `Weaver.innerWeavers` for detecting lossy fallbacks anywhere in a derived weaver tree. Read before adding new composite weaver classes.

--- a/adr/2026-05-04-fromsurfaceopt-and-innerweavers.md
+++ b/adr/2026-05-04-fromsurfaceopt-and-innerweavers.md
@@ -1,0 +1,95 @@
+# 2026-05-04: `Weaver.fromSurfaceOpt` + `innerWeavers` for safe runtime weaver use
+
+PR: https://github.com/wvlet/uni/pull/538 (commit 20dc390 introduces the design)
+
+## Context
+
+`Weaver.fromSurface(surface)` is the runtime, registry-based path used by RPC and
+(after this PR) by `RouterHandler` to derive a weaver from a `Surface`. When no
+factory matches a surface, `fromSurface` returns `emptyObjectWeaver` — a lossy
+fallback that packs as `{}`. It also throws `IllegalArgumentException` for primitive
+surfaces with no matching primitive factory branch (e.g. `java.math.BigInteger`).
+
+For the Router → JSON path we needed: "use the weaver if it can encode this type
+losslessly, otherwise fall through to the legacy toString-quoted JSON path." A
+top-level `eq emptyObjectWeaver` check is not enough — `fromSurface` builds the
+fallback *inside* outer composite weavers for shapes like `Seq[Either[A, B]]` or
+`case class Foo(d: LocalDate)`, which would silently emit `[{}]` / `{"d":{}}`.
+
+## Decision
+
+Two coupled pieces:
+
+1. **`Weaver.innerWeavers: Seq[Weaver[?]]`** — a default-empty hook on the `Weaver`
+   trait. Every composite weaver class (`OptionWeaver`, `SeqWeaver`, `SetWeaver`,
+   `MapWeaver`, `ArrayWeaver`, `JavaListWeaver`, `JavaSetWeaver`, `JavaMapWeaver`,
+   `CaseClassWeaver`, `LazyWeaver`) overrides this to expose the weavers it
+   delegates to.
+
+2. **`Weaver.fromSurfaceOpt(surface): Option[Weaver[?]]`** — wraps `fromSurface` and
+   returns `None` when:
+   - `fromSurface` throws (no factory matches the surface).
+   - The resulting weaver tree contains `emptyObjectWeaver` at any position. The
+     check is an identity-based traversal that reads `innerWeavers` and uses an
+     `IdentityHashMap` to short-circuit cycles introduced by `LazyWeaver` for
+     self-recursive types.
+
+Callers (today: `RouterHandler.returnWeavers`) treat `None` as "fall through to the
+no-weaver path" — preserves the legacy toString-quoted JSON behavior for unsupported
+types instead of silently degrading to `{}`.
+
+## Why not a Surface-side predicate?
+
+We considered an `isFullySupported(surface): Boolean` that would mirror
+`fromSurface`'s factory matching logic at the Surface level (without building a
+weaver). Rejected because:
+
+- It duplicates the factory matching code, with high drift risk: any new factory
+  added to `fromSurface` must remember to also extend `isFullySupported`. The
+  `innerWeavers`-based walker has the inverse coupling — new composite weavers
+  declare what they delegate to, and the walker just reads it.
+- It would need its own cycle handling for self-recursive case classes; the weaver
+  tree already has cycles broken by `LazyWeaver`, so traversing the tree is
+  cheaper.
+- It can't catch the "throw" case (`BigInteger`-style) cleanly — there's no
+  surface-level signal that says "no factory handles this."
+
+## Why an instance method on `Weaver` and not pattern-matching on weaver classes?
+
+Pattern matching would require `fromSurfaceOpt` to know about every concrete weaver
+type. `innerWeavers` puts the responsibility on each composite weaver to declare its
+component weavers, which scales with the inheritance of the framework rather than
+with a central matcher.
+
+The default `Seq.empty` makes adding new leaf weavers (primitives, custom givens) a
+no-op for traversal. New composite weavers — collection or case-class shapes — must
+override the method, but that's a one-liner and easy to forget-test (the weaver tree
+walker silently treats them as opaque, which would surface as a missed
+`emptyObjectWeaver` detection in tests).
+
+## Worked examples (commit 20dc390)
+
+- `Weaver.fromSurfaceOpt(Surface.of[Either[String, Int]])` → `None` (top-level
+  fallback)
+- `Weaver.fromSurfaceOpt(Surface.of[Seq[Either[String, Int]]])` → `None` (fallback
+  inside `SeqWeaver`)
+- `Weaver.fromSurfaceOpt(Surface.of[case class Foo(e: Either[String, Int])])` →
+  `None` (fallback inside `CaseClassWeaver.fieldWeavers`)
+- `Weaver.fromSurfaceOpt(Surface.of[Greeting])` → `Some(weaver)` (case class with
+  fully-supported `String` field)
+- `Weaver.fromSurfaceOpt(Surface.of[BigInteger])` → `None` (`fromSurface` throws,
+  caught and converted)
+
+## Consequences
+
+- `RouterHandler` (and any future runtime weaver consumer) can decide between
+  weaver-aware and toString-fallback paths *per route* without expanding
+  `fromSurface`'s factory list and without reproducing factory logic.
+- New composite weaver classes added to the framework must override
+  `innerWeavers`; missing overrides cause `fromSurfaceOpt` to incorrectly return
+  `Some` for trees that contain hidden fallbacks. Tests that exercise composite
+  shapes against `fromSurfaceOpt` are the primary safeguard — see
+  `WeaverTest.scala` "fromSurfaceOpt" cases.
+- The pattern is also a hook for future "is this weaver lossless?" checks beyond
+  the empty fallback — e.g. detecting `LazyWeaver` cycles that won't terminate, or
+  custom user-registered fallbacks. The traversal API is generic enough.

--- a/plans/2026-05-04-weaver-codecs-and-router-json.md
+++ b/plans/2026-05-04-weaver-codecs-and-router-json.md
@@ -1,0 +1,133 @@
+# 2026-05-04: Fix Weaver codecs for ULID/ElapsedTime (#536) and Router @Endpoint JSON encoding (#537)
+
+PR: https://github.com/wvlet/uni/pull/538
+
+## Problems
+
+Both issues block downstream wvlet's airframe → uni migration (wvlet/wvlet#1662).
+
+### #536 — Weaver lacks ULID / ElapsedTime codecs
+`Weaver.fromSurface` ships built-ins for `Instant`, `UUID`, `URI`, etc., but not for
+uni's own `wvlet.uni.util.ULID` / `wvlet.uni.util.ElapsedTime`. They fell through to
+`CaseClassWeaver` and failed at runtime:
+
+- `ULID` is `final class ULID(private val ulid: String)` — Surface couldn't read its
+  private field, so `pack` got `null` and tried to `packString(null)` → NPE.
+- `ElapsedTime(value: Double, unit: TimeUnit)` decoded fine on the encode side, but the
+  client decode reported "Null value not allowed for non-optional field 'unit'" — the
+  case-class projection didn't line up with what was on the wire.
+
+### #537 — `RouterHandler` falls back to `value.toString` for case classes
+`ResponseConverter.toResponse(Any)` doesn't have access to the method surface, so for
+case-class returns from `@Endpoint` controllers it produced
+`"Greeting(message=world)"` instead of `{"message":"world"}`. RPC routing
+(`MethodCodec.encodeResult`) was already weaver-correct because it has `returnWeaver`
+in scope; the `Router` path didn't.
+
+## Decisions
+
+### #536 — encoding shape
+- `ULID` → its 26-char Crockford-Base32 string. Mirrors the existing `UUID` codec.
+- `ElapsedTime` → its `toString` output (e.g. `5.00ms`), which `ElapsedTime.parse`
+  accepts directly. Round-trip safe; succinct unit normalization happens via
+  `convertToMostSuccinctTimeUnit` on construction.
+
+Wired into `Weaver.fromSurface`'s `primitiveFactory` so they take precedence over the
+case-class fallback. Exported from the `Weaver` companion alongside `uuidWeaver` etc.
+
+### #537 — wiring Weaver into the Router path
+- Pre-compute `Weaver.fromSurface(returnType)` per route in `RouterHandler`, not
+  per-request. Same shape as `MethodCodec`'s `paramWeavers` / `returnWeaver`.
+- **Peel `Rx[_]` and `Option[_]` from the surface before deriving the weaver**, since
+  `ResponseConverter` already unwraps these (Rx → flatMap; Option None → 204
+  noContent). The weaver is for the inner value the client actually sees.
+- Add a new overload `ResponseConverter.toResponse(result, returnWeaver)` rather than
+  changing the existing `toResponse(result)` signature. Old callers (incl. existing
+  tests) keep their toString-fallback behavior.
+- In the weaver-aware path, treat shape-special types (`Response`, `null`, `Unit`,
+  `String`, `JSONValue`, `Array[Byte]`, `Rx`, `Option`) as before; everything else
+  (case classes, `Seq`, `Map`, etc.) goes through the weaver as JSON.
+
+## Worked example
+
+```scala
+case class Greeting(message: String)
+
+class HelloController:
+  @Endpoint(HttpMethod.GET, "/hello")
+  def hello: Greeting = Greeting("world")
+
+  @Endpoint(HttpMethod.GET, "/maybe")
+  def maybe: Option[Greeting] = Some(Greeting("some"))
+
+  @Endpoint(HttpMethod.GET, "/none")
+  def none: Option[Greeting] = None
+
+  @Endpoint(HttpMethod.GET, "/rx")
+  def rx: Rx[Greeting] = Rx.single(Greeting("reactive"))
+```
+
+After the fix:
+- `GET /hello` → 200 `{"message":"world"}`
+- `GET /maybe` → 200 `{"message":"some"}`
+- `GET /rx`    → 200 `{"message":"reactive"}`
+- `GET /none`  → 204 (preserved noContent semantics)
+
+## Test coverage
+
+- `AdditionalTypeWeaverTest` — ULID + ElapsedTime msgpack/JSON round-trips,
+  `Weaver.fromSurface` derivation, invalid-string error paths.
+- `NettyServerTest` — end-to-end test with all four return shapes above.
+
+## Files touched
+- `uni/src/main/scala/wvlet/uni/weaver/Weaver.scala` — register ULID/ElapsedTime in
+  primitive factory; export. Adds `fromSurfaceOpt` and `innerWeavers` for nested-fallback
+  detection.
+- `uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala` — `ulidWeaver` /
+  `elapsedTimeWeaver` givens; promotes `stringBasedWeaver` from `JvmWeaver`.
+- `uni/.jvm/src/main/scala/wvlet/uni/weaver/codec/JvmWeaver.scala` — uses the shared helper.
+- `uni/src/main/scala/wvlet/uni/weaver/CollectionWeaver.scala` — overrides `innerWeavers`
+  on each composite weaver class.
+- `uni/src/main/scala/wvlet/uni/weaver/codec/CaseClassWeaver.scala` — exposes field weavers
+  via `innerWeavers`.
+- `uni/src/main/scala/wvlet/uni/util/ElapsedTime.scala` — extends parse regex to accept
+  exponent form (so `Double.toString` round-trips).
+- `uni/src/main/scala/wvlet/uni/http/router/ResponseConverter.scala` — weaver-aware
+  overload; weaver-throw fallback to no-weaver path (preserves `application/json`).
+- `uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala` — pre-compute
+  `returnWeavers` (IdentityHashMap), peel `Rx[_]` once + `Option` recursively, skip
+  weaver derivation for `Response` / primitive returns.
+- Tests: `AdditionalTypeWeaverTest.scala`, `WeaverTest.scala`, `NettyServerTest.scala`.
+
+## Review iteration learnings
+
+This PR went through ~10 rounds of automated review (Gemini + codex) before settling.
+Notable findings that reshaped the design:
+
+1. **Rx peeling alignment**: initial recursive Rx peel didn't match
+   `ResponseConverter`'s single-level Rx unwrap. Now: peel exactly one Rx at the top,
+   then any number of Options.
+2. **Empty-fallback detection**: `Weaver.fromSurface` returns
+   `emptyObjectWeaver` for unsupported types (`Either`, `LocalDate`, etc.), and the
+   fallback can also be embedded *inside* composite weavers
+   (`Seq[Either]`, `case class Foo(d: LocalDate)`). Added `Weaver.fromSurfaceOpt` that
+   walks the weaver tree via a new `innerWeavers` accessor and returns `None` if the
+   fallback appears at any position. RouterHandler uses this to skip caching weavers
+   that would silently produce `[{}]` / `{"d":{}}`.
+3. **Wire-format stability for primitives**: weaving `Int`/`Boolean` returns produces
+   bare JSON scalars (`42`, `true`) but pre-PR Router emitted toString-quoted strings
+   (`"42"`, `"true"`). Skip weaver derivation when `surface.isPrimitive` to preserve
+   wire format for clients that consume the legacy form.
+4. **Opaque wrapper types**: `final class UserId(private val v: String)` matches the
+   case-class factory but `CaseClassWeaver.pack` throws (Surface can't read the private
+   field). Catch in `ResponseConverter` and fall through to the no-weaver
+   `application/json` toString-quoted path, not `text/plain`.
+5. **`fromSurface` can throw**: `BigInteger` is `isPrimitive=true` but absent from
+   `primitiveFactory`, so `fromSurface` throws. `fromSurfaceOpt` catches and returns
+   `None` — otherwise composite types containing such fields would fail
+   handler construction.
+6. **ElapsedTime precision**: `et.toString` is `%.2f`-formatted (lossy). Encode using
+   `${et.value}${unit}` instead, and extend `ElapsedTime.parse` to accept the
+   exponent suffix (`1.0E-9ns`) so `Double.toString` round-trips losslessly. Decision
+   point: chose JSON-string wire shape over structured `{value, unit}` map to avoid a
+   wire-format change for direct `ElapsedTime` returns from `@Endpoint` methods.

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
@@ -43,9 +43,13 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
   // match how ResponseConverter unwraps these wrappers before encoding the value. We use
   // `fromSurfaceOpt` so routes whose return type isn't covered by a built-in factory (e.g.
   // `Either`, JVM-only `LocalDate`, `Path`) fall through to ResponseConverter's no-weaver path
-  // instead of getting silently encoded as the empty-object fallback. We also skip `Response` /
-  // `Rx[Response]` returns since ResponseConverter short-circuits on those before consulting
-  // any weaver.
+  // instead of getting silently encoded as the empty-object fallback. We also skip:
+  //   - `Response` / `Rx[Response]` — ResponseConverter short-circuits before any weaver call.
+  //   - Primitive surfaces (Int/Long/Boolean/Double/etc.) — the no-weaver path produces a
+  //     toString-quoted JSON string (`"42"`) for these, while the weaver path would emit a
+  //     bare JSON scalar (`42`). Skipping preserves wire format for existing scalar-returning
+  //     endpoints; case classes / collections / ULID / Instant / UUID still flow through the
+  //     weaver and benefit from proper JSON encoding.
   // IdentityHashMap keys on reference equality — every Route returned by RouteMatcher is a
   // direct reference into router.routes, so this avoids walking case-class equals/hashCode on
   // every request.
@@ -55,7 +59,7 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
       .routes
       .foreach { r =>
         val element = RouterHandler.elementSurface(r.methodSurface.returnType)
-        if element.rawType != classOf[Response] then
+        if element.rawType != classOf[Response] && !element.isPrimitive then
           Weaver.fromSurfaceOpt(element).foreach(m.put(r, _))
       }
     m

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
@@ -17,6 +17,8 @@ import wvlet.uni.http.{Request, Response}
 import wvlet.uni.http.router.*
 import wvlet.uni.log.LogSupport
 import wvlet.uni.rx.Rx
+import wvlet.uni.surface.{OptionSurface, Surface}
+import wvlet.uni.weaver.Weaver
 
 /**
   * An RxHttpHandler implementation that dispatches requests to controller methods based on route
@@ -33,6 +35,17 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
 
   private val matcher = RouteMatcher(router.routes)
   private val mapper  = HttpRequestMapper()
+
+  // Pre-compute Weavers for each route's return type so case-class results are encoded as JSON.
+  // The weaver is derived against the inner element surface (Rx[A] / Option[A] are peeled) to
+  // match how ResponseConverter unwraps these wrappers before encoding the value.
+  private val returnWeavers: Map[Route, Weaver[?]] =
+    router
+      .routes
+      .map { r =>
+        r -> Weaver.fromSurface(RouterHandler.elementSurface(r.methodSurface.returnType))
+      }
+      .toMap
 
   // Lazily initialized filter instance (thread-safe)
   private lazy val filterInstance: Option[RxHttpFilter] = router
@@ -61,7 +74,7 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
             Some(controller)
           )
           val result = routeMatch.route.methodSurface.call(controller, args*)
-          ResponseConverter.toResponse(result)
+          ResponseConverter.toResponse(result, returnWeavers(routeMatch.route))
         catch
           case e: HttpRequestMappingException =>
             debug(s"Parameter mapping error: ${e.getMessage}")
@@ -76,6 +89,20 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
 end RouterHandler
 
 object RouterHandler:
+
+  /**
+    * Peel `Rx[_]` and `Option[_]` from a return-type surface, since [[ResponseConverter]] unwraps
+    * these wrappers before encoding the inner value. The weaver derived from the resulting surface
+    * is what eventually handles JSON serialization for case classes, sequences, etc.
+    */
+  private[netty] def elementSurface(surface: Surface): Surface =
+    surface match
+      case opt: OptionSurface =>
+        elementSurface(opt.elementSurface)
+      case s if classOf[Rx[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
+        elementSurface(s.typeArgs.head)
+      case other =>
+        other
 
   /**
     * Create a RouterHandler with a SimpleControllerProvider.

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
@@ -59,7 +59,7 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
       .routes
       .foreach { r =>
         val element = RouterHandler.elementSurface(r.methodSurface.returnType)
-        if element.rawType != classOf[Response] && !element.isPrimitive then
+        if !classOf[Response].isAssignableFrom(element.rawType) && !element.isPrimitive then
           Weaver.fromSurfaceOpt(element).foreach(m.put(r, _))
       }
     m

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
@@ -40,9 +40,12 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
 
   // Pre-compute Weavers for each route's return type so case-class results are encoded as JSON.
   // The weaver is derived against the inner element surface (Rx[A] / Option[A] are peeled) to
-  // match how ResponseConverter unwraps these wrappers before encoding the value. We skip
-  // building a weaver for `Response`/`Rx[Response]` returns since ResponseConverter
-  // short-circuits on those before consulting any weaver.
+  // match how ResponseConverter unwraps these wrappers before encoding the value. We use
+  // `fromSurfaceOpt` so routes whose return type isn't covered by a built-in factory (e.g.
+  // `Either`, JVM-only `LocalDate`, `Path`) fall through to ResponseConverter's no-weaver path
+  // instead of getting silently encoded as the empty-object fallback. We also skip `Response` /
+  // `Rx[Response]` returns since ResponseConverter short-circuits on those before consulting
+  // any weaver.
   // IdentityHashMap keys on reference equality — every Route returned by RouteMatcher is a
   // direct reference into router.routes, so this avoids walking case-class equals/hashCode on
   // every request.
@@ -53,7 +56,7 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
       .foreach { r =>
         val element = RouterHandler.elementSurface(r.methodSurface.returnType)
         if element.rawType != classOf[Response] then
-          m.put(r, Weaver.fromSurface(element))
+          Weaver.fromSurfaceOpt(element).foreach(m.put(r, _))
       }
     m
 

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
@@ -20,6 +20,8 @@ import wvlet.uni.rx.Rx
 import wvlet.uni.surface.{OptionSurface, Surface}
 import wvlet.uni.weaver.Weaver
 
+import java.util.IdentityHashMap
+
 /**
   * An RxHttpHandler implementation that dispatches requests to controller methods based on route
   * matching.
@@ -38,14 +40,22 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
 
   // Pre-compute Weavers for each route's return type so case-class results are encoded as JSON.
   // The weaver is derived against the inner element surface (Rx[A] / Option[A] are peeled) to
-  // match how ResponseConverter unwraps these wrappers before encoding the value.
-  private val returnWeavers: Map[Route, Weaver[?]] =
+  // match how ResponseConverter unwraps these wrappers before encoding the value. We skip
+  // building a weaver for `Response`/`Rx[Response]` returns since ResponseConverter
+  // short-circuits on those before consulting any weaver.
+  // IdentityHashMap keys on reference equality — every Route returned by RouteMatcher is a
+  // direct reference into router.routes, so this avoids walking case-class equals/hashCode on
+  // every request.
+  private val returnWeavers: IdentityHashMap[Route, Weaver[?]] =
+    val m = new IdentityHashMap[Route, Weaver[?]](router.routes.size * 2)
     router
       .routes
-      .map { r =>
-        r -> Weaver.fromSurface(RouterHandler.elementSurface(r.methodSurface.returnType))
+      .foreach { r =>
+        val element = RouterHandler.elementSurface(r.methodSurface.returnType)
+        if element.rawType != classOf[Response] then
+          m.put(r, Weaver.fromSurface(element))
       }
-      .toMap
+    m
 
   // Lazily initialized filter instance (thread-safe)
   private lazy val filterInstance: Option[RxHttpFilter] = router
@@ -74,7 +84,11 @@ class RouterHandler(router: Router, controllerProvider: ControllerProvider)
             Some(controller)
           )
           val result = routeMatch.route.methodSurface.call(controller, args*)
-          ResponseConverter.toResponse(result, returnWeavers(routeMatch.route))
+          val weaver = returnWeavers.get(routeMatch.route)
+          if weaver == null then
+            ResponseConverter.toResponse(result)
+          else
+            ResponseConverter.toResponse(result, weaver)
         catch
           case e: HttpRequestMappingException =>
             debug(s"Parameter mapping error: ${e.getMessage}")
@@ -91,16 +105,30 @@ end RouterHandler
 object RouterHandler:
 
   /**
-    * Peel `Rx[_]` and `Option[_]` from a return-type surface, since [[ResponseConverter]] unwraps
-    * these wrappers before encoding the inner value. The weaver derived from the resulting surface
-    * is what eventually handles JSON serialization for case classes, sequences, etc.
+    * Peel wrapper types from a return-type surface to derive the surface of the value that the
+    * Weaver actually has to encode.
+    *
+    * Peeling rules mirror what [[ResponseConverter]] does at runtime: it unwraps `Rx[_]` only at
+    * the top level (`toResponse`'s `case rx: Rx[?] => rx.map(...)` branch), then unwraps `Option`
+    * recursively inside the per-value path. We follow the same shape — peel at most one `Rx`, then
+    * peel any number of nested `Option`s — so the weaver lines up with the value the converter
+    * eventually hands it. Nested `Rx[Rx[_]]` is not supported by the converter and is left as-is
+    * here too.
     */
-  private[netty] def elementSurface(surface: Surface): Surface =
+  private def elementSurface(surface: Surface): Surface =
+    val afterRx =
+      surface match
+        case s if classOf[Rx[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
+          s.typeArgs.head
+        case other =>
+          other
+    unwrapOption(afterRx)
+
+  @scala.annotation.tailrec
+  private def unwrapOption(surface: Surface): Surface =
     surface match
       case opt: OptionSurface =>
-        elementSurface(opt.elementSurface)
-      case s if classOf[Rx[?]].isAssignableFrom(s.rawType) && s.typeArgs.nonEmpty =>
-        elementSurface(s.typeArgs.head)
+        unwrapOption(opt.elementSurface)
       case other =>
         other
 

--- a/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
+++ b/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
@@ -362,6 +362,12 @@ class NettyServerTest extends UniTest:
         val rRxOpt = get(s"http://localhost:${server.localPort}/rx-opt")
         rRxOpt.statusCode() shouldBe 200
         rRxOpt.body() shouldBe """{"message":"both"}"""
+
+        // Either has no built-in fromSurface factory, so it must fall through to the
+        // no-weaver toString-quoted path rather than the empty-object {} fallback.
+        val rEither = get(s"http://localhost:${server.localPort}/either")
+        rEither.statusCode() shouldBe 200
+        rEither.body() shouldBe """"Right(42)""""
       }
   }
 
@@ -412,3 +418,6 @@ object NettyServerTest:
 
     @Endpoint(HttpMethod.GET, "/rx-opt")
     def rxOpt: Rx[Option[Greeting]] = Rx.single(Some(Greeting("both")))
+
+    @Endpoint(HttpMethod.GET, "/either")
+    def either: Either[String, Int] = Right(42)

--- a/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
+++ b/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
@@ -354,6 +354,14 @@ class NettyServerTest extends UniTest:
 
         val rNone = get(s"http://localhost:${server.localPort}/none")
         rNone.statusCode() shouldBe 204
+
+        val rList = get(s"http://localhost:${server.localPort}/list")
+        rList.statusCode() shouldBe 200
+        rList.body() shouldBe """[{"message":"a"},{"message":"b"}]"""
+
+        val rRxOpt = get(s"http://localhost:${server.localPort}/rx-opt")
+        rRxOpt.statusCode() shouldBe 200
+        rRxOpt.body() shouldBe """{"message":"both"}"""
       }
   }
 
@@ -398,3 +406,9 @@ object NettyServerTest:
 
     @Endpoint(HttpMethod.GET, "/rx")
     def rx: Rx[Greeting] = Rx.single(Greeting("reactive"))
+
+    @Endpoint(HttpMethod.GET, "/list")
+    def list: Seq[Greeting] = Seq(Greeting("a"), Greeting("b"))
+
+    @Endpoint(HttpMethod.GET, "/rx-opt")
+    def rxOpt: Rx[Option[Greeting]] = Rx.single(Some(Greeting("both")))

--- a/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
+++ b/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
@@ -376,6 +376,17 @@ class NettyServerTest extends UniTest:
         rOpaque.statusCode() shouldBe 200
         rOpaque.headers().firstValue("Content-Type").orElse("") shouldContain "application/json"
         rOpaque.body() shouldBe """"Wrap(Opaque(x))""""
+
+        // Primitive scalar returns: preserve the previous toString-quoted JSON form so
+        // existing clients consuming bare-scalar endpoints aren't broken by the wire-format
+        // change a Weaver path would introduce (e.g. `42` vs `"42"`).
+        val rInt = get(s"http://localhost:${server.localPort}/answer")
+        rInt.statusCode() shouldBe 200
+        rInt.body() shouldBe "\"42\""
+
+        val rBool = get(s"http://localhost:${server.localPort}/flag")
+        rBool.statusCode() shouldBe 200
+        rBool.body() shouldBe "\"true\""
       }
   }
 
@@ -442,5 +453,13 @@ object NettyServerTest:
 
     @Endpoint(HttpMethod.GET, "/opaque")
     def opaque: NettyServerTest.Wrap = NettyServerTest.Wrap(NettyServerTest.Opaque("x"))
+
+    @Endpoint(HttpMethod.GET, "/answer")
+    def answer: Int = 42
+
+    @Endpoint(HttpMethod.GET, "/flag")
+    def flag: Boolean = true
+
+  end HelloController
 
 end NettyServerTest

--- a/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
+++ b/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
@@ -14,6 +14,7 @@
 package wvlet.uni.http.netty
 
 import wvlet.uni.http.{HttpHandler, HttpMethod, Request, Response, ServerSentEvent}
+import wvlet.uni.http.router.{Endpoint, Router}
 import wvlet.uni.rx.Rx
 import wvlet.uni.test.UniTest
 
@@ -333,6 +334,29 @@ class NettyServerTest extends UniTest:
       }
   }
 
+  test("should encode case class returns from @Endpoint controllers as JSON") {
+    NettyServer
+      .withPort(0)
+      .withRxHandler(RouterHandler(Router.of[NettyServerTest.HelloController]))
+      .start { server =>
+        val r = get(s"http://localhost:${server.localPort}/hello")
+        r.statusCode() shouldBe 200
+        r.body() shouldBe """{"message":"world"}"""
+        r.headers().firstValue("Content-Type").orElse("") shouldContain "application/json"
+
+        val rOpt = get(s"http://localhost:${server.localPort}/maybe")
+        rOpt.statusCode() shouldBe 200
+        rOpt.body() shouldBe """{"message":"some"}"""
+
+        val rRx = get(s"http://localhost:${server.localPort}/rx")
+        rRx.statusCode() shouldBe 200
+        rRx.body() shouldBe """{"message":"reactive"}"""
+
+        val rNone = get(s"http://localhost:${server.localPort}/none")
+        rNone.statusCode() shouldBe 204
+      }
+  }
+
   test("should detect benign I/O exceptions") {
     import java.io.IOException
     import java.nio.channels.ClosedChannelException
@@ -358,3 +382,19 @@ class NettyServerTest extends UniTest:
   }
 
 end NettyServerTest
+
+object NettyServerTest:
+  case class Greeting(message: String)
+
+  class HelloController:
+    @Endpoint(HttpMethod.GET, "/hello")
+    def hello: Greeting = Greeting("world")
+
+    @Endpoint(HttpMethod.GET, "/maybe")
+    def maybe: Option[Greeting] = Some(Greeting("some"))
+
+    @Endpoint(HttpMethod.GET, "/none")
+    def none: Option[Greeting] = None
+
+    @Endpoint(HttpMethod.GET, "/rx")
+    def rx: Rx[Greeting] = Rx.single(Greeting("reactive"))

--- a/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
+++ b/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
@@ -368,6 +368,14 @@ class NettyServerTest extends UniTest:
         val rEither = get(s"http://localhost:${server.localPort}/either")
         rEither.statusCode() shouldBe 200
         rEither.body() shouldBe """"Right(42)""""
+
+        // Opaque wrapper: Surface exposes a constructor param but no readable accessor,
+        // so CaseClassWeaver throws at pack time. The handler must keep responding with
+        // application/json (not fall to text/plain) for content-type stability.
+        val rOpaque = get(s"http://localhost:${server.localPort}/opaque")
+        rOpaque.statusCode() shouldBe 200
+        rOpaque.headers().firstValue("Content-Type").orElse("") shouldContain "application/json"
+        rOpaque.body() shouldBe """"Wrap(Opaque(x))""""
       }
   }
 
@@ -400,6 +408,16 @@ end NettyServerTest
 object NettyServerTest:
   case class Greeting(message: String)
 
+  // Opaque wrapper: Surface sees a constructor param `value` but the field is private and
+  // unreadable, so CaseClassWeaver fails at pack time when fromSurface picks it up.
+  final class Opaque(private val value: String):
+    override def toString = s"Opaque($value)"
+
+  object Opaque:
+    def apply(v: String) = new Opaque(v)
+
+  case class Wrap(o: Opaque)
+
   class HelloController:
     @Endpoint(HttpMethod.GET, "/hello")
     def hello: Greeting = Greeting("world")
@@ -421,3 +439,8 @@ object NettyServerTest:
 
     @Endpoint(HttpMethod.GET, "/either")
     def either: Either[String, Int] = Right(42)
+
+    @Endpoint(HttpMethod.GET, "/opaque")
+    def opaque: NettyServerTest.Wrap = NettyServerTest.Wrap(NettyServerTest.Opaque("x"))
+
+end NettyServerTest

--- a/uni/.jvm/src/main/scala/wvlet/uni/weaver/codec/JvmWeaver.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/weaver/codec/JvmWeaver.scala
@@ -17,31 +17,7 @@ import java.time.ZonedDateTime
 
 object JvmWeaver:
 
-  private def stringBasedWeaver[A](
-      typeName: String,
-      serialize: A => String,
-      deserialize: String => A
-  ): Weaver[A] =
-    new Weaver[A]:
-      override def pack(p: Packer, v: A, config: WeaverConfig): Unit = p.packString(serialize(v))
-
-      override def unpack(u: Unpacker, context: WeaverContext): Unit =
-        u.getNextValueType match
-          case ValueType.STRING =>
-            PrimitiveWeaver.safeConvertFromString(
-              context,
-              u,
-              deserialize,
-              context.setObject,
-              typeName
-            )
-          case ValueType.NIL =>
-            PrimitiveWeaver.safeUnpackNil(context, u)
-          case other =>
-            u.skipValue
-            context.setError(
-              IllegalArgumentException(s"Cannot convert ${other} to ${typeName}, expected STRING")
-            )
+  import PrimitiveWeaver.stringBasedWeaver
 
   given zonedDateTimeWeaver: Weaver[ZonedDateTime] = stringBasedWeaver(
     "ZonedDateTime",

--- a/uni/src/main/scala/wvlet/uni/http/router/ResponseConverter.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/ResponseConverter.scala
@@ -16,6 +16,7 @@ package wvlet.uni.http.router
 import wvlet.uni.http.{HttpContent, Response}
 import wvlet.uni.json.JSON.JSONValue
 import wvlet.uni.rx.Rx
+import wvlet.uni.weaver.Weaver
 
 /**
   * Converts controller method return values to HTTP responses.
@@ -39,19 +40,40 @@ object ResponseConverter:
     * @return
     *   An Rx that emits the HTTP response
     */
-  def toResponse(result: Any): Rx[Response] =
+  def toResponse(result: Any): Rx[Response] = toResponse(result, None)
+
+  /**
+    * Convert a method return value to an Rx[Response] using the given Weaver to encode case classes
+    * and other complex types as JSON.
+    *
+    * The weaver is expected to be derived for the inner element type, after peeling [[Rx]] and
+    * [[Option]] from the controller method's declared return type.
+    *
+    * @param result
+    *   The return value from a controller method
+    * @param returnWeaver
+    *   Weaver for the inner element type
+    * @return
+    *   An Rx that emits the HTTP response
+    */
+  def toResponse(result: Any, returnWeaver: Weaver[?]): Rx[Response] = toResponse(
+    result,
+    Some(returnWeaver)
+  )
+
+  private def toResponse(result: Any, weaverOpt: Option[Weaver[?]]): Rx[Response] =
     result match
       case r: Response =>
         Rx.single(r)
       case rx: Rx[?] =>
-        rx.map(convertToResponse)
+        rx.map(convertToResponse(_, weaverOpt))
       case other =>
-        Rx.single(convertToResponse(other))
+        Rx.single(convertToResponse(other, weaverOpt))
 
   /**
     * Convert a single value to an HTTP response.
     */
-  private def convertToResponse(value: Any): Response =
+  private def convertToResponse(value: Any, weaverOpt: Option[Weaver[?]]): Response =
     value match
       case r: Response =>
         r
@@ -65,27 +87,34 @@ object ResponseConverter:
         Response.ok.withContent(HttpContent.json(json))
       case bytes: Array[Byte] =>
         Response.ok.withBytesContent(bytes)
-      case seq: Seq[?] =>
-        // Convert sequences to JSON arrays
-        Response.ok.withContent(HttpContent.json(seqToJson(seq)))
-      case map: Map[?, ?] =>
-        // Convert maps to JSON objects
-        Response.ok.withContent(HttpContent.json(mapToJson(map)))
       case opt: Option[?] =>
         opt match
           case Some(v) =>
-            convertToResponse(v)
+            convertToResponse(v, weaverOpt)
           case None =>
             Response.noContent
       case other =>
-        // Try to serialize as JSON
-        try
-          val jsonStr = toJsonString(other)
-          Response.ok.withJsonContent(jsonStr)
-        catch
-          case e: Exception =>
-            // Fall back to toString
-            Response.ok.withTextContent(other.toString)
+        weaverOpt match
+          case Some(weaver) =>
+            try
+              val jsonStr = weaver.asInstanceOf[Weaver[Any]].toJson(other)
+              Response.ok.withJsonContent(jsonStr)
+            catch
+              case e: Exception =>
+                Response.ok.withTextContent(other.toString)
+          case None =>
+            other match
+              case seq: Seq[?] =>
+                Response.ok.withContent(HttpContent.json(seqToJson(seq)))
+              case map: Map[?, ?] =>
+                Response.ok.withContent(HttpContent.json(mapToJson(map)))
+              case _ =>
+                try
+                  val jsonStr = toJsonString(other)
+                  Response.ok.withJsonContent(jsonStr)
+                catch
+                  case e: Exception =>
+                    Response.ok.withTextContent(other.toString)
 
   /**
     * Convert a sequence to a JSON array string.

--- a/uni/src/main/scala/wvlet/uni/http/router/ResponseConverter.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/ResponseConverter.scala
@@ -96,12 +96,7 @@ object ResponseConverter:
       case other =>
         weaverOpt match
           case Some(weaver) =>
-            try
-              val jsonStr = weaver.asInstanceOf[Weaver[Any]].toJson(other)
-              Response.ok.withJsonContent(jsonStr)
-            catch
-              case e: Exception =>
-                Response.ok.withTextContent(other.toString)
+            jsonOrText(other, weaver.asInstanceOf[Weaver[Any]].toJson(other))
           case None =>
             other match
               case seq: Seq[?] =>
@@ -109,12 +104,14 @@ object ResponseConverter:
               case map: Map[?, ?] =>
                 Response.ok.withContent(HttpContent.json(mapToJson(map)))
               case _ =>
-                try
-                  val jsonStr = toJsonString(other)
-                  Response.ok.withJsonContent(jsonStr)
-                catch
-                  case e: Exception =>
-                    Response.ok.withTextContent(other.toString)
+                jsonOrText(other, toJsonString(other))
+
+  private def jsonOrText(value: Any, encode: => String): Response =
+    try
+      Response.ok.withJsonContent(encode)
+    catch
+      case _: Exception =>
+        Response.ok.withTextContent(value.toString)
 
   /**
     * Convert a sequence to a JSON array string.

--- a/uni/src/main/scala/wvlet/uni/http/router/ResponseConverter.scala
+++ b/uni/src/main/scala/wvlet/uni/http/router/ResponseConverter.scala
@@ -96,22 +96,30 @@ object ResponseConverter:
       case other =>
         weaverOpt match
           case Some(weaver) =>
-            jsonOrText(other, weaver.asInstanceOf[Weaver[Any]].toJson(other))
+            // If the weaver throws (e.g. opaque wrapper type with un-readable fields),
+            // fall through to the no-weaver path rather than text/plain so the response
+            // stays application/json — preserves content-type stability for existing
+            // clients that expect a JSON content-type even when the body shape changes.
+            try
+              Response.ok.withJsonContent(weaver.asInstanceOf[Weaver[Any]].toJson(other))
+            catch
+              case _: Exception =>
+                noWeaverJson(other)
           case None =>
-            other match
-              case seq: Seq[?] =>
-                Response.ok.withContent(HttpContent.json(seqToJson(seq)))
-              case map: Map[?, ?] =>
-                Response.ok.withContent(HttpContent.json(mapToJson(map)))
-              case _ =>
-                jsonOrText(other, toJsonString(other))
+            noWeaverJson(other)
 
-  private def jsonOrText(value: Any, encode: => String): Response =
-    try
-      Response.ok.withJsonContent(encode)
-    catch
-      case _: Exception =>
-        Response.ok.withTextContent(value.toString)
+  private def noWeaverJson(other: Any): Response =
+    other match
+      case seq: Seq[?] =>
+        Response.ok.withContent(HttpContent.json(seqToJson(seq)))
+      case map: Map[?, ?] =>
+        Response.ok.withContent(HttpContent.json(mapToJson(map)))
+      case _ =>
+        try
+          Response.ok.withJsonContent(toJsonString(other))
+        catch
+          case _: Exception =>
+            Response.ok.withTextContent(other.toString)
 
   /**
     * Convert a sequence to a JSON array string.

--- a/uni/src/main/scala/wvlet/uni/util/ElapsedTime.scala
+++ b/uni/src/main/scala/wvlet/uni/util/ElapsedTime.scala
@@ -56,7 +56,11 @@ object ElapsedTime:
 
   def units = List(NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS)
 
-  private val strReprPattern = Pattern.compile("^\\s*(\\d+(?:\\.\\d+)?)\\s*([a-zA-Z]+)\\s*$")
+  // Number pattern allows decimal, optional fractional part, and optional exponent so the
+  // Weaver round-trip via Double.toString (which can emit "1.0E-9") parses back losslessly.
+  private val strReprPattern = Pattern.compile(
+    "^\\s*(\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)\\s*([a-zA-Z]+)\\s*$"
+  )
 
   def nanosSince(start: Long): ElapsedTime    = succinctNanos(System.nanoTime - start)
   def succinctNanos(nanos: Long): ElapsedTime = succinctDuration(nanos.toDouble, NANOSECONDS)

--- a/uni/src/main/scala/wvlet/uni/weaver/CollectionWeaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/CollectionWeaver.scala
@@ -13,6 +13,8 @@ import scala.jdk.CollectionConverters.*
   */
 
 class OptionWeaver(inner: Weaver[?]) extends Weaver[Option[?]]:
+  override def innerWeavers: Seq[Weaver[?]] = Seq(inner)
+
   override def pack(p: Packer, v: Option[?], config: WeaverConfig): Unit =
     v match
       case Some(value) =>
@@ -36,6 +38,8 @@ class OptionWeaver(inner: Weaver[?]) extends Weaver[Option[?]]:
           context.setObject(Some(elementContext.getLastValue))
 
 class SeqWeaver(elem: Weaver[?], targetType: Class[?]) extends Weaver[Seq[?]]:
+  override def innerWeavers: Seq[Weaver[?]] = Seq(elem)
+
   override def pack(p: Packer, v: Seq[?], config: WeaverConfig): Unit =
     p.packArrayHeader(v.size)
     v.foreach(e => elem.asInstanceOf[Weaver[Any]].pack(p, e, config))
@@ -64,6 +68,8 @@ class SeqWeaver(elem: Weaver[?], targetType: Class[?]) extends Weaver[Seq[?]]:
         context.setError(IllegalArgumentException(s"Cannot convert ${other} to Seq"))
 
 class SetWeaver(elem: Weaver[?]) extends Weaver[Set[?]]:
+  override def innerWeavers: Seq[Weaver[?]] = Seq(elem)
+
   override def pack(p: Packer, v: Set[?], config: WeaverConfig): Unit =
     p.packArrayHeader(v.size)
     v.foreach(e => elem.asInstanceOf[Weaver[Any]].pack(p, e, config))
@@ -83,6 +89,8 @@ class SetWeaver(elem: Weaver[?]) extends Weaver[Set[?]]:
         context.setError(IllegalArgumentException(s"Cannot convert ${other} to Set"))
 
 class MapWeaver(keyWeaver: Weaver[?], valueWeaver: Weaver[?]) extends Weaver[Map[?, ?]]:
+  override def innerWeavers: Seq[Weaver[?]] = Seq(keyWeaver, valueWeaver)
+
   override def pack(p: Packer, v: Map[?, ?], config: WeaverConfig): Unit =
     p.packMapHeader(v.size)
     v.foreach { case (key, value) =>
@@ -105,6 +113,8 @@ class MapWeaver(keyWeaver: Weaver[?], valueWeaver: Weaver[?]) extends Weaver[Map
         context.setError(IllegalArgumentException(s"Cannot convert ${other} to Map"))
 
 class ArrayWeaver(elem: Weaver[?], elemClass: Class[?]) extends Weaver[Array[?]]:
+  override def innerWeavers: Seq[Weaver[?]] = Seq(elem)
+
   override def pack(p: Packer, v: Array[?], config: WeaverConfig): Unit =
     p.packArrayHeader(v.length)
     v.foreach(e => elem.asInstanceOf[Weaver[Any]].pack(p, e, config))
@@ -130,6 +140,8 @@ class ArrayWeaver(elem: Weaver[?], elemClass: Class[?]) extends Weaver[Array[?]]
         context.setError(IllegalArgumentException(s"Cannot convert ${other} to Array"))
 
 class JavaListWeaver(elem: Weaver[?]) extends Weaver[java.util.List[?]]:
+  override def innerWeavers: Seq[Weaver[?]] = Seq(elem)
+
   override def pack(p: Packer, v: java.util.List[?], config: WeaverConfig): Unit =
     p.packArrayHeader(v.size)
     v.forEach(e => elem.asInstanceOf[Weaver[Any]].pack(p, e, config))
@@ -149,6 +161,8 @@ class JavaListWeaver(elem: Weaver[?]) extends Weaver[java.util.List[?]]:
         context.setError(IllegalArgumentException(s"Cannot convert ${other} to java.util.List"))
 
 class JavaSetWeaver(elem: Weaver[?]) extends Weaver[java.util.Set[?]]:
+  override def innerWeavers: Seq[Weaver[?]] = Seq(elem)
+
   override def pack(p: Packer, v: java.util.Set[?], config: WeaverConfig): Unit =
     p.packArrayHeader(v.size)
     v.forEach(e => elem.asInstanceOf[Weaver[Any]].pack(p, e, config))
@@ -169,6 +183,8 @@ class JavaSetWeaver(elem: Weaver[?]) extends Weaver[java.util.Set[?]]:
 
 class JavaMapWeaver(keyWeaver: Weaver[?], valueWeaver: Weaver[?])
     extends Weaver[java.util.Map[?, ?]]:
+  override def innerWeavers: Seq[Weaver[?]] = Seq(keyWeaver, valueWeaver)
+
   override def pack(p: Packer, v: java.util.Map[?, ?], config: WeaverConfig): Unit =
     p.packMapHeader(v.size)
     v.forEach { (key, value) =>

--- a/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
@@ -199,6 +199,19 @@ object Weaver:
       override def initialValue() = scala.collection.mutable.LinkedHashMap.empty
 
   /**
+    * Like [[fromSurface]], but returns `None` when the resulting weaver is the lossy empty-object
+    * fallback used for surfaces that no built-in factory can handle. Callers that want to fall back
+    * to a different encoding strategy (e.g. tagged-string toString) when a type isn't directly
+    * supported can use this overload to detect the gap.
+    */
+  def fromSurfaceOpt(surface: Surface): Option[Weaver[?]] =
+    val w = fromSurface(surface)
+    if w eq emptyObjectWeaver then
+      None
+    else
+      Some(w)
+
+  /**
     * Create a Weaver from Surface at runtime. Uses Surface type information to look up or build
     * appropriate Weaver by composing existing weavers.
     *

--- a/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
@@ -7,6 +7,8 @@ import wvlet.uni.msgpack.spi.Packer
 import wvlet.uni.msgpack.spi.Unpacker
 import wvlet.uni.msgpack.spi.ValueType
 import wvlet.uni.surface.*
+import wvlet.uni.util.ElapsedTime
+import wvlet.uni.util.ULID
 import wvlet.uni.weaver.codec.AnyWeaver
 import wvlet.uni.weaver.codec.CaseClassWeaver
 import wvlet.uni.weaver.codec.EnumWeaver
@@ -157,6 +159,8 @@ object Weaver:
     instantWeaver,
     uuidWeaver,
     uriWeaver,
+    ulidWeaver,
+    elapsedTimeWeaver,
     scalaDurationWeaver,
     optionWeaver,
     listWeaver,
@@ -286,6 +290,10 @@ object Weaver:
         uuidWeaver
       case s if s.rawType == classOf[Instant] =>
         instantWeaver
+      case s if s.rawType == classOf[ULID] =>
+        ulidWeaver
+      case s if s.rawType == classOf[ElapsedTime] =>
+        elapsedTimeWeaver
     }
 
   end primitiveFactory

--- a/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
@@ -208,17 +208,23 @@ object Weaver:
   /**
     * Like [[fromSurface]], but returns `None` when the resulting weaver tree contains the lossy
     * empty-object fallback at any position — top-level or nested inside a collection / case class.
-    * Callers that want to fall back to a different encoding strategy (e.g. toString-quoted JSON)
-    * when a type isn't directly supported can use this overload to detect the gap, including cases
-    * like `Seq[Either[A, B]]` or `case class Foo(d: LocalDate)` where `fromSurface` would otherwise
+    * Also returns `None` when [[fromSurface]] itself throws because no factory matches (e.g. a
+    * primitive surface like `java.math.BigInteger` that has no built-in branch). Callers that want
+    * to fall back to a different encoding strategy (e.g. toString-quoted JSON) when a type isn't
+    * directly supported can use this overload to detect the gap, including cases like
+    * `Seq[Either[A, B]]` or `case class Foo(d: LocalDate)` where `fromSurface` would otherwise
     * embed an empty fallback inside an outer composite weaver.
     */
   def fromSurfaceOpt(surface: Surface): Option[Weaver[?]] =
-    val w = fromSurface(surface)
-    if containsEmptyFallback(w) then
-      None
-    else
-      Some(w)
+    try
+      val w = fromSurface(surface)
+      if containsEmptyFallback(w) then
+        None
+      else
+        Some(w)
+    catch
+      case _: IllegalArgumentException =>
+        None
 
   private def containsEmptyFallback(w: Weaver[?]): Boolean =
     val visited = java

--- a/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
@@ -101,6 +101,13 @@ trait Weaver[A]:
     */
   def unpack(u: Unpacker, context: WeaverContext): Unit
 
+  /**
+    * Composite weavers (collections, case classes, etc.) override this to expose the weavers they
+    * delegate to. Used by [[Weaver.fromSurfaceOpt]] to detect when any nested weaver in the tree is
+    * the lossy empty-object fallback. Default: no inner weavers.
+    */
+  def innerWeavers: Seq[Weaver[?]] = Seq.empty
+
 end Weaver
 
 object Weaver:
@@ -199,17 +206,33 @@ object Weaver:
       override def initialValue() = scala.collection.mutable.LinkedHashMap.empty
 
   /**
-    * Like [[fromSurface]], but returns `None` when the resulting weaver is the lossy empty-object
-    * fallback used for surfaces that no built-in factory can handle. Callers that want to fall back
-    * to a different encoding strategy (e.g. tagged-string toString) when a type isn't directly
-    * supported can use this overload to detect the gap.
+    * Like [[fromSurface]], but returns `None` when the resulting weaver tree contains the lossy
+    * empty-object fallback at any position — top-level or nested inside a collection / case class.
+    * Callers that want to fall back to a different encoding strategy (e.g. toString-quoted JSON)
+    * when a type isn't directly supported can use this overload to detect the gap, including cases
+    * like `Seq[Either[A, B]]` or `case class Foo(d: LocalDate)` where `fromSurface` would otherwise
+    * embed an empty fallback inside an outer composite weaver.
     */
   def fromSurfaceOpt(surface: Surface): Option[Weaver[?]] =
     val w = fromSurface(surface)
-    if w eq emptyObjectWeaver then
+    if containsEmptyFallback(w) then
       None
     else
       Some(w)
+
+  private def containsEmptyFallback(w: Weaver[?]): Boolean =
+    val visited = java
+      .util
+      .Collections
+      .newSetFromMap(new java.util.IdentityHashMap[Weaver[?], java.lang.Boolean])
+    def walk(x: Weaver[?]): Boolean =
+      if !visited.add(x) then
+        false
+      else if x eq emptyObjectWeaver then
+        true
+      else
+        x.innerWeavers.exists(walk)
+    walk(w)
 
   /**
     * Create a Weaver from Surface at runtime. Uses Surface type information to look up or build
@@ -410,6 +433,13 @@ object Weaver:
     private var ref: Weaver[Any] = null
 
     def resolve(w: Weaver[?]): Unit = ref = w.asInstanceOf[Weaver[Any]]
+
+    override def innerWeavers: Seq[Weaver[?]] =
+      val w = ref
+      if w == null then
+        Seq.empty
+      else
+        Seq(w)
 
     override def pack(p: Packer, v: Any, config: WeaverConfig): Unit =
       val w = ref

--- a/uni/src/main/scala/wvlet/uni/weaver/codec/CaseClassWeaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/codec/CaseClassWeaver.scala
@@ -16,6 +16,8 @@ import wvlet.uni.weaver.WeaverContext
   */
 class CaseClassWeaver[A](surface: Surface, fieldWeavers: IndexedSeq[Weaver[?]]) extends Weaver[A]:
 
+  override def innerWeavers: Seq[Weaver[?]] = fieldWeavers
+
   // Pre-compute canonicalized name lookup for flexible field matching
   private val paramsByCanonicalName: Map[String, (Int, Parameter)] =
     surface

--- a/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
@@ -3,6 +3,8 @@ package wvlet.uni.weaver.codec
 import wvlet.uni.msgpack.spi.Packer
 import wvlet.uni.msgpack.spi.Unpacker
 import wvlet.uni.msgpack.spi.ValueType
+import wvlet.uni.util.ElapsedTime
+import wvlet.uni.util.ULID
 import wvlet.uni.weaver.CollectionWeaver
 import wvlet.uni.weaver.Weaver
 import wvlet.uni.weaver.WeaverConfig
@@ -774,6 +776,50 @@ object PrimitiveWeaver:
           case other =>
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to URI"))
+
+  given ulidWeaver: Weaver[ULID] =
+    new Weaver[ULID]:
+      override def pack(p: Packer, v: ULID, config: WeaverConfig): Unit =
+        if v == null then
+          p.packNil
+        else
+          p.packString(v.toString)
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.STRING =>
+            safeConvertFromString(context, u, ULID(_), context.setObject, "ULID")
+          case ValueType.NIL =>
+            safeUnpackNil(context, u)
+          case other =>
+            u.skipValue
+            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to ULID"))
+
+  given elapsedTimeWeaver: Weaver[ElapsedTime] =
+    new Weaver[ElapsedTime]:
+      override def pack(p: Packer, v: ElapsedTime, config: WeaverConfig): Unit =
+        if v == null then
+          p.packNil
+        else
+          p.packString(v.toString)
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.STRING =>
+            safeConvertFromString(
+              context,
+              u,
+              ElapsedTime.parse(_),
+              context.setObject,
+              "ElapsedTime"
+            )
+          case ValueType.NIL =>
+            safeUnpackNil(context, u)
+          case other =>
+            u.skipValue
+            context.setError(
+              new IllegalArgumentException(s"Cannot convert ${other} to ElapsedTime")
+            )
 
   // Tuple support via recursive given resolution
   trait TupleElementWeaver[T <: Tuple]:

--- a/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
@@ -838,7 +838,14 @@ object PrimitiveWeaver:
               while i < mapSize do
                 u.unpackString match
                   case "value" =>
-                    value = u.unpackDouble
+                    // Accept integer literals like `{"value":5,...}` from JSON producers that
+                    // omit the `.0` for whole-number durations.
+                    value =
+                      u.getNextValueType match
+                        case ValueType.INTEGER =>
+                          u.unpackLong.toDouble
+                        case _ =>
+                          u.unpackDouble
                     hasValue = true
                   case "unit" =>
                     unit = ElapsedTime.valueOfTimeUnit(u.unpackString)

--- a/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
@@ -56,6 +56,31 @@ object PrimitiveWeaver:
       case e: Exception =>
         context.setError(e)
 
+  /**
+    * Build a Weaver for a type that round-trips through a single string. `pack` writes
+    * `serialize(v)` as a MessagePack STRING; `unpack` reads STRING via `deserialize` and passes NIL
+    * through as null.
+    */
+  private[codec] def stringBasedWeaver[A](
+      typeName: String,
+      serialize: A => String,
+      deserialize: String => A
+  ): Weaver[A] =
+    new Weaver[A]:
+      override def pack(p: Packer, v: A, config: WeaverConfig): Unit = p.packString(serialize(v))
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.STRING =>
+            safeConvertFromString(context, u, deserialize, context.setObject, typeName)
+          case ValueType.NIL =>
+            safeUnpackNil(context, u)
+          case other =>
+            u.skipValue
+            context.setError(
+              IllegalArgumentException(s"Cannot convert ${other} to ${typeName}, expected STRING")
+            )
+
   private def collectionWeaver[A, C](
       elementWeaver: Weaver[A],
       typeName: String,
@@ -777,49 +802,13 @@ object PrimitiveWeaver:
             u.skipValue
             context.setError(new IllegalArgumentException(s"Cannot convert ${other} to URI"))
 
-  given ulidWeaver: Weaver[ULID] =
-    new Weaver[ULID]:
-      override def pack(p: Packer, v: ULID, config: WeaverConfig): Unit =
-        if v == null then
-          p.packNil
-        else
-          p.packString(v.toString)
+  given ulidWeaver: Weaver[ULID] = stringBasedWeaver("ULID", _.toString, ULID(_))
 
-      override def unpack(u: Unpacker, context: WeaverContext): Unit =
-        u.getNextValueType match
-          case ValueType.STRING =>
-            safeConvertFromString(context, u, ULID(_), context.setObject, "ULID")
-          case ValueType.NIL =>
-            safeUnpackNil(context, u)
-          case other =>
-            u.skipValue
-            context.setError(new IllegalArgumentException(s"Cannot convert ${other} to ULID"))
-
-  given elapsedTimeWeaver: Weaver[ElapsedTime] =
-    new Weaver[ElapsedTime]:
-      override def pack(p: Packer, v: ElapsedTime, config: WeaverConfig): Unit =
-        if v == null then
-          p.packNil
-        else
-          p.packString(v.toString)
-
-      override def unpack(u: Unpacker, context: WeaverContext): Unit =
-        u.getNextValueType match
-          case ValueType.STRING =>
-            safeConvertFromString(
-              context,
-              u,
-              ElapsedTime.parse(_),
-              context.setObject,
-              "ElapsedTime"
-            )
-          case ValueType.NIL =>
-            safeUnpackNil(context, u)
-          case other =>
-            u.skipValue
-            context.setError(
-              new IllegalArgumentException(s"Cannot convert ${other} to ElapsedTime")
-            )
+  given elapsedTimeWeaver: Weaver[ElapsedTime] = stringBasedWeaver(
+    "ElapsedTime",
+    _.toString,
+    ElapsedTime.parse(_)
+  )
 
   // Tuple support via recursive given resolution
   trait TupleElementWeaver[T <: Tuple]:

--- a/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
@@ -832,18 +832,20 @@ object PrimitiveWeaver:
             try
               val mapSize                             = u.unpackMapHeader
               var value: Double                       = 0.0
+              var hasValue                            = false
               var unit: java.util.concurrent.TimeUnit = null
               var i                                   = 0
               while i < mapSize do
                 u.unpackString match
                   case "value" =>
                     value = u.unpackDouble
+                    hasValue = true
                   case "unit" =>
                     unit = ElapsedTime.valueOfTimeUnit(u.unpackString)
                   case _ =>
                     u.skipValue
                 i += 1
-              if unit == null then
+              if !hasValue || unit == null then
                 context.setError(
                   IllegalArgumentException("ElapsedTime requires both 'value' and 'unit' fields")
                 )

--- a/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
@@ -804,11 +804,63 @@ object PrimitiveWeaver:
 
   given ulidWeaver: Weaver[ULID] = stringBasedWeaver("ULID", _.toString, ULID(_))
 
-  given elapsedTimeWeaver: Weaver[ElapsedTime] = stringBasedWeaver(
-    "ElapsedTime",
-    _.toString,
-    ElapsedTime.parse(_)
-  )
+  // ElapsedTime.toString is %.2f-formatted (lossy on the value), and a `${value}${unit}` string
+  // form would only round-trip cleanly when Double.toString avoids exponential notation. Encode
+  // as a structured `{value, unit}` map instead so the original (Double, TimeUnit) pair is
+  // preserved exactly for any value the user could construct.
+  given elapsedTimeWeaver: Weaver[ElapsedTime] =
+    new Weaver[ElapsedTime]:
+      override def pack(p: Packer, v: ElapsedTime, config: WeaverConfig): Unit =
+        p.packMapHeader(2)
+        p.packString("value")
+        p.packDouble(v.value)
+        p.packString("unit")
+        p.packString(ElapsedTime.timeUnitToString(v.unit))
+
+      override def unpack(u: Unpacker, context: WeaverContext): Unit =
+        u.getNextValueType match
+          case ValueType.STRING =>
+            // Backward-compatibility for legacy "<value><unit>" string form (e.g. "2.50ms").
+            safeConvertFromString(
+              context,
+              u,
+              ElapsedTime.parse(_),
+              context.setObject,
+              "ElapsedTime"
+            )
+          case ValueType.MAP =>
+            try
+              val mapSize                             = u.unpackMapHeader
+              var value: Double                       = 0.0
+              var unit: java.util.concurrent.TimeUnit = null
+              var i                                   = 0
+              while i < mapSize do
+                u.unpackString match
+                  case "value" =>
+                    value = u.unpackDouble
+                  case "unit" =>
+                    unit = ElapsedTime.valueOfTimeUnit(u.unpackString)
+                  case _ =>
+                    u.skipValue
+                i += 1
+              if unit == null then
+                context.setError(
+                  IllegalArgumentException("ElapsedTime requires both 'value' and 'unit' fields")
+                )
+              else
+                context.setObject(ElapsedTime(value, unit))
+            catch
+              case e: Exception =>
+                context.setError(e)
+          case ValueType.NIL =>
+            safeUnpackNil(context, u)
+          case other =>
+            u.skipValue
+            context.setError(
+              IllegalArgumentException(
+                s"Cannot convert ${other} to ElapsedTime, expected STRING or MAP"
+              )
+            )
 
   // Tuple support via recursive given resolution
   trait TupleElementWeaver[T <: Tuple]:

--- a/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/codec/PrimitiveWeaver.scala
@@ -804,72 +804,16 @@ object PrimitiveWeaver:
 
   given ulidWeaver: Weaver[ULID] = stringBasedWeaver("ULID", _.toString, ULID(_))
 
-  // ElapsedTime.toString is %.2f-formatted (lossy on the value), and a `${value}${unit}` string
-  // form would only round-trip cleanly when Double.toString avoids exponential notation. Encode
-  // as a structured `{value, unit}` map instead so the original (Double, TimeUnit) pair is
-  // preserved exactly for any value the user could construct.
-  given elapsedTimeWeaver: Weaver[ElapsedTime] =
-    new Weaver[ElapsedTime]:
-      override def pack(p: Packer, v: ElapsedTime, config: WeaverConfig): Unit =
-        p.packMapHeader(2)
-        p.packString("value")
-        p.packDouble(v.value)
-        p.packString("unit")
-        p.packString(ElapsedTime.timeUnitToString(v.unit))
-
-      override def unpack(u: Unpacker, context: WeaverContext): Unit =
-        u.getNextValueType match
-          case ValueType.STRING =>
-            // Backward-compatibility for legacy "<value><unit>" string form (e.g. "2.50ms").
-            safeConvertFromString(
-              context,
-              u,
-              ElapsedTime.parse(_),
-              context.setObject,
-              "ElapsedTime"
-            )
-          case ValueType.MAP =>
-            try
-              val mapSize                             = u.unpackMapHeader
-              var value: Double                       = 0.0
-              var hasValue                            = false
-              var unit: java.util.concurrent.TimeUnit = null
-              var i                                   = 0
-              while i < mapSize do
-                u.unpackString match
-                  case "value" =>
-                    // Accept integer literals like `{"value":5,...}` from JSON producers that
-                    // omit the `.0` for whole-number durations.
-                    value =
-                      u.getNextValueType match
-                        case ValueType.INTEGER =>
-                          u.unpackLong.toDouble
-                        case _ =>
-                          u.unpackDouble
-                    hasValue = true
-                  case "unit" =>
-                    unit = ElapsedTime.valueOfTimeUnit(u.unpackString)
-                  case _ =>
-                    u.skipValue
-                i += 1
-              if !hasValue || unit == null then
-                context.setError(
-                  IllegalArgumentException("ElapsedTime requires both 'value' and 'unit' fields")
-                )
-              else
-                context.setObject(ElapsedTime(value, unit))
-            catch
-              case e: Exception =>
-                context.setError(e)
-          case ValueType.NIL =>
-            safeUnpackNil(context, u)
-          case other =>
-            u.skipValue
-            context.setError(
-              IllegalArgumentException(
-                s"Cannot convert ${other} to ElapsedTime, expected STRING or MAP"
-              )
-            )
+  // Encode as `<value><unit>` (e.g. "2.555s", "1.0E-9ns") rather than `et.toString`, which is
+  // %.2f-rounded and would lose precision on round-trip. ElapsedTime.parse accepts the value
+  // in plain decimal *and* exponent form so any Double.toString output round-trips exactly,
+  // and the wire shape stays a JSON string — matching the pre-PR Router fallback for this
+  // type and avoiding a content-shape change for clients already on the wire.
+  given elapsedTimeWeaver: Weaver[ElapsedTime] = stringBasedWeaver(
+    "ElapsedTime",
+    et => s"${et.value}${ElapsedTime.timeUnitToString(et.unit)}",
+    ElapsedTime.parse(_)
+  )
 
   // Tuple support via recursive given resolution
   trait TupleElementWeaver[T <: Tuple]:

--- a/uni/src/test/scala/wvlet/uni/weaver/WeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/WeaverTest.scala
@@ -636,6 +636,16 @@ class WeaverTest extends UniTest:
     Weaver.fromSurfaceOpt(Surface.of[Map[String, WeaverTest.Greeting]]).isDefined shouldBe true
   }
 
+  test("fromSurfaceOpt returns None when fromSurface itself throws") {
+    // java.math.BigInteger is marked primitive in Surface but has no primitiveFactory branch,
+    // so fromSurface throws IllegalArgumentException. fromSurfaceOpt must convert that to None
+    // so RouterHandler doesn't fail at handler-construction time for routes returning a type
+    // that transitively contains BigInteger.
+    import wvlet.uni.surface.Surface
+    Weaver.fromSurfaceOpt(Surface.of[java.math.BigInteger]) shouldBe None
+    Weaver.fromSurfaceOpt(Surface.of[Seq[java.math.BigInteger]]) shouldBe None
+  }
+
 end WeaverTest
 
 object WeaverTest:

--- a/uni/src/test/scala/wvlet/uni/weaver/WeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/WeaverTest.scala
@@ -611,4 +611,33 @@ class WeaverTest extends UniTest:
     v2 shouldBe v
   }
 
+  // Regression coverage for fromSurfaceOpt: ensure unsupported nested types are detected even
+  // when wrapped inside collections or case classes — otherwise callers that key behavior on
+  // "is this weaver lossless" would silently emit `[{}]` / `{"d":{}}`.
+  test("fromSurfaceOpt returns None for top-level Either") {
+    import wvlet.uni.surface.Surface
+    Weaver.fromSurfaceOpt(Surface.of[Either[String, Int]]) shouldBe None
+  }
+
+  test("fromSurfaceOpt returns None for Seq with unsupported element type") {
+    import wvlet.uni.surface.Surface
+    Weaver.fromSurfaceOpt(Surface.of[Seq[Either[String, Int]]]) shouldBe None
+  }
+
+  test("fromSurfaceOpt returns None for case class with unsupported field type") {
+    import wvlet.uni.surface.Surface
+    Weaver.fromSurfaceOpt(Surface.of[WeaverTest.HasEither]) shouldBe None
+  }
+
+  test("fromSurfaceOpt returns Some for fully-supported types") {
+    import wvlet.uni.surface.Surface
+    Weaver.fromSurfaceOpt(Surface.of[WeaverTest.Greeting]).isDefined shouldBe true
+    Weaver.fromSurfaceOpt(Surface.of[Seq[WeaverTest.Greeting]]).isDefined shouldBe true
+    Weaver.fromSurfaceOpt(Surface.of[Map[String, WeaverTest.Greeting]]).isDefined shouldBe true
+  }
+
 end WeaverTest
+
+object WeaverTest:
+  case class HasEither(e: Either[String, Int])
+  case class Greeting(message: String)

--- a/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
@@ -400,6 +400,13 @@ class AdditionalTypeWeaverTest extends UniTest:
     e2.getMessage shouldContain "unit"
   }
 
+  test("ElapsedTime accepts integer value literal") {
+    // JSON producers commonly emit whole numbers without a fractional part. Accept both.
+    val v = Weaver.fromJson[ElapsedTime]("""{"value":5,"unit":"ms"}""")
+    v.value shouldBe 5.0
+    v.unit shouldBe TimeUnit.MILLISECONDS
+  }
+
   // ====== Composite: case class with new types ======
 
   case class Record(id: UUID, tags: Set[String], amount: BigDecimal, createdAt: Instant)

--- a/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
@@ -1,11 +1,14 @@
 package wvlet.uni.weaver.codec
 
 import wvlet.uni.test.UniTest
+import wvlet.uni.util.ElapsedTime
+import wvlet.uni.util.ULID
 import wvlet.uni.weaver.Weaver
 import scala.concurrent.duration.Duration as ScalaDuration
 import java.net.URI
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 class AdditionalTypeWeaverTest extends UniTest:
 
@@ -294,6 +297,71 @@ class AdditionalTypeWeaverTest extends UniTest:
     json shouldBe "\"file:///tmp/test.txt\""
     val v2 = Weaver.fromJson[URI](json)
     v2 shouldBe v
+  }
+
+  // ====== ULID ======
+
+  test("roundtrip ULID") {
+    val v       = ULID("01arz3ndektsv4rrffq69g5fav")
+    val msgpack = Weaver.weave(v)
+    val v2      = Weaver.unweave[ULID](msgpack)
+    v2 shouldBe v
+  }
+
+  test("ULID to/from JSON") {
+    val v    = ULID("01arz3ndektsv4rrffq69g5fav")
+    val json = Weaver.toJson(v)
+    json shouldBe "\"01arz3ndektsv4rrffq69g5fav\""
+    val v2 = Weaver.fromJson[ULID](json)
+    v2 shouldBe v
+  }
+
+  test("ULID via fromSurface") {
+    import wvlet.uni.surface.Surface
+    val w  = Weaver.fromSurface(Surface.of[ULID]).asInstanceOf[Weaver[ULID]]
+    val v  = ULID("01arz3ndektsv4rrffq69g5fav")
+    val s  = w.toJson(v)
+    val v2 = w.fromJson(s)
+    v2 shouldBe v
+  }
+
+  test("ULID invalid string") {
+    val e = intercept[IllegalArgumentException] {
+      Weaver.fromJson[ULID]("\"not-a-ulid\"")
+    }
+    e.getMessage shouldContain "ULID"
+  }
+
+  // ====== ElapsedTime ======
+
+  test("roundtrip ElapsedTime") {
+    val v       = ElapsedTime(5.0, TimeUnit.MILLISECONDS)
+    val msgpack = Weaver.weave(v)
+    val v2      = Weaver.unweave[ElapsedTime](msgpack)
+    v2 shouldBe v
+  }
+
+  test("ElapsedTime to/from JSON") {
+    val v    = ElapsedTime(2.5, TimeUnit.SECONDS)
+    val json = Weaver.toJson(v)
+    val v2   = Weaver.fromJson[ElapsedTime](json)
+    v2 shouldBe v
+  }
+
+  test("ElapsedTime via fromSurface") {
+    import wvlet.uni.surface.Surface
+    val w  = Weaver.fromSurface(Surface.of[ElapsedTime]).asInstanceOf[Weaver[ElapsedTime]]
+    val v  = ElapsedTime(123.0, TimeUnit.MILLISECONDS)
+    val s  = w.toJson(v)
+    val v2 = w.fromJson(s)
+    v2 shouldBe v
+  }
+
+  test("ElapsedTime invalid string") {
+    val e = intercept[IllegalArgumentException] {
+      Weaver.fromJson[ElapsedTime]("\"not-a-duration\"")
+    }
+    e.getMessage shouldContain "duration"
   }
 
   // ====== Composite: case class with new types ======

--- a/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
@@ -364,6 +364,28 @@ class AdditionalTypeWeaverTest extends UniTest:
     e.getMessage shouldContain "duration"
   }
 
+  test("ElapsedTime preserves full Double precision") {
+    // Regression: toString-based encoding rounded to 2 decimals and lost extreme values.
+    val v       = ElapsedTime(2.555, TimeUnit.SECONDS)
+    val msgpack = Weaver.weave(v)
+    val v2      = Weaver.unweave[ElapsedTime](msgpack)
+    v2.value shouldBe v.value
+    v2.unit shouldBe v.unit
+
+    val tiny     = ElapsedTime(1.0e-5, TimeUnit.NANOSECONDS)
+    val tinyJson = Weaver.toJson(tiny)
+    val tinyBack = Weaver.fromJson[ElapsedTime](tinyJson)
+    tinyBack.value shouldBe tiny.value
+    tinyBack.unit shouldBe tiny.unit
+  }
+
+  test("ElapsedTime accepts legacy string form for backward compatibility") {
+    val legacy = "\"2.50ms\""
+    val v      = Weaver.fromJson[ElapsedTime](legacy)
+    v.value shouldBe 2.5
+    v.unit shouldBe TimeUnit.MILLISECONDS
+  }
+
   // ====== Composite: case class with new types ======
 
   case class Record(id: UUID, tags: Set[String], amount: BigDecimal, createdAt: Instant)

--- a/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
@@ -379,32 +379,19 @@ class AdditionalTypeWeaverTest extends UniTest:
     tinyBack.unit shouldBe tiny.unit
   }
 
-  test("ElapsedTime accepts legacy string form for backward compatibility") {
+  test("ElapsedTime accepts legacy %.2f-formatted string form") {
     val legacy = "\"2.50ms\""
     val v      = Weaver.fromJson[ElapsedTime](legacy)
     v.value shouldBe 2.5
     v.unit shouldBe TimeUnit.MILLISECONDS
   }
 
-  test("ElapsedTime rejects map missing value or unit") {
-    val noValue = """{"unit":"ms"}"""
-    val e1      = intercept[IllegalArgumentException] {
-      Weaver.fromJson[ElapsedTime](noValue)
-    }
-    e1.getMessage shouldContain "value"
-
-    val noUnit = """{"value":5.0}"""
-    val e2     = intercept[IllegalArgumentException] {
-      Weaver.fromJson[ElapsedTime](noUnit)
-    }
-    e2.getMessage shouldContain "unit"
-  }
-
-  test("ElapsedTime accepts integer value literal") {
-    // JSON producers commonly emit whole numbers without a fractional part. Accept both.
-    val v = Weaver.fromJson[ElapsedTime]("""{"value":5,"unit":"ms"}""")
-    v.value shouldBe 5.0
-    v.unit shouldBe TimeUnit.MILLISECONDS
+  test("ElapsedTime parse accepts exponent form so Double.toString round-trips") {
+    // 1.0E-9 is what `(1.0e-9).toString` produces — the encoder uses Double.toString so the
+    // parse regex must accept this form to avoid losing very small values.
+    val v = ElapsedTime.parse("1.0E-9ns")
+    v.value shouldBe 1.0e-9
+    v.unit shouldBe TimeUnit.NANOSECONDS
   }
 
   // ====== Composite: case class with new types ======

--- a/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/codec/AdditionalTypeWeaverTest.scala
@@ -386,6 +386,20 @@ class AdditionalTypeWeaverTest extends UniTest:
     v.unit shouldBe TimeUnit.MILLISECONDS
   }
 
+  test("ElapsedTime rejects map missing value or unit") {
+    val noValue = """{"unit":"ms"}"""
+    val e1      = intercept[IllegalArgumentException] {
+      Weaver.fromJson[ElapsedTime](noValue)
+    }
+    e1.getMessage shouldContain "value"
+
+    val noUnit = """{"value":5.0}"""
+    val e2     = intercept[IllegalArgumentException] {
+      Weaver.fromJson[ElapsedTime](noUnit)
+    }
+    e2.getMessage shouldContain "unit"
+  }
+
   // ====== Composite: case class with new types ======
 
   case class Record(id: UUID, tags: Set[String], amount: BigDecimal, createdAt: Instant)


### PR DESCRIPTION
## Summary

- **Fixes #536** — built-in `Weaver` codecs for `wvlet.uni.util.ULID` and `wvlet.uni.util.ElapsedTime`. Both encode as JSON strings (ULID's 26-char base32; ElapsedTime as `${value}${unit}` with full Double precision). Extends `ElapsedTime.parse` to accept exponent form so `Double.toString` round-trips losslessly.
- **Fixes #537** — `RouterHandler` pre-computes a `Weaver` per route and threads it through a new `ResponseConverter.toResponse(result, weaver)` overload, so `@Endpoint` controllers returning case classes (or `Rx[CaseClass]` / `Option[CaseClass]` / `Seq[CaseClass]`) emit proper JSON like `{"message":"world"}` instead of `"Greeting(message=world)"`.
- **`Weaver.fromSurfaceOpt` + `Weaver.innerWeavers`** — new safety hook that returns `None` when the derived weaver tree contains the lossy empty-object fallback at any position (top-level *or* nested inside `Seq[Either[A,B]]` / `case class Foo(d: LocalDate)`), or when `fromSurface` itself throws (e.g. `BigInteger`). RouterHandler uses it so unsupported return types fall through to the legacy toString-quoted JSON path instead of silently emitting `[{}]` / `{"d":{}}`. See `adr/2026-05-04-fromsurfaceopt-and-innerweavers.md`.
- **Wire-format compatibility**: skip Weaver derivation for `Response` returns and primitive surfaces; fall back to no-weaver `application/json` (not `text/plain`) when the weaver throws on opaque wrapper types.
- **Reuse**: promotes `stringBasedWeaver` from `JvmWeaver` to `PrimitiveWeaver` so cross-platform codecs share it.

## Notable behavior changes

- `ElapsedTime` JSON form changes from `"5.00ms"` (lossy `%.2f`) to `"5.0ms"` (full precision). Both parse to the same value via `ElapsedTime.parse`.
- `ElapsedTime.parse` now accepts exponent form (e.g. `"1.0E-9ns"`). Strict extension — no input previously rejected fails now.

## Test plan

- [x] `./sbt uniJVM/testOnly *AdditionalTypeWeaverTest *WeaverTest` — ULID/ElapsedTime round-trips, `fromSurfaceOpt` for top-level / nested / throwing surfaces
- [x] `./sbt netty/testOnly *NettyServerTest` — end-to-end Router cases: `Greeting`, `Option[Greeting]`, `Rx[Greeting]`, `Rx[Option[Greeting]]`, `Seq[Greeting]`, `None`, `Either` (legacy fallback), opaque wrapper (content-type stability), `Int` / `Boolean` (wire-format preservation)
- [x] `./sbt uniJVM/test` — 1599 passed, 4 pending, 0 failed
- [x] `./sbt scalafmtCheckAll`
- [x] `./sbt uniJS/compile uniNative/compile`
- [x] CI green across Scala 3, Scala.js, Scala Native, sbt scripted, integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)