### PR TITLE
feature: Synchronous HTTP for Node.js / Bun / Deno via worker_threads + Atomics.wait

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,4 @@ Gemini reviews PRs. Address feedback before merging.
 ## Architecture decisions
 
 - [`adr/2026-05-04-fromsurfaceopt-and-innerweavers.md`](adr/2026-05-04-fromsurfaceopt-and-innerweavers.md) — `Weaver.fromSurfaceOpt` + `Weaver.innerWeavers` for detecting lossy fallbacks anywhere in a derived weaver tree. Read before adding new composite weaver classes.
+- [`adr/2026-05-14-nodejs-sync-http.md`](adr/2026-05-14-nodejs-sync-http.md) — Synchronous HTTP on Node.js via `worker_threads` + `Atomics.wait`. Read before touching `NodeSyncHttpChannel` or the JS HTTP channels (covers the `worker_threads` runtime-load, the `Long`-to-JS trap, and why tests run their server in a worker thread).

--- a/adr/2026-05-14-nodejs-sync-http.md
+++ b/adr/2026-05-14-nodejs-sync-http.md
@@ -27,8 +27,9 @@ Implement `NodeSyncHttpChannel` using the `worker_threads` + `Atomics.wait` on
    buffer, then `Atomics.store` + `Atomics.notify` wakes the parent.
 3. The main thread decodes the buffer and returns `HttpResponse` synchronously.
 
-Node.js only. Browser environments still throw `NotImplementedError`;
-`JSHttpChannelFactory.newChannel` detects Node via `process.versions.node` first.
+Works on any Node-compatible runtime — verified on Node.js, Bun, and Deno. Browser
+environments still throw `NotImplementedError`; `JSHttpChannelFactory.newChannel` detects
+a Node-compatible runtime via `process.versions.node` first (Bun and Deno both set it).
 
 ## Non-obvious points a future reader would otherwise reverse-engineer
 
@@ -46,13 +47,19 @@ Scala.js has no synchronous dynamic `require`. The fix is `process.getBuiltinMod
 as a fallback for older Node / `NoModule` builds. Being a plain runtime call it is
 invisible to bundlers — browser bundles build fine and hit the `isNode == false` path.
 
-### The eval'd worker string runs as CommonJS regardless of the parent's module kind
+### The worker gets `workerData` via `await import`, not `require`
 
-uni links as `ModuleKind.ESModule`. It is tempting to assume a worker spawned from an
-ESM parent is itself ESM and lacks `require`. It is not: `new Worker(code, {eval:true})`
-evaluates `code` as CommonJS, so `require('worker_threads')` inside `WorkerScript` works
-even though the surrounding artifact is an ES module. (Verified directly on Node 25.)
-The worker's own module kind is independent of the parent's.
+The worker's module kind is independent of the parent artifact's. Node's
+`new Worker(code, {eval:true})` evaluates `code` as CommonJS — `require('worker_threads')`
+works there even though uni links as `ModuleKind.ESModule`. **Deno's** eval workers,
+however, run as ESM and have no `require`, so `require('worker_threads')` throws and the
+worker never notifies — the main thread then blocks until the safety timeout.
+
+`WorkerScript` therefore obtains `workerData` via `await import('node:worker_threads')`
+inside its async IIFE. Dynamic `import('node:...')` works in Node, Bun, and Deno alike,
+which is why this channel runs on all three (Bun and Deno both set `process.versions.node`,
+so `isNode` accepts them). Verified directly: a GET against `https://example.com` through
+the exact `WorkerScript` succeeds on Node 25, Bun 1.2, and Deno 2.2.
 
 ### The test server must run in its own worker thread
 

--- a/adr/2026-05-14-nodejs-sync-http.md
+++ b/adr/2026-05-14-nodejs-sync-http.md
@@ -1,0 +1,107 @@
+# 2026-05-14: Synchronous HTTP on Node.js via `worker_threads` + `Atomics.wait`
+
+PR: https://github.com/wvlet/uni/pull/546 (commit 60e6d35 introduces the design;
+refined through 505d70a)
+
+## Context
+
+`HttpChannel.send` is synchronous — it returns an `HttpResponse`, not an `Rx`/`Future`.
+JVM and Native back it with genuinely blocking clients. On Scala.js the sync channel
+(`JSHttpChannelFactory.newChannel`) used to just `throw NotImplementedError`, because
+JavaScript has no native synchronous HTTP API: `fetch` is async, sync `XMLHttpRequest`
+is deprecated and unavailable off the main thread, and Node has no blocking HTTP call.
+
+`wvlet/wvlet` needs a sync HTTP client that works on JVM, Node, and Native so its Trino
+client can match the shape of `DuckDB.execute`. That forced the question: can Node do
+sync HTTP at all, without a `curl` shell-out or a `deasync`-style libuv hack?
+
+## Decision
+
+Implement `NodeSyncHttpChannel` using the `worker_threads` + `Atomics.wait` on
+`SharedArrayBuffer` pattern (the same trick `sync-fetch` uses internally):
+
+1. The main thread allocates a `SharedArrayBuffer` (`HeaderBytes` + `maxResponseBytes`),
+   spawns `new Worker(code, { eval: true })` with the request in `workerData`, and calls
+   `Atomics.wait` to block.
+2. The worker runs `await fetch(...)`, encodes status/headers/body into the shared
+   buffer, then `Atomics.store` + `Atomics.notify` wakes the parent.
+3. The main thread decodes the buffer and returns `HttpResponse` synchronously.
+
+Node.js only. Browser environments still throw `NotImplementedError`;
+`JSHttpChannelFactory.newChannel` detects Node via `process.versions.node` first.
+
+## Non-obvious points a future reader would otherwise reverse-engineer
+
+### `worker_threads` is loaded at runtime, not via `@JSImport`
+
+A static `@JSImport("worker_threads")` is emitted by Scala.js as a top-level
+`import "worker_threads"` into **every** bundle that links `NodeSyncHttpChannel`.
+Because `JSHttpChannelFactory` is the *default* channel factory and its `newChannel`
+references `NodeSyncHttpChannel`, that import lands in any browser bundle using uni's
+HTTP at all — and browser bundlers (Webpack/Vite/Rollup) fail to resolve the Node-only
+`worker_threads` at build time, before `isNode` can ever return false.
+
+Scala.js has no synchronous dynamic `require`. The fix is `process.getBuiltinModule`
+(Node 20.16+ / 22.3+), which works in both CommonJS and ESM, with the global `require`
+as a fallback for older Node / `NoModule` builds. Being a plain runtime call it is
+invisible to bundlers — browser bundles build fine and hit the `isNode == false` path.
+
+### The eval'd worker string runs as CommonJS regardless of the parent's module kind
+
+uni links as `ModuleKind.ESModule`. It is tempting to assume a worker spawned from an
+ESM parent is itself ESM and lacks `require`. It is not: `new Worker(code, {eval:true})`
+evaluates `code` as CommonJS, so `require('worker_threads')` inside `WorkerScript` works
+even though the surrounding artifact is an ES module. (Verified directly on Node 25.)
+The worker's own module kind is independent of the parent's.
+
+### The test server must run in its own worker thread
+
+`Atomics.wait` blocks the **main thread's event loop**. A test HTTP server created
+in-process with `http.createServer` would never accept the connection — the client
+blocks the very loop the server needs. `NodeSyncHttpChannelTest` therefore runs its
+echo server inside a separate `worker_threads.Worker` and hands the port back through
+its own tiny `SharedArrayBuffer` + `Atomics` handshake. This is also why the tests do
+not (and should not) hit an external service like httpbin.org.
+
+### `redirect: 'manual'` in the worker fetch
+
+`DefaultHttpSyncClient` owns redirect handling (`followRedirects`, `maxRedirects`,
+method rewriting), so the worker fetch must not silently follow redirects. It sets
+`redirect: 'manual'`; Node's `fetch` (unlike browsers) exposes the real 3xx status and
+`Location` header on a manual redirect, which is what the client needs. This mirrors
+`FetchChannel`'s `RequestRedirect.manual`.
+
+### Timeouts: a single effective value, and the `Long` trap
+
+`fetch`'s `AbortController` cannot separate connect from read timeouts, so the channel
+computes one effective timeout — `readTimeoutMillis` if set, else `connectTimeoutMillis`
+— mirroring `JavaHttpChannel`, which applies `readTimeoutMillis` as the request timeout.
+
+Crucially: `HttpClientConfig.connect/readTimeoutMillis` are `Long`. Scala.js represents
+`Long` as a `RuntimeLong` object, **not** a JS number, so passing them straight into
+`js.Dynamic.literal` (or `Atomics.wait`'s timeout argument) silently produces a
+non-numeric value — the worker abort and the parent's safety-net `Atomics.wait` timeout
+both became no-ops. The effective timeout must be `.toInt` before crossing into JS.
+
+### Worker streams the body to bound memory
+
+The worker reads the response via `resp.body.getReader()` and aborts once the
+cumulative size exceeds `maxResponseBytes`, instead of materialising the whole body
+with `arrayBuffer()` first — otherwise a huge response OOMs the worker before the size
+check, and a worker crash leaves the parent blocked until the safety timeout.
+
+## Consequences
+
+- `HttpSyncClient` now works on all three platforms; `wvlet/wvlet` can use one API.
+- `HttpClientConfig.maxResponseBytes` (default 16 MB) caps the `SharedArrayBuffer`;
+  it is cross-platform config but only `NodeSyncHttpChannel` enforces it — other
+  channels ignore it.
+- Per-call worker spawn and a per-call 16 MB buffer allocation are known costs,
+  acceptable for the CLI/scripted use case that motivated this. Worker reuse / lazy
+  buffer growth are possible follow-ups if profiling shows they matter.
+- Requires Node 20.16+ for `process.getBuiltinModule` (older Node falls back to global
+  `require`, which only exists in CommonJS / `NoModule` builds).
+- The shared-buffer layout (`OffsetState/StatusOrErrLen/HeadersLen/BodyLen`,
+  `HeaderBytes`, `StatePending/Success/Error`) is a contract between Scala and the JS
+  worker string. The constants are defined once on the Scala side and interpolated into
+  `WorkerScript`; keep them single-sourced when changing the layout.

--- a/plans/2026-05-14-js-sync-http.md
+++ b/plans/2026-05-14-js-sync-http.md
@@ -14,8 +14,8 @@ sync HTTP client on JVM, Node, and Native to give its Trino client the same shap
 
 `NodeSyncHttpChannel` — `worker_threads` + `Atomics.wait` on a `SharedArrayBuffer`.
 Main thread blocks in `Atomics.wait`; a worker runs `await fetch(...)`, writes the
-response into the shared buffer, and `Atomics.notify`s the parent. Node.js only;
-browsers continue to throw with a message pointing at the async client.
+response into the shared buffer, and `Atomics.notify`s the parent. Works on Node.js,
+Bun, and Deno; browsers continue to throw with a message pointing at the async client.
 
 See `adr/2026-05-14-nodejs-sync-http.md` for the design rationale and the non-obvious
 points (they are the bulk of the value here).
@@ -47,8 +47,12 @@ These all came out of review (Gemini + Codex) and are captured in the ADR:
 4. **`redirect: 'manual'`** so `DefaultHttpSyncClient` keeps owning redirect handling.
 5. **Stream the worker response body** and abort past `maxResponseBytes` rather than
    buffering it all with `arrayBuffer()` (worker OOM risk).
-6. The eval'd worker string runs as CommonJS regardless of the parent module kind, so
-   `require(...)` inside `WorkerScript` is fine even though uni links as ESModule.
+6. **Worker uses `await import('node:worker_threads')`, not `require`.** Node's eval
+   workers are CommonJS (so `require` works), but Deno's are ESM and have no `require` —
+   `require('worker_threads')` there throws and the worker never notifies. Dynamic
+   `import('node:...')` works on Node, Bun, and Deno. With this, the channel was verified
+   end-to-end on all three runtimes (Bun and Deno both set `process.versions.node`, so
+   `isNode` already accepts them).
 
 ## Known follow-ups (not in this PR)
 

--- a/plans/2026-05-14-js-sync-http.md
+++ b/plans/2026-05-14-js-sync-http.md
@@ -1,0 +1,58 @@
+# Synchronous HTTP on Node.js
+
+PR: https://github.com/wvlet/uni/pull/546
+Branch: `feature/js-sync-http-20260514_114113`
+
+## Problem
+
+`HttpChannel.send` is synchronous, but `JSHttpChannelFactory.newChannel` threw
+`NotImplementedError` because JavaScript has no native sync HTTP. `wvlet/wvlet` needs a
+sync HTTP client on JVM, Node, and Native to give its Trino client the same shape as
+`DuckDB.execute`.
+
+## Solution
+
+`NodeSyncHttpChannel` — `worker_threads` + `Atomics.wait` on a `SharedArrayBuffer`.
+Main thread blocks in `Atomics.wait`; a worker runs `await fetch(...)`, writes the
+response into the shared buffer, and `Atomics.notify`s the parent. Node.js only;
+browsers continue to throw with a message pointing at the async client.
+
+See `adr/2026-05-14-nodejs-sync-http.md` for the design rationale and the non-obvious
+points (they are the bulk of the value here).
+
+## Files
+
+- `uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala` — new channel +
+  companion (`isNode`, lazy `worker_threads` loader, layout constants, `WorkerScript`).
+- `uni/.js/src/main/scala/wvlet/uni/http/JSHttpChannelFactory.scala` — `newChannel`
+  returns `NodeSyncHttpChannel()` on Node, throws on browsers.
+- `uni/src/main/scala/wvlet/uni/http/HttpClientConfig.scala` — added `maxResponseBytes`
+  (+ `withMaxResponseBytes`).
+- `uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala` — 5 tests
+  against an in-process echo server (run in its own worker thread).
+
+## Learnings from the PR cycle
+
+These all came out of review (Gemini + Codex) and are captured in the ADR:
+
+1. **A static `@JSImport("worker_threads")` breaks browser bundler builds** for the
+   whole library, since `JSHttpChannelFactory` is the default factory. Switched to a
+   runtime `process.getBuiltinModule` load (bundler-invisible, works in CJS + ESM).
+2. **`Long` config values do not cross into JS as numbers** — the timeout values were
+   `RuntimeLong` objects, so both the worker abort and the parent `Atomics.wait`
+   timeout were silently no-ops. Fixed by computing one effective `Int` timeout.
+3. **The test echo server must run in a separate worker thread** — `Atomics.wait`
+   blocks the main event loop, so an in-process same-thread server would deadlock.
+   This also replaced an initial httpbin.org dependency.
+4. **`redirect: 'manual'`** so `DefaultHttpSyncClient` keeps owning redirect handling.
+5. **Stream the worker response body** and abort past `maxResponseBytes` rather than
+   buffering it all with `arrayBuffer()` (worker OOM risk).
+6. The eval'd worker string runs as CommonJS regardless of the parent module kind, so
+   `require(...)` inside `WorkerScript` is fine even though uni links as ESModule.
+
+## Known follow-ups (not in this PR)
+
+- Per-call worker spawn and a per-call 16 MB buffer allocation — acceptable for the
+  CLI/scripted use case; worker reuse / lazy buffer growth if profiling demands it.
+- `process.getBuiltinModule` needs Node 20.16+ (older Node falls back to global
+  `require`, CJS only).

--- a/uni/.js/src/main/scala/wvlet/uni/http/JSHttpChannelFactory.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/JSHttpChannelFactory.scala
@@ -14,16 +14,24 @@
 package wvlet.uni.http
 
 /**
-  * JavaScript-specific HTTP channel factory using the Fetch API.
+  * JavaScript-specific HTTP channel factory.
   *
-  * Note: Synchronous HTTP is not supported in JavaScript. Use async client instead.
+  *   - `newAsyncChannel` uses the Fetch API (works in browsers and Node alike).
+  *   - `newChannel` (synchronous) uses `worker_threads` + `Atomics.wait` on a `SharedArrayBuffer`.
+  *     Node.js only — there is no recovery path for sync HTTP in modern browsers (sync XHR is
+  *     deprecated, and `worker_threads` doesn't exist on the web). On browser-like environments we
+  *     throw a `NotImplementedError` recommending the async client.
   */
 object JSHttpChannelFactory extends HttpChannelFactory:
 
   override def newChannel: HttpChannel =
-    throw NotImplementedError(
-      "Synchronous HTTP is not supported in JavaScript. Use Http.client.newAsyncClient instead."
-    )
+    if NodeSyncHttpChannel.isNode then
+      NodeSyncHttpChannel()
+    else
+      throw NotImplementedError(
+        "Synchronous HTTP is not supported in browser JavaScript. " +
+          "Use Http.client.newAsyncClient instead, or run on Node.js."
+      )
 
   override def newAsyncChannel: HttpAsyncChannel = FetchChannel()
 

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
@@ -182,6 +182,11 @@ end NodeSyncHttpChannel
 
 object NodeSyncHttpChannel:
 
+  // `worker_threads` is imported statically rather than lazily: Scala.js has no synchronous
+  // dynamic require, and a static import is exactly what Node ESModule consumers need. Trade-off:
+  // a *browser* ESModule bundle that links `JSHttpChannelFactory` (only to reach the browser
+  // `NotImplementedError` path) will fail to resolve this Node-only import at load time, so that
+  // fallback is never actually reached. That is acceptable — browsers never supported sync HTTP.
   @js.native
   @JSImport("worker_threads", JSImport.Namespace)
   private[http] val workerThreads: js.Dynamic = js.native
@@ -230,7 +235,10 @@ object NodeSyncHttpChannel:
 
     (async () => {
       try {
-        const init = { method, headers: new Headers(headers) };
+        // redirect: 'manual' so DefaultHttpSyncClient owns redirect handling
+        // (noFollowRedirects / maxRedirects / method rewriting), matching FetchChannel.
+        // Node's fetch exposes the real 3xx status + Location on a manual redirect.
+        const init = { method, headers: new Headers(headers), redirect: 'manual' };
         if (body !== undefined && body !== null) init.body = body;
         if (connectTimeoutMillis > 0 || readTimeoutMillis > 0) {
           const controller = new AbortController();

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
@@ -15,7 +15,6 @@ package wvlet.uni.http
 
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters.*
-import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.typedarray.*
 
 /**
@@ -34,14 +33,15 @@ import scala.scalajs.js.typedarray.*
   *   - Node.js only. Browser sync HTTP is unrecoverable (sync XHR is deprecated and
   *     `worker_threads` doesn't exist on the web). `JSHttpChannelFactory.newChannel` should detect
   *     non-Node environments and throw before constructing this channel.
-  *   - Response size is capped by the `SharedArrayBuffer` (default 16 MB). Larger responses surface
-  *     as `HttpException` from the worker.
+  *   - Response size is capped by the `SharedArrayBuffer` (`HttpClientConfig.maxResponseBytes`,
+  *     default 16 MB). Larger responses surface as `HttpException` from the worker.
   */
-class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends HttpChannel:
+class NodeSyncHttpChannel extends HttpChannel:
 
   import NodeSyncHttpChannel.*
 
   override def send(request: HttpRequest, config: HttpClientConfig): HttpResponse =
+    val maxResponseBytes = config.maxResponseBytes
     val sab       = js.Dynamic.newInstance(SharedArrayBufferCtor)(HeaderBytes + maxResponseBytes)
     val stateWord = Int32Array(sab.asInstanceOf[ArrayBuffer], OffsetState, 1)
 
@@ -193,14 +193,17 @@ object NodeSyncHttpChannel:
   // thread gives up waiting.
   private final val WorkerGraceMillis = 5000
 
-  // `worker_threads` is imported statically rather than lazily: Scala.js has no synchronous
-  // dynamic require, and a static import is exactly what Node ESModule consumers need. Trade-off:
-  // a *browser* ESModule bundle that links `JSHttpChannelFactory` (only to reach the browser
-  // `NotImplementedError` path) will fail to resolve this Node-only import at load time, so that
-  // fallback is never actually reached. That is acceptable — browsers never supported sync HTTP.
-  @js.native
-  @JSImport("worker_threads", JSImport.Namespace)
-  private[http] val workerThreads: js.Dynamic = js.native
+  // Load Node's `worker_threads` lazily at call time rather than via a static `@JSImport`.
+  // `process.getBuiltinModule` (Node 20.16+ / 22.3+) works in both CommonJS and ESM; the global
+  // `require` is the fallback for older Node / NoModule builds. Being a runtime call, this is
+  // invisible to browser bundlers — a browser bundle that links `JSHttpChannelFactory` still
+  // builds, and simply never reaches here because `isNode` is false.
+  private[http] def workerThreads: js.Dynamic =
+    val process = js.Dynamic.global.process
+    if !js.isUndefined(process) && !js.isUndefined(process.getBuiltinModule) then
+      process.applyDynamic("getBuiltinModule")("worker_threads")
+    else
+      js.Dynamic.global.applyDynamic("require")("worker_threads")
 
   /**
     * Detects Node by the presence of `process.versions.node`. Browser environments — including web
@@ -260,7 +263,28 @@ object NodeSyncHttpChannel:
           setTimeout(() => controller.abort(), timeoutMillis);
         }
         const resp = await fetch(uri, init);
-        const bodyBuf = new Uint8Array(await resp.arrayBuffer());
+
+        // Stream the body so an oversized response is rejected before it is fully buffered,
+        // rather than letting `arrayBuffer()` materialise it all and risk an OOM.
+        let bodyBuf = new Uint8Array(0);
+        if (resp.body) {
+          const reader = resp.body.getReader();
+          const parts = [];
+          let received = 0;
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            received += value.length;
+            if (received > maxResponseBytes) {
+              finishError(`response too large: exceeded ${maxResponseBytes} bytes`);
+              return;
+            }
+            parts.push(value);
+          }
+          bodyBuf = new Uint8Array(received);
+          let offset = 0;
+          for (const part of parts) { bodyBuf.set(part, offset); offset += part.length; }
+        }
 
         // Header list preserves duplicate keys.
         const headerList = [];

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters.*
+import scala.scalajs.js.annotation.JSImport
+
+/**
+  * Synchronous HTTP channel for Node.js, implemented via `worker_threads` + `Atomics.wait` on a
+  * `SharedArrayBuffer`. Node.js has no native sync HTTP API; this is the modern "wait until a
+  * worker signals" pattern that production libraries (e.g. `sync-fetch`) use internally.
+  *
+  * Flow:
+  *   - Main thread allocates a `SharedArrayBuffer`, spawns a `new Worker(code, { eval: true })`,
+  *     and calls `Atomics.wait` to block.
+  *   - Worker performs an async `fetch`, encodes the response into the shared buffer, then
+  *     `Atomics.notify`s the main thread.
+  *   - Main thread decodes the response and returns it synchronously.
+  *
+  * Limitations:
+  *   - Node.js only. Browser sync HTTP is unrecoverable (sync XHR is deprecated and
+  *     `worker_threads` doesn't exist on the web). `JSHttpChannelFactory.newChannel` should detect
+  *     non-Node environments and throw before constructing this channel.
+  *   - Response size is capped by the `SharedArrayBuffer` (default 16 MB). Larger responses surface
+  *     as `HttpException` from the worker.
+  */
+class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends HttpChannel:
+
+  import NodeSyncHttpChannel.*
+
+  override def send(request: HttpRequest, config: HttpClientConfig): HttpResponse =
+    // Shared buffer layout (little-endian):
+    //   [0..4)   stateWord (i32):    0 pending, 1 success, 2 error
+    //   [4..8)   statusOrErrLen:     on success — HTTP status; on error — error msg byte length
+    //   [8..12)  headersJsonLen:     length of headers-JSON UTF-8 bytes (success only)
+    //   [12..16) bodyLen:            length of body bytes (success only)
+    //   [16..)   headersJson || body (success) | errorMsg (error)
+    val headerBytes = 16
+    val sab         = js.Dynamic.newInstance(SharedArrayBufferCtor)(headerBytes + maxResponseBytes)
+    val stateWord   = js.Dynamic.newInstance(Int32ArrayCtor)(sab, 0, 1)
+
+    val requestData = js
+      .Dynamic
+      .literal(
+        method = request.method.name,
+        uri = request.fullUri,
+        headers =
+          request
+            .wireHeaders
+            .entries
+            .map { case (k, v) =>
+              js.Array(k, v)
+            }
+            .toJSArray,
+        body =
+          if request.content.isEmpty then
+            js.undefined
+          else
+            // Need a stable typed-array view — toTypedArray gives a fresh Uint8Array backed
+            // by an ArrayBuffer (not the shared one). The worker's `fetch` accepts it.
+            asUint8Array(request.content.toContentBytes)
+        ,
+        sab = sab,
+        connectTimeoutMillis = config.connectTimeoutMillis,
+        readTimeoutMillis = config.readTimeoutMillis,
+        maxBodyBytes = maxResponseBytes
+      )
+
+    val worker =
+      js.Dynamic
+        .newInstance(workerThreads.Worker)(
+          WorkerScript,
+          js.Dynamic.literal(eval = true, workerData = requestData)
+        )
+
+    try
+      // Block until the worker stores a non-zero value at stateWord[0]. `applyDynamic` is
+      // needed because plain `.wait(...)` resolves to `java.lang.Object.wait` on Scala 3.
+      js.Dynamic.global.Atomics.applyDynamic("wait")(stateWord, 0, 0)
+
+      val state = stateWord.selectDynamic("0").asInstanceOf[Int]
+
+      // DataView over the shared buffer for reading the small header (status, lengths).
+      val view = js.Dynamic.newInstance(DataViewCtor)(sab)
+
+      if state == 2 then
+        val errLen   = view.getInt32(4, true).asInstanceOf[Int]
+        val errBytes = readBytes(sab, headerBytes, errLen)
+        throw HttpException.connectionFailed(new String(errBytes, "UTF-8"))
+
+      if state != 1 then
+        throw HttpException.connectionFailed(s"worker returned unexpected state ${state}")
+
+      val status         = view.getInt32(4, true).asInstanceOf[Int]
+      val headersJsonLen = view.getInt32(8, true).asInstanceOf[Int]
+      val bodyLen        = view.getInt32(12, true).asInstanceOf[Int]
+
+      val headersJson = new String(readBytes(sab, headerBytes, headersJsonLen), "UTF-8")
+      val bodyBytes   = readBytes(sab, headerBytes + headersJsonLen, bodyLen)
+
+      val headers = decodeHeaders(headersJson)
+      val content =
+        if bodyBytes.isEmpty then
+          HttpContent.Empty
+        else
+          HttpContent.bytes(bodyBytes)
+      Response(HttpStatus.ofCode(status), headers, content)
+    finally
+      // Always terminate — Atomics.wait returns once the worker stores + notifies, but the
+      // Worker handle isn't garbage-collected until we explicitly terminate.
+      worker.terminate()
+    end try
+  end send
+
+  private def asUint8Array(bytes: Array[Byte]): js.Any =
+    val arr = js.Dynamic.newInstance(Uint8ArrayCtor)(bytes.length)
+    var i   = 0
+    while i < bytes.length do
+      arr.updateDynamic(i.toString)(bytes(i).toShort & 0xff)
+      i += 1
+    arr
+
+  private def readBytes(sab: js.Dynamic, offset: Int, length: Int): Array[Byte] =
+    if length == 0 then
+      Array.emptyByteArray
+    else
+      val u8    = js.Dynamic.newInstance(Uint8ArrayCtor)(sab, offset, length)
+      val bytes = new Array[Byte](length)
+      var i     = 0
+      while i < length do
+        bytes(i) = u8.selectDynamic(i.toString).asInstanceOf[Int].toByte
+        i += 1
+      bytes
+
+  private def decodeHeaders(json: String): HttpMultiMap =
+    // The worker serialises headers as a flat `[[k,v],[k,v],…]` array (not an object) so
+    // duplicate header names (e.g. multiple `Set-Cookie`) survive the round-trip.
+    val parsed  = js.JSON.parse(json).asInstanceOf[js.Array[js.Array[String]]]
+    val builder = HttpMultiMap.newBuilder
+    parsed.foreach { entry =>
+      builder.add(entry(0), entry(1))
+    }
+    builder.result()
+
+end NodeSyncHttpChannel
+
+object NodeSyncHttpChannel:
+
+  @js.native
+  @JSImport("worker_threads", JSImport.Namespace)
+  private[http] val workerThreads: js.Dynamic = js.native
+
+  /**
+    * Detects Node by the presence of `process.versions.node`. Browser environments — including web
+    * workers — lack it.
+    */
+  def isNode: Boolean =
+    !js.isUndefined(js.Dynamic.global.process) &&
+      !js.isUndefined(js.Dynamic.global.process.versions) &&
+      !js.isUndefined(js.Dynamic.global.process.versions.node)
+
+  // `SharedArrayBuffer`, `Atomics`, `DataView`, `Int32Array`, `Uint8Array` are all standard
+  // ES globals — accessed via js.Dynamic since scalajs-library doesn't ship typed bindings
+  // for SharedArrayBuffer / Atomics. Scala.js disallows loading `js.Dynamic.global` itself
+  // as a value, so resolve lazily on every reference.
+  private def SharedArrayBufferCtor = js.Dynamic.global.SharedArrayBuffer
+  private def Int32ArrayCtor        = js.Dynamic.global.Int32Array
+  private def Uint8ArrayCtor        = js.Dynamic.global.Uint8Array
+  private def DataViewCtor          = js.Dynamic.global.DataView
+
+  /**
+    * Worker source. Receives the request via `workerData`, performs an async fetch, encodes the
+    * response into the shared buffer, then calls `Atomics.notify` to wake the parent.
+    */
+  private val WorkerScript =
+    """
+    const { workerData } = require('worker_threads');
+    const { method, uri, headers, body, sab, connectTimeoutMillis, readTimeoutMillis, maxBodyBytes } = workerData;
+    const HEADER_BYTES = 16;
+    const stateView = new Int32Array(sab, 0, 1);
+    const ints = new DataView(sab);
+    const encoder = new TextEncoder();
+
+    function setI32(offset, value) { ints.setInt32(offset, value, true); }
+
+    function finishError(message) {
+      const bytes = encoder.encode(String(message));
+      const len = Math.min(bytes.length, sab.byteLength - HEADER_BYTES);
+      new Uint8Array(sab, HEADER_BYTES, len).set(bytes.subarray(0, len));
+      setI32(4, len);
+      Atomics.store(stateView, 0, 2);
+      Atomics.notify(stateView, 0);
+    }
+
+    (async () => {
+      try {
+        const init = { method, headers: new Headers(headers) };
+        if (body !== undefined && body !== null) init.body = body;
+        if (connectTimeoutMillis > 0 || readTimeoutMillis > 0) {
+          const controller = new AbortController();
+          init.signal = controller.signal;
+          const timeout = Math.max(connectTimeoutMillis, readTimeoutMillis);
+          if (timeout > 0) setTimeout(() => controller.abort(), timeout);
+        }
+        const resp = await fetch(uri, init);
+        const bodyBuf = new Uint8Array(await resp.arrayBuffer());
+
+        // Header list preserves duplicate keys.
+        const headerList = [];
+        resp.headers.forEach((v, k) => { headerList.push([k, v]); });
+        const headersJson = encoder.encode(JSON.stringify(headerList));
+
+        const totalLen = headersJson.length + bodyBuf.length;
+        if (totalLen > maxBodyBytes) {
+          finishError(`response too large: ${totalLen} > ${maxBodyBytes} bytes`);
+          return;
+        }
+
+        setI32(4, resp.status);
+        setI32(8, headersJson.length);
+        setI32(12, bodyBuf.length);
+        new Uint8Array(sab, HEADER_BYTES, headersJson.length).set(headersJson);
+        new Uint8Array(sab, HEADER_BYTES + headersJson.length, bodyBuf.length).set(bodyBuf);
+
+        Atomics.store(stateView, 0, 1);
+        Atomics.notify(stateView, 0);
+      } catch (e) {
+        finishError(e && e.stack ? e.stack : (e && e.message ? e.message : String(e)));
+      }
+    })();
+  """
+
+end NodeSyncHttpChannel

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
@@ -42,15 +42,8 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
   import NodeSyncHttpChannel.*
 
   override def send(request: HttpRequest, config: HttpClientConfig): HttpResponse =
-    // Shared buffer layout (little-endian):
-    //   [0..4)   stateWord (i32):    0 pending, 1 success, 2 error
-    //   [4..8)   statusOrErrLen:     on success — HTTP status; on error — error msg byte length
-    //   [8..12)  headersJsonLen:     length of headers-JSON UTF-8 bytes (success only)
-    //   [12..16) bodyLen:            length of body bytes (success only)
-    //   [16..)   headersJson || body (success) | errorMsg (error)
-    val headerBytes = 16
-    val sab         = js.Dynamic.newInstance(SharedArrayBufferCtor)(headerBytes + maxResponseBytes)
-    val stateWord   = js.Dynamic.newInstance(Int32ArrayCtor)(sab, 0, 1)
+    val sab       = js.Dynamic.newInstance(SharedArrayBufferCtor)(HeaderBytes + maxResponseBytes)
+    val stateWord = Int32Array(sab.asInstanceOf[ArrayBuffer], OffsetState, 1)
 
     val requestData = js
       .Dynamic
@@ -69,14 +62,14 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
           if request.content.isEmpty then
             js.undefined
           else
-            // Need a stable typed-array view — toTypedArray gives a fresh Uint8Array backed
-            // by an ArrayBuffer (not the shared one). The worker's `fetch` accepts it.
-            asUint8Array(request.content.toContentBytes)
+            // toTypedArray yields a fresh Int8Array backed by its own ArrayBuffer (not the
+            // shared one); the worker's `fetch` accepts any ArrayBufferView as a body.
+            request.content.toContentBytes.toTypedArray
         ,
         sab = sab,
         connectTimeoutMillis = config.connectTimeoutMillis,
         readTimeoutMillis = config.readTimeoutMillis,
-        maxBodyBytes = maxResponseBytes
+        maxResponseBytes = maxResponseBytes
       )
 
     val worker =
@@ -88,12 +81,17 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
 
     // Cap the wait with a safety timeout so a crashed or hung worker can't block the main
     // thread forever. The worker aborts its fetch at max(connect, read) timeout, so give it
-    // a 5s grace period on top of that before we give up. `js.undefined` means "wait forever"
-    // when no timeout is configured.
+    // a grace period on top of that before we give up. A non-positive value means no timeout
+    // is configured, so wait forever (`js.undefined`).
     val workerTimeoutMillis = math.max(config.connectTimeoutMillis, config.readTimeoutMillis)
-    val waitTimeout: js.Any =
+    val waitTimeoutMillis   =
       if workerTimeoutMillis > 0 then
-        workerTimeoutMillis + 5000
+        workerTimeoutMillis + WorkerGraceMillis
+      else
+        0
+    val waitTimeout: js.Any =
+      if waitTimeoutMillis > 0 then
+        waitTimeoutMillis
       else
         js.undefined
 
@@ -104,32 +102,31 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
         .Dynamic
         .global
         .Atomics
-        .applyDynamic("wait")(stateWord, 0, 0, waitTimeout)
+        .applyDynamic("wait")(stateWord, 0, StatePending, waitTimeout)
         .asInstanceOf[String]
       if waitResult == "timed-out" then
         throw HttpException.connectionFailed(
-          s"sync HTTP request timed out after ${workerTimeoutMillis + 5000} ms"
+          s"sync HTTP request timed out after ${waitTimeoutMillis} ms"
         )
 
-      val state = stateWord.selectDynamic("0").asInstanceOf[Int]
+      val state = stateWord(0)
 
       // DataView over the shared buffer for reading the small header (status, lengths).
-      val view = js.Dynamic.newInstance(DataViewCtor)(sab)
+      val view = DataView(sab.asInstanceOf[ArrayBuffer])
 
-      if state == 2 then
-        val errLen   = view.getInt32(4, true).asInstanceOf[Int]
-        val errBytes = readBytes(sab, headerBytes, errLen)
-        throw HttpException.connectionFailed(new String(errBytes, "UTF-8"))
+      if state == StateError then
+        val errLen = view.getInt32(OffsetStatusOrErrLen, littleEndian = true)
+        throw HttpException.connectionFailed(String(readBytes(sab, HeaderBytes, errLen), "UTF-8"))
 
-      if state != 1 then
+      if state != StateSuccess then
         throw HttpException.connectionFailed(s"worker returned unexpected state ${state}")
 
-      val status         = view.getInt32(4, true).asInstanceOf[Int]
-      val headersJsonLen = view.getInt32(8, true).asInstanceOf[Int]
-      val bodyLen        = view.getInt32(12, true).asInstanceOf[Int]
+      val status         = view.getInt32(OffsetStatusOrErrLen, littleEndian = true)
+      val headersJsonLen = view.getInt32(OffsetHeadersLen, littleEndian = true)
+      val bodyLen        = view.getInt32(OffsetBodyLen, littleEndian = true)
 
-      val headersJson = new String(readBytes(sab, headerBytes, headersJsonLen), "UTF-8")
-      val bodyBytes   = readBytes(sab, headerBytes + headersJsonLen, bodyLen)
+      val headersJson = String(readBytes(sab, HeaderBytes, headersJsonLen), "UTF-8")
+      val bodyBytes   = readBytes(sab, HeaderBytes + headersJsonLen, bodyLen)
 
       val headers = decodeHeaders(headersJson)
       val content =
@@ -145,28 +142,12 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
     end try
   end send
 
-  private def asUint8Array(bytes: Array[Byte]): js.Any =
-    // `.set` with a typed array does a bulk native copy; element-by-element `updateDynamic`
-    // with stringified indices is far slower in Scala.js. Int8 -> Uint8 wraps as expected.
-    val arr = js.Dynamic.newInstance(Uint8ArrayCtor)(bytes.length)
-    arr.set(bytes.toTypedArray)
-    arr
-
   private def readBytes(sab: js.Dynamic, offset: Int, length: Int): Array[Byte] =
     if length == 0 then
       Array.emptyByteArray
     else
-      // Cast to js.Array[Int] so the loop uses numeric indexing instead of stringified keys.
-      val u8 = js
-        .Dynamic
-        .newInstance(Uint8ArrayCtor)(sab, offset, length)
-        .asInstanceOf[js.Array[Int]]
-      val bytes = new Array[Byte](length)
-      var i     = 0
-      while i < length do
-        bytes(i) = u8(i).toByte
-        i += 1
-      bytes
+      // Int8Array view over the shared buffer; `.toArray` does a bulk copy into a JVM array.
+      Int8Array(sab.asInstanceOf[ArrayBuffer], offset, length).toArray
 
   private def decodeHeaders(json: String): HttpMultiMap =
     // The worker serialises headers as a flat `[[k,v],[k,v],…]` array (not an object) so
@@ -181,6 +162,27 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
 end NodeSyncHttpChannel
 
 object NodeSyncHttpChannel:
+
+  // Shared buffer layout (little-endian). The Scala side reads these; the worker writes them.
+  // The values are single-sourced into the worker via the constants block in WorkerScript.
+  //   [0..4)   state (i32):          StatePending / StateSuccess / StateError
+  //   [4..8)   statusOrErrLen (i32): HTTP status (success) | error-message byte length (error)
+  //   [8..12)  headersJsonLen (i32): headers-JSON UTF-8 byte length (success only)
+  //   [12..16) bodyLen (i32):        body byte length (success only)
+  //   [16..)   headersJson ++ body (success) | errorMessage (error)
+  private final val OffsetState          = 0
+  private final val OffsetStatusOrErrLen = 4
+  private final val OffsetHeadersLen     = 8
+  private final val OffsetBodyLen        = 12
+  private final val HeaderBytes          = 16
+
+  private final val StatePending = 0
+  private final val StateSuccess = 1
+  private final val StateError   = 2
+
+  // Extra time granted to the worker beyond its own fetch-abort timeout before the main
+  // thread gives up waiting.
+  private final val WorkerGraceMillis = 5000
 
   // `worker_threads` is imported statically rather than lazily: Scala.js has no synchronous
   // dynamic require, and a static import is exactly what Node ESModule consumers need. Trade-off:
@@ -200,24 +202,28 @@ object NodeSyncHttpChannel:
       !js.isUndefined(js.Dynamic.global.process.versions) &&
       !js.isUndefined(js.Dynamic.global.process.versions.node)
 
-  // `SharedArrayBuffer`, `Atomics`, `DataView`, `Int32Array`, `Uint8Array` are all standard
-  // ES globals — accessed via js.Dynamic since scalajs-library doesn't ship typed bindings
-  // for SharedArrayBuffer / Atomics. Scala.js disallows loading `js.Dynamic.global` itself
-  // as a value, so resolve lazily on every reference.
+  // `SharedArrayBuffer` has no typed binding in scalajs-library, so it's accessed via js.Dynamic.
+  // Scala.js disallows loading `js.Dynamic.global` itself as a value, so resolve it lazily.
   private def SharedArrayBufferCtor = js.Dynamic.global.SharedArrayBuffer
-  private def Int32ArrayCtor        = js.Dynamic.global.Int32Array
-  private def Uint8ArrayCtor        = js.Dynamic.global.Uint8Array
-  private def DataViewCtor          = js.Dynamic.global.DataView
 
   /**
     * Worker source. Receives the request via `workerData`, performs an async fetch, encodes the
-    * response into the shared buffer, then calls `Atomics.notify` to wake the parent.
+    * response into the shared buffer, then calls `Atomics.notify` to wake the parent. The leading
+    * constants block is interpolated from the Scala-side layout constants so the buffer contract
+    * stays single-sourced.
     */
   private val WorkerScript =
-    """
+    s"""
+    const HEADER_BYTES = ${HeaderBytes};
+    const OFF_STATUS = ${OffsetStatusOrErrLen};
+    const OFF_HEADERS_LEN = ${OffsetHeadersLen};
+    const OFF_BODY_LEN = ${OffsetBodyLen};
+    const STATE_SUCCESS = ${StateSuccess};
+    const STATE_ERROR = ${StateError};
+    """ +
+      """
     const { workerData } = require('worker_threads');
-    const { method, uri, headers, body, sab, connectTimeoutMillis, readTimeoutMillis, maxBodyBytes } = workerData;
-    const HEADER_BYTES = 16;
+    const { method, uri, headers, body, sab, connectTimeoutMillis, readTimeoutMillis, maxResponseBytes } = workerData;
     const stateView = new Int32Array(sab, 0, 1);
     const ints = new DataView(sab);
     const encoder = new TextEncoder();
@@ -228,8 +234,8 @@ object NodeSyncHttpChannel:
       const bytes = encoder.encode(String(message));
       const len = Math.min(bytes.length, sab.byteLength - HEADER_BYTES);
       new Uint8Array(sab, HEADER_BYTES, len).set(bytes.subarray(0, len));
-      setI32(4, len);
-      Atomics.store(stateView, 0, 2);
+      setI32(OFF_STATUS, len);
+      Atomics.store(stateView, 0, STATE_ERROR);
       Atomics.notify(stateView, 0);
     }
 
@@ -255,18 +261,18 @@ object NodeSyncHttpChannel:
         const headersJson = encoder.encode(JSON.stringify(headerList));
 
         const totalLen = headersJson.length + bodyBuf.length;
-        if (totalLen > maxBodyBytes) {
-          finishError(`response too large: ${totalLen} > ${maxBodyBytes} bytes`);
+        if (totalLen > maxResponseBytes) {
+          finishError(`response too large: ${totalLen} > ${maxResponseBytes} bytes`);
           return;
         }
 
-        setI32(4, resp.status);
-        setI32(8, headersJson.length);
-        setI32(12, bodyBuf.length);
+        setI32(OFF_STATUS, resp.status);
+        setI32(OFF_HEADERS_LEN, headersJson.length);
+        setI32(OFF_BODY_LEN, bodyBuf.length);
         new Uint8Array(sab, HEADER_BYTES, headersJson.length).set(headersJson);
         new Uint8Array(sab, HEADER_BYTES + headersJson.length, bodyBuf.length).set(bodyBuf);
 
-        Atomics.store(stateView, 0, 1);
+        Atomics.store(stateView, 0, STATE_SUCCESS);
         Atomics.notify(stateView, 0);
       } catch (e) {
         finishError(e && e.stack ? e.stack : (e && e.message ? e.message : String(e)));

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
@@ -45,6 +45,17 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
     val sab       = js.Dynamic.newInstance(SharedArrayBufferCtor)(HeaderBytes + maxResponseBytes)
     val stateWord = Int32Array(sab.asInstanceOf[ArrayBuffer], OffsetState, 1)
 
+    // A single overall request timeout. `fetch`'s AbortController can't separate connect from
+    // read, so mirror JavaHttpChannel (which applies readTimeoutMillis as the request timeout):
+    // prefer readTimeoutMillis, fall back to connectTimeoutMillis, 0 means no timeout.
+    val effectiveTimeoutMillis =
+      (
+        if config.readTimeoutMillis > 0 then
+          config.readTimeoutMillis
+        else
+          config.connectTimeoutMillis
+      ).toInt
+
     val requestData = js
       .Dynamic
       .literal(
@@ -67,8 +78,7 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
             request.content.toContentBytes.toTypedArray
         ,
         sab = sab,
-        connectTimeoutMillis = config.connectTimeoutMillis,
-        readTimeoutMillis = config.readTimeoutMillis,
+        timeoutMillis = effectiveTimeoutMillis,
         maxResponseBytes = maxResponseBytes
       )
 
@@ -80,13 +90,12 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
         )
 
     // Cap the wait with a safety timeout so a crashed or hung worker can't block the main
-    // thread forever. The worker aborts its fetch at max(connect, read) timeout, so give it
-    // a grace period on top of that before we give up. A non-positive value means no timeout
-    // is configured, so wait forever (`js.undefined`).
-    val workerTimeoutMillis = math.max(config.connectTimeoutMillis, config.readTimeoutMillis)
-    val waitTimeoutMillis   =
-      if workerTimeoutMillis > 0 then
-        workerTimeoutMillis + WorkerGraceMillis
+    // thread forever. The worker aborts its fetch at effectiveTimeoutMillis, so give it a
+    // grace period on top of that before we give up. 0 means no timeout was configured, so
+    // wait forever (`js.undefined`).
+    val waitTimeoutMillis =
+      if effectiveTimeoutMillis > 0 then
+        effectiveTimeoutMillis + WorkerGraceMillis
       else
         0
     val waitTimeout: js.Any =
@@ -220,10 +229,9 @@ object NodeSyncHttpChannel:
     const OFF_BODY_LEN = ${OffsetBodyLen};
     const STATE_SUCCESS = ${StateSuccess};
     const STATE_ERROR = ${StateError};
-    """ +
-      """
+    """ + """
     const { workerData } = require('worker_threads');
-    const { method, uri, headers, body, sab, connectTimeoutMillis, readTimeoutMillis, maxResponseBytes } = workerData;
+    const { method, uri, headers, body, sab, timeoutMillis, maxResponseBytes } = workerData;
     const stateView = new Int32Array(sab, 0, 1);
     const ints = new DataView(sab);
     const encoder = new TextEncoder();
@@ -246,11 +254,10 @@ object NodeSyncHttpChannel:
         // Node's fetch exposes the real 3xx status + Location on a manual redirect.
         const init = { method, headers: new Headers(headers), redirect: 'manual' };
         if (body !== undefined && body !== null) init.body = body;
-        if (connectTimeoutMillis > 0 || readTimeoutMillis > 0) {
+        if (timeoutMillis > 0) {
           const controller = new AbortController();
           init.signal = controller.signal;
-          const timeout = Math.max(connectTimeoutMillis, readTimeoutMillis);
-          if (timeout > 0) setTimeout(() => controller.abort(), timeout);
+          setTimeout(() => controller.abort(), timeoutMillis);
         }
         const resp = await fetch(uri, init);
         const bodyBuf = new Uint8Array(await resp.arrayBuffer());

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
@@ -16,6 +16,7 @@ package wvlet.uni.http
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters.*
 import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.typedarray.*
 
 /**
   * Synchronous HTTP channel for Node.js, implemented via `worker_threads` + `Atomics.wait` on a
@@ -85,10 +86,30 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
           js.Dynamic.literal(eval = true, workerData = requestData)
         )
 
+    // Cap the wait with a safety timeout so a crashed or hung worker can't block the main
+    // thread forever. The worker aborts its fetch at max(connect, read) timeout, so give it
+    // a 5s grace period on top of that before we give up. `js.undefined` means "wait forever"
+    // when no timeout is configured.
+    val workerTimeoutMillis = math.max(config.connectTimeoutMillis, config.readTimeoutMillis)
+    val waitTimeout: js.Any =
+      if workerTimeoutMillis > 0 then
+        workerTimeoutMillis + 5000
+      else
+        js.undefined
+
     try
       // Block until the worker stores a non-zero value at stateWord[0]. `applyDynamic` is
       // needed because plain `.wait(...)` resolves to `java.lang.Object.wait` on Scala 3.
-      js.Dynamic.global.Atomics.applyDynamic("wait")(stateWord, 0, 0)
+      val waitResult = js
+        .Dynamic
+        .global
+        .Atomics
+        .applyDynamic("wait")(stateWord, 0, 0, waitTimeout)
+        .asInstanceOf[String]
+      if waitResult == "timed-out" then
+        throw HttpException.connectionFailed(
+          s"sync HTTP request timed out after ${workerTimeoutMillis + 5000} ms"
+        )
 
       val state = stateWord.selectDynamic("0").asInstanceOf[Int]
 
@@ -125,22 +146,25 @@ class NodeSyncHttpChannel(maxResponseBytes: Int = 16 * 1024 * 1024) extends Http
   end send
 
   private def asUint8Array(bytes: Array[Byte]): js.Any =
+    // `.set` with a typed array does a bulk native copy; element-by-element `updateDynamic`
+    // with stringified indices is far slower in Scala.js. Int8 -> Uint8 wraps as expected.
     val arr = js.Dynamic.newInstance(Uint8ArrayCtor)(bytes.length)
-    var i   = 0
-    while i < bytes.length do
-      arr.updateDynamic(i.toString)(bytes(i).toShort & 0xff)
-      i += 1
+    arr.set(bytes.toTypedArray)
     arr
 
   private def readBytes(sab: js.Dynamic, offset: Int, length: Int): Array[Byte] =
     if length == 0 then
       Array.emptyByteArray
     else
-      val u8    = js.Dynamic.newInstance(Uint8ArrayCtor)(sab, offset, length)
+      // Cast to js.Array[Int] so the loop uses numeric indexing instead of stringified keys.
+      val u8 = js
+        .Dynamic
+        .newInstance(Uint8ArrayCtor)(sab, offset, length)
+        .asInstanceOf[js.Array[Int]]
       val bytes = new Array[Byte](length)
       var i     = 0
       while i < length do
-        bytes(i) = u8.selectDynamic(i.toString).asInstanceOf[Int].toByte
+        bytes(i) = u8(i).toByte
         i += 1
       bytes
 

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
@@ -18,9 +18,10 @@ import scala.scalajs.js.JSConverters.*
 import scala.scalajs.js.typedarray.*
 
 /**
-  * Synchronous HTTP channel for Node.js, implemented via `worker_threads` + `Atomics.wait` on a
-  * `SharedArrayBuffer`. Node.js has no native sync HTTP API; this is the modern "wait until a
-  * worker signals" pattern that production libraries (e.g. `sync-fetch`) use internally.
+  * Synchronous HTTP channel for Node-compatible runtimes, implemented via `worker_threads` +
+  * `Atomics.wait` on a `SharedArrayBuffer`. JavaScript has no native sync HTTP API; this is the
+  * modern "wait until a worker signals" pattern that production libraries (e.g. `sync-fetch`) use
+  * internally. Verified on Node.js, Bun, and Deno.
   *
   * Flow:
   *   - Main thread allocates a `SharedArrayBuffer`, spawns a `new Worker(code, { eval: true })`,
@@ -30,9 +31,10 @@ import scala.scalajs.js.typedarray.*
   *   - Main thread decodes the response and returns it synchronously.
   *
   * Limitations:
-  *   - Node.js only. Browser sync HTTP is unrecoverable (sync XHR is deprecated and
-  *     `worker_threads` doesn't exist on the web). `JSHttpChannelFactory.newChannel` should detect
-  *     non-Node environments and throw before constructing this channel.
+  *   - Requires a Node-compatible runtime (`worker_threads`, `SharedArrayBuffer`, `Atomics`).
+  *     Browser sync HTTP is unrecoverable (sync XHR is deprecated and `worker_threads` doesn't
+  *     exist on the web). `JSHttpChannelFactory.newChannel` detects browsers and throws before
+  *     constructing this channel.
   *   - Response size is capped by the `SharedArrayBuffer` (`HttpClientConfig.maxResponseBytes`,
   *     default 16 MB). Larger responses surface as `HttpException` from the worker.
   */
@@ -206,7 +208,8 @@ object NodeSyncHttpChannel:
       js.Dynamic.global.applyDynamic("require")("worker_threads")
 
   /**
-    * Detects Node by the presence of `process.versions.node`. Browser environments — including web
+    * True on a Node-compatible runtime, detected by `process.versions.node`. Bun and Deno both set
+    * it (they target Node compatibility) and run this channel fine; browsers — including web
     * workers — lack it.
     */
   def isNode: Boolean =
@@ -223,6 +226,10 @@ object NodeSyncHttpChannel:
     * response into the shared buffer, then calls `Atomics.notify` to wake the parent. The leading
     * constants block is interpolated from the Scala-side layout constants so the buffer contract
     * stays single-sourced.
+    *
+    * `workerData` is obtained via `await import('node:worker_threads')` rather than `require(...)`:
+    * Node's `eval` workers are CommonJS (so `require` works there), but Deno's `eval` workers are
+    * ESM and have no `require`. Dynamic `import('node:...')` works in Node, Bun, and Deno alike.
     */
   private val WorkerScript =
     s"""
@@ -233,24 +240,24 @@ object NodeSyncHttpChannel:
     const STATE_SUCCESS = ${StateSuccess};
     const STATE_ERROR = ${StateError};
     """ + """
-    const { workerData } = require('worker_threads');
-    const { method, uri, headers, body, sab, timeoutMillis, maxResponseBytes } = workerData;
-    const stateView = new Int32Array(sab, 0, 1);
-    const ints = new DataView(sab);
-    const encoder = new TextEncoder();
-
-    function setI32(offset, value) { ints.setInt32(offset, value, true); }
-
-    function finishError(message) {
-      const bytes = encoder.encode(String(message));
-      const len = Math.min(bytes.length, sab.byteLength - HEADER_BYTES);
-      new Uint8Array(sab, HEADER_BYTES, len).set(bytes.subarray(0, len));
-      setI32(OFF_STATUS, len);
-      Atomics.store(stateView, 0, STATE_ERROR);
-      Atomics.notify(stateView, 0);
-    }
-
     (async () => {
+      const { workerData } = await import('node:worker_threads');
+      const { method, uri, headers, body, sab, timeoutMillis, maxResponseBytes } = workerData;
+      const stateView = new Int32Array(sab, 0, 1);
+      const ints = new DataView(sab);
+      const encoder = new TextEncoder();
+
+      const setI32 = (offset, value) => ints.setInt32(offset, value, true);
+
+      const finishError = (message) => {
+        const bytes = encoder.encode(String(message));
+        const len = Math.min(bytes.length, sab.byteLength - HEADER_BYTES);
+        new Uint8Array(sab, HEADER_BYTES, len).set(bytes.subarray(0, len));
+        setI32(OFF_STATUS, len);
+        Atomics.store(stateView, 0, STATE_ERROR);
+        Atomics.notify(stateView, 0);
+      };
+
       try {
         // redirect: 'manual' so DefaultHttpSyncClient owns redirect handling
         // (noFollowRedirects / maxRedirects / method rewriting), matching FetchChannel.

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
@@ -84,6 +84,29 @@ class NodeSyncHttpChannelTest extends UniTest:
     }
   }
 
+  test("HttpSyncClient rejects a response larger than maxResponseBytes") {
+    withLocalServer { port =>
+      Http.setDefaultChannelFactory(JSHttpChannelFactory)
+      val client =
+        Http
+          .client
+          .withBaseUri(s"http://localhost:${port}")
+          .withMaxResponseBytes(8)
+          .newSyncClient
+          .noRetry
+      try
+        var thrown = false
+        try
+          client.send(Request(method = HttpMethod.GET, uri = "/get"))
+        catch
+          case _: Throwable =>
+            thrown = true
+        thrown shouldBe true
+      finally
+        client.close()
+    }
+  }
+
   /**
     * Runs `body` with a throwaway echo HTTP server bound to an ephemeral port. The server runs in
     * its own worker thread on purpose: the sync client blocks the main thread's event loop while

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
@@ -55,6 +55,35 @@ class NodeSyncHttpChannelTest extends UniTest:
     }
   }
 
+  test("HttpSyncClient aborts a stalled request at readTimeoutMillis") {
+    withLocalServer { port =>
+      Http.setDefaultChannelFactory(JSHttpChannelFactory)
+      val client =
+        Http
+          .client
+          .withBaseUri(s"http://localhost:${port}")
+          .withReadTimeoutMillis(500)
+          .newSyncClient
+          .noRetry
+      try
+        val start  = System.currentTimeMillis()
+        var thrown = false
+        try
+          client.send(Request(method = HttpMethod.GET, uri = "/slow"))
+        catch
+          case _: Throwable =>
+            thrown = true
+        val elapsed = System.currentTimeMillis() - start
+        info(s"stalled request aborted after ${elapsed}ms")
+        thrown shouldBe true
+        // The worker's own fetch abort fires near 500ms; well before the parent's
+        // safety-net wait (readTimeout + grace). A broken timeout would blow past this.
+        (elapsed < 4000) shouldBe true
+      finally
+        client.close()
+    }
+  }
+
   /**
     * Runs `body` with a throwaway echo HTTP server bound to an ephemeral port. The server runs in
     * its own worker thread on purpose: the sync client blocks the main thread's event loop while
@@ -92,6 +121,10 @@ object NodeSyncHttpChannelTest:
     const http = require('http');
     const state = new Int32Array(workerData, 0, 2);
     const server = http.createServer((req, res) => {
+      if (req.url === '/slow') {
+        // Never respond, so the client read timeout has to fire.
+        return;
+      }
       const chunks = [];
       req.on('data', (c) => chunks.push(c));
       req.on('end', () => {

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
@@ -15,34 +15,101 @@ package wvlet.uni.http
 
 import wvlet.uni.test.UniTest
 
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
 class NodeSyncHttpChannelTest extends UniTest:
 
   test("isNode returns true under Node") {
-    NodeSyncHttpChannel.isNode.shouldBe(true)
+    NodeSyncHttpChannel.isNode shouldBe true
   }
 
-  test("HttpSyncClient round-trips GET against httpbin.org") {
-    Http.setDefaultChannelFactory(JSHttpChannelFactory)
-    val client = Http.client.withBaseUri("https://httpbin.org").newSyncClient
-    try
-      val resp = client.send(Request(method = HttpMethod.GET, uri = "/get"))
-      info(s"status=${resp.status} bytes=${resp.content.toContentString.length}")
-      resp.status.code.shouldBe(200)
-      resp.content.toContentString.shouldContain("httpbin.org")
-    finally
-      client.close()
+  test("HttpSyncClient round-trips GET against a local server") {
+    withLocalServer { port =>
+      Http.setDefaultChannelFactory(JSHttpChannelFactory)
+      val client = Http.client.withBaseUri(s"http://localhost:${port}").newSyncClient
+      try
+        val resp = client.send(Request(method = HttpMethod.GET, uri = "/get"))
+        info(s"status=${resp.status} bytes=${resp.content.toContentString.length}")
+        resp.status.code shouldBe 200
+        resp.content.toContentString shouldContain "\"method\":\"GET\""
+        resp.content.toContentString shouldContain "\"url\":\"/get\""
+      finally
+        client.close()
+    }
   }
 
   test("HttpSyncClient round-trips POST with a JSON body") {
-    Http.setDefaultChannelFactory(JSHttpChannelFactory)
-    val client = Http.client.withBaseUri("https://httpbin.org").newSyncClient
-    try
-      val body = """{"hello": "world"}"""
-      val resp = client.send(Request(method = HttpMethod.POST, uri = "/post").withJsonContent(body))
-      resp.status.code.shouldBe(200)
-      resp.content.toContentString.shouldContain("\"hello\"")
-    finally
-      client.close()
+    withLocalServer { port =>
+      Http.setDefaultChannelFactory(JSHttpChannelFactory)
+      val client = Http.client.withBaseUri(s"http://localhost:${port}").newSyncClient
+      try
+        val body = """{"hello": "world"}"""
+        val resp = client.send(
+          Request(method = HttpMethod.POST, uri = "/post").withJsonContent(body)
+        )
+        resp.status.code shouldBe 200
+        resp.content.toContentString shouldContain "\"method\":\"POST\""
+        resp.content.toContentString shouldContain "\\\"hello\\\""
+      finally
+        client.close()
+    }
   }
+
+  /**
+    * Runs `body` with a throwaway echo HTTP server bound to an ephemeral port. The server runs in
+    * its own worker thread on purpose: the sync client blocks the main thread's event loop while
+    * waiting for a response, so a same-thread server could never accept the connection.
+    */
+  private def withLocalServer(body: Int => Unit): Unit =
+    import NodeSyncHttpChannelTest.*
+    // Shared buffer layout: [0] readiness flag, [1] assigned port.
+    val sab    = js.Dynamic.newInstance(js.Dynamic.global.SharedArrayBuffer)(8)
+    val state  = js.Dynamic.newInstance(js.Dynamic.global.Int32Array)(sab, 0, 2)
+    val worker =
+      js.Dynamic
+        .newInstance(workerThreads.Worker)(
+          ServerScript,
+          js.Dynamic.literal(eval = true, workerData = sab)
+        )
+    try
+      js.Dynamic.global.Atomics.applyDynamic("wait")(state, 0, 0, 10000)
+      val port = state.selectDynamic("1").asInstanceOf[Int]
+      (port > 0) shouldBe true
+      body(port)
+    finally
+      worker.terminate()
+
+end NodeSyncHttpChannelTest
+
+object NodeSyncHttpChannelTest:
+
+  @js.native
+  @JSImport("worker_threads", JSImport.Namespace)
+  private val workerThreads: js.Dynamic = js.native
+
+  /**
+    * Worker source for the test echo server. Listens on an ephemeral port, then reports the port
+    * back through the shared buffer and notifies the waiting main thread.
+    */
+  private val ServerScript = """
+    const { workerData } = require('worker_threads');
+    const http = require('http');
+    const state = new Int32Array(workerData, 0, 2);
+    const server = http.createServer((req, res) => {
+      const chunks = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        const reqBody = Buffer.concat(chunks).toString('utf-8');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ method: req.method, url: req.url, body: reqBody }));
+      });
+    });
+    server.listen(0, () => {
+      Atomics.store(state, 1, server.address().port);
+      Atomics.store(state, 0, 1);
+      Atomics.notify(state, 0);
+    });
+    """
 
 end NodeSyncHttpChannelTest

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.test.UniTest
+
+class NodeSyncHttpChannelTest extends UniTest:
+
+  test("isNode returns true under Node") {
+    NodeSyncHttpChannel.isNode.shouldBe(true)
+  }
+
+  test("HttpSyncClient round-trips GET against httpbin.org") {
+    Http.setDefaultChannelFactory(JSHttpChannelFactory)
+    val client = Http.client.withBaseUri("https://httpbin.org").newSyncClient
+    try
+      val resp = client.send(Request(method = HttpMethod.GET, uri = "/get"))
+      info(s"status=${resp.status} bytes=${resp.content.toContentString.length}")
+      resp.status.code.shouldBe(200)
+      resp.content.toContentString.shouldContain("httpbin.org")
+    finally
+      client.close()
+  }
+
+  test("HttpSyncClient round-trips POST with a JSON body") {
+    Http.setDefaultChannelFactory(JSHttpChannelFactory)
+    val client = Http.client.withBaseUri("https://httpbin.org").newSyncClient
+    try
+      val body = """{"hello": "world"}"""
+      val resp = client.send(Request(method = HttpMethod.POST, uri = "/post").withJsonContent(body))
+      resp.status.code.shouldBe(200)
+      resp.content.toContentString.shouldContain("\"hello\"")
+    finally
+      client.close()
+  }
+
+end NodeSyncHttpChannelTest

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeSyncHttpChannelTest.scala
@@ -16,7 +16,6 @@ package wvlet.uni.http
 import wvlet.uni.test.UniTest
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSImport
 
 class NodeSyncHttpChannelTest extends UniTest:
 
@@ -68,7 +67,7 @@ class NodeSyncHttpChannelTest extends UniTest:
     val state  = js.Dynamic.newInstance(js.Dynamic.global.Int32Array)(sab, 0, 2)
     val worker =
       js.Dynamic
-        .newInstance(workerThreads.Worker)(
+        .newInstance(NodeSyncHttpChannel.workerThreads.Worker)(
           ServerScript,
           js.Dynamic.literal(eval = true, workerData = sab)
         )
@@ -83,10 +82,6 @@ class NodeSyncHttpChannelTest extends UniTest:
 end NodeSyncHttpChannelTest
 
 object NodeSyncHttpChannelTest:
-
-  @js.native
-  @JSImport("worker_threads", JSImport.Namespace)
-  private val workerThreads: js.Dynamic = js.native
 
   /**
     * Worker source for the test echo server. Listens on an ephemeral port, then reports the port

--- a/uni/src/main/scala/wvlet/uni/http/HttpClientConfig.scala
+++ b/uni/src/main/scala/wvlet/uni/http/HttpClientConfig.scala
@@ -25,6 +25,9 @@ case class HttpClientConfig(
     readTimeoutMillis: Long = 60000,
     followRedirects: Boolean = true,
     maxRedirects: Int = 10,
+    // Upper bound on a single response size. Currently enforced only by the Node.js sync HTTP
+    // channel, which must size a fixed SharedArrayBuffer up front; other channels ignore it.
+    maxResponseBytes: Int = 16 * 1024 * 1024,
     retryContext: RetryContext =
       Retry
         .withBackOff(maxRetry = 3, initialIntervalMillis = 1000, maxIntervalMillis = 30000)
@@ -42,6 +45,8 @@ case class HttpClientConfig(
   def noFollowRedirects: HttpClientConfig   = copy(followRedirects = false)
 
   def withMaxRedirects(max: Int): HttpClientConfig = copy(maxRedirects = max)
+
+  def withMaxResponseBytes(bytes: Int): HttpClientConfig = copy(maxResponseBytes = bytes)
 
   def withRetryContext(ctx: RetryContext): HttpClientConfig = copy(retryContext = ctx)
   def noRetry: HttpClientConfig = copy(retryContext = retryContext.noRetry)


### PR DESCRIPTION
## Summary

`HttpSyncClient` on Scala.js previously threw `NotImplementedError` because JavaScript has no native sync HTTP API. This adds a real implementation using the **`worker_threads` + `Atomics.wait` on `SharedArrayBuffer`** pattern that production libraries like [`sync-fetch`](https://www.npmjs.com/package/sync-fetch) use internally — no external deps, no spawn-per-request `curl` shell-out, no `deasync` libuv hacks.

Verified end-to-end on **Node.js, Bun, and Deno**.

## How it works

1. Main thread allocates a `SharedArrayBuffer` (16-byte header + body region) and spawns a worker via `new Worker(code, { eval: true })`, passing the request through `workerData`.
2. Worker obtains `workerData` via `await import('node:worker_threads')`, performs `await fetch(...)`, streams the response body, and encodes status / headers (a flat `[[k,v],…]` list to preserve duplicates) / body into the shared buffer, then `Atomics.store` + `Atomics.notify`.
3. Main thread is blocked in `Atomics.wait`; once notified it decodes the buffer and returns `HttpResponse` synchronously.

## API changes

- New `NodeSyncHttpChannel` class implementing `HttpChannel`.
- `JSHttpChannelFactory.newChannel` returns `NodeSyncHttpChannel()` on a Node-compatible runtime (`process.versions.node` present — Bun and Deno set it too) and throws a clearer error in browsers.
- New `NodeSyncHttpChannel.isNode: Boolean` helper.
- New `HttpClientConfig.maxResponseBytes` (+ `withMaxResponseBytes`) — caps the `SharedArrayBuffer` size, configurable through the standard `Http.client.…newSyncClient` path. Cross-platform field; only `NodeSyncHttpChannel` enforces it.

## Design notes (see `adr/2026-05-14-nodejs-sync-http.md`)

- **`worker_threads` is loaded at runtime via `process.getBuiltinModule`**, not a static `@JSImport`. A static import is emitted into every browser bundle that links the default `JSHttpChannelFactory` and breaks browser bundler builds; a runtime call is invisible to bundlers.
- **The worker uses `await import('node:worker_threads')`**, not `require` — Node's eval workers are CommonJS but Deno's are ESM; dynamic `import('node:…')` works on all three.
- **`redirect: 'manual'`** so `DefaultHttpSyncClient` keeps owning redirect handling, matching `FetchChannel`.
- **One effective timeout** (`readTimeoutMillis`, falling back to `connectTimeoutMillis`), mirroring `JavaHttpChannel` — `fetch`'s `AbortController` can't separate connect from read. Timeout values are converted to `Int` because Scala.js `Long` doesn't cross into JS as a number.
- **The worker streams the body** and aborts past `maxResponseBytes` rather than buffering it all with `arrayBuffer()` (worker OOM guard).

## Tests

5 tests in `NodeSyncHttpChannelTest`, run against an in-process echo server (spawned in its own worker thread, since `Atomics.wait` blocks the main event loop):

- `isNode returns true under Node`
- GET / POST round-trips against the local server
- stalled request aborts at `readTimeoutMillis`
- response larger than `maxResponseBytes` is rejected

## Limitations

- **Node-compatible runtimes only.** Browsers can't do sync HTTP (sync XHR is deprecated, `worker_threads` doesn't exist on the web); `JSHttpChannelFactory.newChannel` throws a helpful error there.
- **Response capped by the shared buffer** (`HttpClientConfig.maxResponseBytes`, default 16 MB).
- **Per-call worker spawn + per-call buffer allocation.** Acceptable for the CLI / scripted use case; worker reuse / lazy buffer growth are possible follow-ups.
- **`process.getBuiltinModule` needs Node 20.16+** (older Node falls back to the global `require`).

## Motivating use case

[`wvlet/wvlet`](https://github.com/wvlet/wvlet) needs a sync Trino HTTP client that works cross-platform (JVM, Node, Native) to match its `DuckDB.execute` shape. With this, the Trino client can use the same `HttpSyncClient` API on all platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
