### PR TITLE
feature: Add cross-platform HTTP server abstraction with Node.js backend

### DIFF
--- a/docs/http/router.md
+++ b/docs/http/router.md
@@ -180,7 +180,7 @@ Paths are parsed into components:
 Add filters that apply to all routes in a router:
 
 ```scala
-import wvlet.uni.http.netty.RxHttpFilter
+import wvlet.uni.http.RxHttpFilter
 
 class AuthFilter extends RxHttpFilter:
   def apply(request: Request, next: RxHttpHandler): Rx[Response] =

--- a/plans/2026-06-18-cross-platform-http-server.md
+++ b/plans/2026-06-18-cross-platform-http-server.md
@@ -149,6 +149,17 @@ cross-project `.js` tree alongside `FetchChannel`/`NodeSyncHttpChannel`.
 - `start[A](block)` lives on the shared trait; backends override only `start(): HttpServer` with a
   covariant return type (`NettyHttpServer` / `NodeHttpServer`). Netty's previous bespoke
   `start[A](block)` and `effectiveHandler` were removed in favor of the shared ones.
+- Readiness was promoted to a first-class cross-platform concept (`HttpServer.whenReady: Rx[...]`,
+  `HttpServerConfig.startAndAwait`) after review: Netty completes immediately (sync bind), Node on
+  the `listening` event. The sync `start[A](block)` is documented as safe only for sync-binding
+  backends.
+- **Node hardening (from `/code-review` + Gemini):** wrap the whole synchronous request-init in
+  try/catch (unknown verb → 400, other init errors → 500) so a bad request can't crash the process;
+  register `server.on("error")` so a bind failure fails `whenReady` instead of crashing/hanging;
+  guard double-start with a synchronous `started` flag; guard the async response write; cancel the
+  SSE `response.events` subscription on the client `close` event; and make `startAndAwait` stop the
+  server on stream *termination* (incl. zero-emission completion) rather than per emitted value
+  (`tapOn` does not fire on `OnCompletion`, so an `Rx.empty` block would otherwise leak the server).
 
 ## Out of scope (follow-up PRs)
 - WebSocket handlers/routes (server + cross-platform client).

--- a/plans/2026-06-18-cross-platform-http-server.md
+++ b/plans/2026-06-18-cross-platform-http-server.md
@@ -1,0 +1,158 @@
+# Cross-Platform HTTP Server Foundation (toward WebSocket support)
+
+## Context
+
+Airframe recently added WebSocket support — but only **server-side, JVM/Netty-only**. We want WebSocket
+in Uni too, and ideally cross-platform. A WebSocket server is an HTTP server with an `Upgrade` handshake,
+so a cross-platform WS server is impossible without a cross-platform HTTP server first.
+
+Today Uni's HTTP **server** lives entirely in the JVM-only `uni-netty` module; the core server contract
+(`RxHttpHandler`/`RxHttpFilter`, `Request => Rx[Response]`) is trapped inside that module. JS and Native
+only have HTTP **clients**. Airframe never made its server cross-platform either — but it *did* make the
+server *abstraction* (lifecycle trait + handler/filter contract) reusable across backends.
+
+**This PR delivers the foundation, not WebSocket itself:**
+1. Lift the server abstraction (`HttpServer`, `RxHttpHandler`, `RxHttpFilter`, `HttpServerConfig`) into the
+   shared `uni` cross-project.
+2. Refactor `uni-netty` to implement the shared abstraction (JVM backend, behavior unchanged).
+3. Add a **real Node.js (Scala.js) HTTP server backend** via `http.createServer`, proving the seam is
+   genuinely cross-platform.
+
+Long-term goal is **JVM + Node + eventual Native** (posix sockets). WebSocket and the Native server are
+explicit follow-up PRs; the abstraction here is designed to accommodate both.
+
+## Design
+
+### 1. Shared abstraction — `uni/src/main/scala/wvlet/uni/http/`
+
+**Move** (from `uni-netty`, package `wvlet.uni.http.netty` → shared, package `wvlet.uni.http`):
+- `RxHttpHandler.scala` (`RxHttpHandler` + `RxHttpFilter`, currently `uni-netty/.../netty/RxHttpHandler.scala`).
+  These are pure (`Request`/`Response`/`Rx` only) and already compile everywhere. Update all `uni-netty`
+  imports accordingly.
+
+**Add** `HttpServer.scala` — platform-neutral lifecycle trait:
+```scala
+trait HttpServer extends AutoCloseable:
+  def localAddress: String   // "host:port"
+  def localPort: Int
+  def isRunning: Boolean
+  def stop(): Unit
+  def awaitTermination(): Unit
+  override def close(): Unit = stop()
+```
+
+**Add** `HttpServerConfig.scala` — shared trait factoring the common config surface + the filter-chaining
+logic currently duplicated as `NettyHttpServer.effectiveHandler`:
+```scala
+trait HttpServerConfig:
+  def name: String
+  def host: String
+  def port: Int
+  def handler: RxHttpHandler
+  def filters: Seq[RxHttpFilter]
+
+  // lifted from NettyHttpServer.effectiveHandler — reused by every backend
+  def effectiveHandler: RxHttpHandler =
+    if filters.isEmpty then handler
+    else
+      val chained = RxHttpFilter.chain(filters)
+      RxHttpHandler(request => chained.apply(request, handler))
+
+  def start(): HttpServer                    // backend-specific (covariant return)
+  def start[A](block: HttpServer => A): A =  // shared convenience
+    val s = start(); try block(s) finally s.stop()
+```
+
+### 2. JVM backend — refactor `uni-netty` (behavior unchanged)
+- `NettyServerConfig extends HttpServerConfig` (it already has `name/host/port/handler/filters`); drop its
+  bespoke handler-chaining and reuse the shared `effectiveHandler`. Keep all Netty-specific knobs
+  (`maxContentLength`, `useNativeTransport`, graceful-shutdown, `handlerExecutorThreads`, …) and
+  `start()` overriding with covariant return `NettyHttpServer`.
+- `NettyHttpServer extends HttpServer`: implement `localAddress: String` as `s"${host}:${port}"` (keep the
+  existing `InetSocketAddress`-typed accessor as a private/separate method); `localPort`, `isRunning`,
+  `stop`, `awaitTermination` already exist.
+- Files: `uni-netty/.../netty/{NettyServer,NettyHttpServer}.scala`, import fixes in
+  `NettyRequestHandler.scala`, `RouterHandler.scala`, `RPCHandler.scala`.
+
+### 3. JS (Node) backend — NEW, `uni/.js/src/main/scala/wvlet/uni/http/`
+- `NodeServer.scala`: `object NodeServer` entry + `case class NodeServerConfig extends HttpServerConfig`
+  mirroring NettyServer's common builders (`withName/withHost/withPort/withHandler/withRxHandler/withFilter/
+  withFilters`, `start()/start(block)`).
+- `NodeHttpServer.scala`: `class NodeHttpServer extends HttpServer`, backed by Node's built-in `http`:
+  - Load `http` lazily via `getBuiltinModule("http")` with `require("http")` fallback — reuse the exact
+    pattern in `NodeSyncHttpChannel.workerThreads` (`uni/.js/.../NodeSyncHttpChannel.scala:203`). Factor it
+    into a tiny shared `NodeModules.builtin(name)` helper to avoid duplication.
+  - `http.createServer((req, res) => …)`: collect the body via `req.on("data")`/`req.on("end")` into a
+    `Buffer` → `Array[Byte]`, build a uni `Request` (method, url→uri, headers).
+  - Run `config.effectiveHandler.handle(request): Rx[Response]`, consume with `RxRunner.runOnce`
+    (`wvlet.uni.rx.RxRunner`, cross-platform). On `OnNext(resp)`:
+    - if `resp.isEventStream`: `res.writeHead(200, text/event-stream + chunked)`, subscribe
+      `resp.events` via `RxRunner.run`, `res.write` each formatted SSE event, `res.end` on completion —
+      mirrors `NettyRequestHandler`'s SSE branch (`NettyRequestHandler.scala:79-160`).
+    - else: `res.writeHead(status, headers)` + `res.end(bodyBytes)`.
+  - `server.listen(port, host)`; `localPort` reads `server.address().port` (so `withPort(0)` ephemeral
+    binding works); `stop()` → `server.close()`; `awaitTermination()` is a no-op (Node's event loop keeps
+    the process alive while listening — documented); `isRunning` via a plain `var` (JS is single-threaded).
+
+### 4. Designed-for-future (no code this PR, captured as comments/notes)
+- **WebSocket** (next PR): both backends already expose an upgrade seam — Netty pipeline mutation in
+  `NettyRequestHandler` (the SSE branch is the precedent), and Node `server.on("upgrade", …)`. WS will add
+  shared `WebSocketHandler`/`WebSocketContext` traits + a `webSocketRoutes` list on `HttpServerConfig`,
+  registered separately from the RPC router (matching airframe's design).
+- **Native server** (later): implement `HttpServer` over posix sockets. The abstraction deliberately
+  assumes neither Netty nor Node specifics so a `NativeHttpServer` slots in.
+
+## Files
+
+| Action | Path |
+|---|---|
+| Move + repackage | `uni-netty/.../netty/RxHttpHandler.scala` → `uni/src/main/scala/wvlet/uni/http/RxHttpHandler.scala` |
+| Add | `uni/src/main/scala/wvlet/uni/http/HttpServer.scala` |
+| Add | `uni/src/main/scala/wvlet/uni/http/HttpServerConfig.scala` |
+| Refactor | `uni-netty/.../netty/{NettyServer,NettyHttpServer,NettyRequestHandler,RouterHandler,RPCHandler}.scala` (imports + trait impl) |
+| Add | `uni/.js/src/main/scala/wvlet/uni/http/{NodeServer,NodeHttpServer}.scala` |
+| Add | `uni/.js/src/main/scala/wvlet/uni/http/NodeModules.scala` (builtin-module loader helper) |
+| Add | `uni/.js/src/test/scala/wvlet/uni/http/NodeServerTest.scala` |
+
+No new sbt module; no new dependencies (Node `http` is built-in). `NodeServer` lives in the existing `uni`
+cross-project `.js` tree alongside `FetchChannel`/`NodeSyncHttpChannel`.
+
+## Verification
+
+- `./sbt scalafmtAll` then `./sbt compile` (compiles JVM/JS/Native).
+- `./sbt nettyJVM/test` (or the netty module's test task) — **existing `NettyServerTest` must pass
+  unchanged**, proving the JVM refactor is behavior-preserving.
+- New `uni/.js` test `NodeServerTest`: start `NodeServer.withPort(0).withRxHandler(...).start { server => … }`,
+  then hit it with the **async** `FetchChannel` client
+  (`Http.client.withBaseUri(s"http://localhost:${server.localPort}").newAsyncClient`) — async, not sync,
+  because `NodeSyncHttpChannel` blocks the event loop and would deadlock against an in-process server.
+  Assert: GET returns body+status, POST echoes the body, request/response headers round-trip, unmatched
+  path → 404 (default handler). Run via `./sbt uniJS/test` (the JS test env is NodeJS, which can bind ports —
+  `NodeSyncHttpChannelTest` already spins up a Node server in tests).
+- `./sbt test` for the full cross-platform suite before pushing.
+
+## Implementation notes / learnings
+
+- **Scala 3 does not auto-import enclosing-package members.** Moving `RxHttpHandler`/`RxHttpFilter`
+  from `wvlet.uni.http.netty` up to `wvlet.uni.http` required adding explicit imports in every netty
+  file that names them (`NettyServer`, `NettyRequestHandler`, `RouterHandler`, `RPCHandler`, and the
+  test) — a flat `package a.b.c` clause does not bring `a.b` members into scope.
+- **Node's socket bind is asynchronous**, so `server.address()` returns null until the `listening`
+  event fires. The shared `HttpServerConfig.start()` is synchronous and returns immediately; reading
+  `localPort` or connecting before readiness fails. Resolved with `NodeHttpServer.whenReady: Rx[...]`
+  (backed by a `Promise` completed in the listen callback) and the `NodeServerConfig.startAndAwait`
+  convenience. This is the key cross-platform impedance mismatch — the abstraction is sync, one
+  backend binds async.
+- **Node rejects `Int8Array` response bodies.** `Array[Byte].toTypedArray` yields an `Int8Array`, but
+  `res.end(...)` requires `string`/`Buffer`/`Uint8Array`. Fixed by viewing the bytes as a `Uint8Array`
+  over the same buffer (`toUint8Array`).
+- `start[A](block)` lives on the shared trait; backends override only `start(): HttpServer` with a
+  covariant return type (`NettyHttpServer` / `NodeHttpServer`). Netty's previous bespoke
+  `start[A](block)` and `effectiveHandler` were removed in favor of the shared ones.
+
+## Out of scope (follow-up PRs)
+- WebSocket handlers/routes (server + cross-platform client).
+- Scala Native HTTP server.
+- A unified `Http.server` auto-resolving factory (JVM's Netty backend lives in a separate module from
+  `uni/.jvm`, so a compile-time default would be circular; explicit `NettyServer`/`NodeServer` entry points
+  are used instead, which also matches how `uni-netty` is already consumed).

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyHttpServer.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyHttpServer.scala
@@ -30,6 +30,7 @@ import io.netty.handler.stream.ChunkedWriteHandler
 import io.netty.util.concurrent.DefaultEventExecutorGroup
 import wvlet.uni.http.HttpServer
 import wvlet.uni.log.LogSupport
+import wvlet.uni.rx.Rx
 import wvlet.uni.util.ThreadUtil
 
 import java.net.InetSocketAddress
@@ -218,6 +219,10 @@ class NettyHttpServer(config: NettyServerConfig) extends HttpServer with LogSupp
       channel.closeFuture().sync()
 
   override def isRunning: Boolean = started.get() && !stopped.get()
+
+  // Netty binds synchronously in start() (bootstrap.bind(...).sync()), so the server is ready as
+  // soon as this instance is returned.
+  override def whenReady: Rx[HttpServer] = Rx.single(this)
 
   /**
     * The bound socket address. JVM-specific accessor exposing the underlying `InetSocketAddress`.

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyHttpServer.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyHttpServer.scala
@@ -28,6 +28,7 @@ import io.netty.handler.codec.http.{
 }
 import io.netty.handler.stream.ChunkedWriteHandler
 import io.netty.util.concurrent.DefaultEventExecutorGroup
+import wvlet.uni.http.HttpServer
 import wvlet.uni.log.LogSupport
 import wvlet.uni.util.ThreadUtil
 
@@ -38,7 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
   * Netty-based HTTP server implementation
   */
-class NettyHttpServer(config: NettyServerConfig) extends LogSupport:
+class NettyHttpServer(config: NettyServerConfig) extends HttpServer with LogSupport:
   private var bossGroup: EventLoopGroup                               = null
   private var workerGroup: EventLoopGroup                             = null
   private var handlerExecutorGroup: Option[DefaultEventExecutorGroup] = None
@@ -55,15 +56,6 @@ class NettyHttpServer(config: NettyServerConfig) extends LogSupport:
 
   @volatile
   private var shutdownHook: Option[Thread] = None
-
-  private def effectiveHandler: RxHttpHandler =
-    if config.filters.isEmpty then
-      config.handler
-    else
-      val chained = RxHttpFilter.chain(config.filters)
-      RxHttpHandler { request =>
-        chained.apply(request, config.handler)
-      }
 
   def start(): Unit =
     if stopped.get() then
@@ -96,7 +88,7 @@ class NettyHttpServer(config: NettyServerConfig) extends LogSupport:
         )
       }
 
-    val handler = effectiveHandler
+    val handler = config.effectiveHandler
 
     val bootstrap = ServerBootstrap()
     bootstrap
@@ -142,7 +134,7 @@ class NettyHttpServer(config: NettyServerConfig) extends LogSupport:
 
   end start
 
-  def stop(): Unit =
+  override def stop(): Unit =
     if !stopped.compareAndSet(false, true) then
       return
 
@@ -221,19 +213,26 @@ class NettyHttpServer(config: NettyServerConfig) extends LogSupport:
     shutdownHook = None
   }
 
-  def awaitTermination(): Unit =
+  override def awaitTermination(): Unit =
     if channel != null then
       channel.closeFuture().sync()
 
-  def isRunning: Boolean = started.get() && !stopped.get()
+  override def isRunning: Boolean = started.get() && !stopped.get()
 
-  def localAddress: InetSocketAddress =
+  /**
+    * The bound socket address. JVM-specific accessor exposing the underlying `InetSocketAddress`.
+    */
+  def localSocketAddress: InetSocketAddress =
     if channel != null then
       channel.localAddress().asInstanceOf[InetSocketAddress]
     else
       InetSocketAddress(config.host, config.port)
 
-  def localPort: Int = localAddress.getPort
+  override def localAddress: String =
+    val addr = localSocketAddress
+    s"${addr.getHostString}:${addr.getPort}"
+
+  override def localPort: Int = localSocketAddress.getPort
 
 end NettyHttpServer
 

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyRequestHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyRequestHandler.scala
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.{
   LastHttpContent
 }
 import wvlet.uni.http.{
-  ContentType,
   HttpContent,
   HttpHeader,
   HttpMethod,
@@ -196,12 +195,7 @@ class NettyRequestHandler(handler: RxHttpHandler, sseExecutor: ExecutorService)
       if buf.readableBytes() > 0 then
         val bytes = new Array[Byte](buf.readableBytes())
         buf.readBytes(bytes)
-        val ct = headersBuilder
-          .result()
-          .get(HttpHeader.ContentType)
-          .flatMap(ContentType.parse)
-          .getOrElse(ContentType.ApplicationOctetStream)
-        HttpContent.bytes(bytes, ct)
+        HttpContent.fromBytes(bytes, headersBuilder.result())
       else
         HttpContent.Empty
 

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyRequestHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyRequestHandler.scala
@@ -36,6 +36,7 @@ import wvlet.uni.http.{
   HttpStatus,
   Request,
   Response,
+  RxHttpHandler,
   ServerSentEvent
 }
 import wvlet.uni.log.LogSupport

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyServer.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/NettyServer.scala
@@ -13,7 +13,14 @@
  */
 package wvlet.uni.http.netty
 
-import wvlet.uni.http.{HttpHandler, Request, Response}
+import wvlet.uni.http.{
+  HttpHandler,
+  HttpServerConfig,
+  Request,
+  Response,
+  RxHttpFilter,
+  RxHttpHandler
+}
 import wvlet.uni.rx.Rx
 
 import java.net.InetSocketAddress
@@ -61,7 +68,7 @@ case class NettyServerConfig(
     // Set this to match expected concurrent long-running requests (e.g., upstream
     // proxy calls) to prevent them from starving the event loop.
     handlerExecutorThreads: Option[Int] = None
-):
+) extends HttpServerConfig:
 
   def withName(name: String): NettyServerConfig                      = copy(name = name)
   def withHost(host: String): NettyServerConfig                      = copy(host = host)
@@ -127,17 +134,9 @@ case class NettyServerConfig(
   /**
     * Start the server and return the running server instance
     */
-  def start(): NettyHttpServer =
+  override def start(): NettyHttpServer =
     val server = NettyHttpServer(this)
     server.start()
     server
-
-  /**
-    * Start the server and run the given block, then stop the server
-    */
-  def start[A](block: NettyHttpServer => A): A =
-    val server = start()
-    try block(server)
-    finally server.stop()
 
 end NettyServerConfig

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/RPCHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/RPCHandler.scala
@@ -17,6 +17,7 @@ import wvlet.uni.http.HttpHeader
 import wvlet.uni.http.HttpMethod
 import wvlet.uni.http.Request
 import wvlet.uni.http.Response
+import wvlet.uni.http.RxHttpHandler
 import wvlet.uni.http.rpc.RPCException
 import wvlet.uni.http.rpc.RPCRoute
 import wvlet.uni.http.rpc.RPCRouter

--- a/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
+++ b/uni-netty/src/main/scala/wvlet/uni/http/netty/RouterHandler.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.uni.http.netty
 
-import wvlet.uni.http.{Request, Response}
+import wvlet.uni.http.{Request, Response, RxHttpFilter, RxHttpHandler}
 import wvlet.uni.http.router.*
 import wvlet.uni.log.LogSupport
 import wvlet.uni.rx.Rx

--- a/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
+++ b/uni-netty/src/test/scala/wvlet/uni/http/netty/NettyServerTest.scala
@@ -13,7 +13,7 @@
  */
 package wvlet.uni.http.netty
 
-import wvlet.uni.http.{HttpHandler, HttpMethod, Request, Response, ServerSentEvent}
+import wvlet.uni.http.{HttpHandler, HttpMethod, Request, Response, RxHttpFilter, ServerSentEvent}
 import wvlet.uni.http.router.{Endpoint, Router}
 import wvlet.uni.rx.Rx
 import wvlet.uni.test.UniTest

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
@@ -1,0 +1,237 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.log.LogSupport
+import wvlet.uni.rx.{OnCompletion, OnError, OnNext, Rx, RxRunner}
+
+import scala.concurrent.{ExecutionContext, Promise}
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters.*
+import scala.scalajs.js.typedarray.*
+
+/**
+  * Node.js-based HTTP server implementation, backed by the built-in `http` module. It implements
+  * the platform-neutral [[HttpServer]] contract and runs the same [[RxHttpHandler]] /
+  * [[RxHttpFilter]] chain as the JVM (Netty) backend.
+  *
+  * Node's socket bind is asynchronous, so [[localPort]] is only known after the underlying
+  * `listening` event fires. Use [[whenReady]] (or `NodeServerConfig.startAndAwait`) before reading
+  * the port or connecting a client.
+  */
+class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSupport:
+
+  private given ExecutionContext = scala.scalajs.concurrent.JSExecutionContext.queue
+
+  private val handler: RxHttpHandler = config.effectiveHandler
+
+  private var server: js.Dynamic = null
+  private var running: Boolean   = false
+
+  private val readyPromise = Promise[NodeHttpServer]()
+
+  /**
+    * Completes once the server is listening (after the asynchronous bind), yielding this server
+    * with its [[localPort]] resolved.
+    */
+  def whenReady: Rx[NodeHttpServer] = Rx.future(readyPromise.future)
+
+  def start(): Unit =
+    if running then
+      throw IllegalStateException("Server is already running")
+
+    val http = NodeModules.builtin("http")
+    server =
+      http.applyDynamic("createServer")(
+        ((req: js.Dynamic, res: js.Dynamic) => handleRequest(req, res)): js.Function2[
+          js.Dynamic,
+          js.Dynamic,
+          Unit
+        ]
+      )
+
+    val onListening: js.Function0[Unit] =
+      () =>
+        running = true
+        debug(s"Node server started at ${localAddress}")
+        readyPromise.success(this)
+
+    server.applyDynamic("listen")(config.port, config.host, onListening)
+
+  end start
+
+  private def handleRequest(req: js.Dynamic, res: js.Dynamic): Unit =
+    val method = HttpMethod
+      .of(req.method.asInstanceOf[String])
+      .getOrElse(throw IllegalArgumentException(s"Unsupported HTTP method: ${req.method}"))
+    val uri = req.url.asInstanceOf[String]
+
+    // rawHeaders is a flat [k, v, k, v, ...] array, preserving duplicate header names.
+    val headersBuilder = HttpMultiMap.newBuilder
+    val rawHeaders     = req.rawHeaders.asInstanceOf[js.Array[String]]
+    var i              = 0
+    while i + 1 < rawHeaders.length do
+      headersBuilder.add(rawHeaders(i), rawHeaders(i + 1))
+      i += 2
+    val headers = headersBuilder.result()
+
+    val bodyChunks = Array.newBuilder[Byte]
+
+    val onData: js.Function1[js.Dynamic, Unit] =
+      (chunk: js.Dynamic) =>
+        bodyChunks ++= toBytes(chunk)
+        ()
+
+    val onEnd: js.Function0[Unit] =
+      () =>
+        try
+          val body    = bodyChunks.result()
+          val content =
+            if body.isEmpty then
+              HttpContent.Empty
+            else
+              val ct = headers
+                .get(HttpHeader.ContentType)
+                .flatMap(ContentType.parse)
+                .getOrElse(ContentType.ApplicationOctetStream)
+              HttpContent.bytes(body, ct)
+
+          val request = Request(method = method, uri = uri, headers = headers, content = content)
+          runResponse(res, handler.handle(request))
+        catch
+          case e: Throwable =>
+            warn(s"Error handling request: ${e.getMessage}", e)
+            writeResponse(res, Response.internalServerError(e.getMessage))
+
+    req.applyDynamic("on")("data", onData)
+    req.applyDynamic("on")("end", onEnd)
+
+  end handleRequest
+
+  private def runResponse(res: js.Dynamic, rx: Rx[Response]): Unit =
+    RxRunner.runOnce(rx) {
+      case OnNext(response) =>
+        writeResponse(res, response.asInstanceOf[Response])
+      case OnError(e) =>
+        warn(s"Error in Rx handler: ${e.getMessage}", e)
+        writeResponse(res, Response.internalServerError(e.getMessage))
+      case OnCompletion =>
+        writeResponse(res, Response.notFound)
+    }
+
+  private def writeResponse(res: js.Dynamic, response: Response): Unit =
+    if response.isEventStream then
+      writeSseResponse(res, response)
+    else
+      setHeaders(res, response.headers)
+      response
+        .content
+        .contentType
+        .foreach { ct =>
+          res.applyDynamic("setHeader")(HttpHeader.ContentType, ct.value)
+        }
+      res.updateDynamic("statusCode")(response.status.code)
+      val bytes = response.content.toContentBytes
+      if bytes.isEmpty then
+        res.applyDynamic("end")()
+      else
+        // Node sets Content-Length automatically for a buffered body. The body must be a
+        // Uint8Array/Buffer (Node rejects Int8Array), so view the bytes as unsigned.
+        res.applyDynamic("end")(toUint8Array(bytes))
+
+  private def writeSseResponse(res: js.Dynamic, response: Response): Unit =
+    // Stream Server-Sent Events. Node uses chunked transfer encoding automatically when no
+    // Content-Length is set. This mirrors NettyRequestHandler.sendSseResponse.
+    res.applyDynamic("setHeader")("Content-Type", "text/event-stream")
+    res.applyDynamic("setHeader")("Cache-Control", "no-cache")
+    res.applyDynamic("setHeader")("Connection", "keep-alive")
+    response
+      .headers
+      .entries
+      .foreach { case (name, value) =>
+        if !name.equalsIgnoreCase(HttpHeader.ContentType) then
+          res.applyDynamic("setHeader")(name, value)
+      }
+    res.updateDynamic("statusCode")(response.status.code)
+
+    RxRunner.run(response.events) {
+      case OnNext(event) =>
+        res.applyDynamic("write")(event.asInstanceOf[ServerSentEvent].toContent)
+      case OnError(e) =>
+        warn(s"SSE stream error: ${e.getMessage}", e)
+        res.applyDynamic("end")()
+      case OnCompletion =>
+        res.applyDynamic("end")()
+    }
+
+  /**
+    * Set response headers, preserving duplicate header names (e.g. multiple `Set-Cookie`) by
+    * passing an array value to Node when a name appears more than once.
+    */
+  private def setHeaders(res: js.Dynamic, headers: HttpMultiMap): Unit = headers
+    .entries
+    .groupBy(_._1)
+    .foreach { case (name, kvs) =>
+      val values = kvs.map(_._2)
+      if values.sizeIs == 1 then
+        res.applyDynamic("setHeader")(name, values.head)
+      else
+        res.applyDynamic("setHeader")(name, values.toJSArray)
+    }
+
+  /**
+    * Copy a Node `Buffer`/`Uint8Array` chunk into a JVM byte array. The chunk may be a view into a
+    * larger pooled buffer, so honor its `byteOffset`/`length`.
+    */
+  private def toBytes(chunk: js.Dynamic): Array[Byte] =
+    val u8 = chunk.asInstanceOf[Uint8Array]
+    Int8Array(u8.buffer, u8.byteOffset, u8.length).toArray
+
+  /**
+    * View a JVM byte array as a Node-compatible `Uint8Array` (Node rejects `Int8Array` response
+    * bodies). The two share the same underlying bytes; only the signed/unsigned interpretation
+    * differs, which Node ignores when writing raw bytes.
+    */
+  private def toUint8Array(bytes: Array[Byte]): Uint8Array =
+    val i8 = bytes.toTypedArray
+    Uint8Array(i8.buffer, i8.byteOffset, i8.length)
+
+  override def stop(): Unit =
+    if running && server != null then
+      server.applyDynamic("close")()
+      running = false
+      debug(s"Node server stopped")
+
+  override def awaitTermination(): Unit =
+    // Node has no blocking await; the event loop keeps the process alive while the server listens.
+    ()
+
+  override def isRunning: Boolean = running
+
+  override def localPort: Int =
+    if server == null then
+      -1
+    else
+      val addr = server.applyDynamic("address")()
+      if js.isUndefined(addr) || addr == null then
+        -1
+      else
+        addr.port.asInstanceOf[Int]
+
+  override def localAddress: String = s"${config.host}:${localPort}"
+
+end NodeHttpServer
+
+object NodeHttpServer:
+  def apply(config: NodeServerConfig): NodeHttpServer = new NodeHttpServer(config)

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
@@ -296,19 +296,21 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
       else
         addr
 
+  // Before the server is listening, fall back to the configured port (matching NettyHttpServer,
+  // which returns config.port pre-bind) rather than a -1 sentinel, for cross-backend consistency.
   override def localPort: Int =
     val addr = boundAddress
     if addr == null then
-      -1
+      config.port
     else
       addr.port.asInstanceOf[Int]
 
-  // Report the actually-bound host:port (matching Netty), falling back to the configured host
-  // before the server is listening.
+  // Report the actually-bound host:port (matching Netty), falling back to the configured host:port
+  // before the server is listening. Reads boundAddress once rather than via localPort.
   override def localAddress: String =
     val addr = boundAddress
     if addr == null then
-      s"${config.host}:${localPort}"
+      s"${config.host}:${config.port}"
     else
       s"${addr.address.asInstanceOf[String]}:${addr.port.asInstanceOf[Int]}"
 

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
@@ -41,11 +41,8 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
 
   private val readyPromise = Promise[NodeHttpServer]()
 
-  /**
-    * Completes once the server is listening (after the asynchronous bind), yielding this server
-    * with its [[localPort]] resolved.
-    */
-  def whenReady: Rx[NodeHttpServer] = Rx.future(readyPromise.future)
+  // Node binds asynchronously, so readiness is signaled on the `listening` event (see start()).
+  override def whenReady: Rx[NodeHttpServer] = Rx.future(readyPromise.future)
 
   def start(): Unit =
     if running then
@@ -96,17 +93,7 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
     val onEnd: js.Function0[Unit] =
       () =>
         try
-          val body    = bodyChunks.result()
-          val content =
-            if body.isEmpty then
-              HttpContent.Empty
-            else
-              val ct = headers
-                .get(HttpHeader.ContentType)
-                .flatMap(ContentType.parse)
-                .getOrElse(ContentType.ApplicationOctetStream)
-              HttpContent.bytes(body, ct)
-
+          val content = HttpContent.fromBytes(bodyChunks.result(), headers)
           val request = Request(method = method, uri = uri, headers = headers, content = content)
           runResponse(res, handler.handle(request))
         catch
@@ -153,9 +140,9 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
   private def writeSseResponse(res: js.Dynamic, response: Response): Unit =
     // Stream Server-Sent Events. Node uses chunked transfer encoding automatically when no
     // Content-Length is set. This mirrors NettyRequestHandler.sendSseResponse.
-    res.applyDynamic("setHeader")("Content-Type", "text/event-stream")
-    res.applyDynamic("setHeader")("Cache-Control", "no-cache")
-    res.applyDynamic("setHeader")("Connection", "keep-alive")
+    res.applyDynamic("setHeader")(HttpHeader.ContentType, ContentType.TextEventStream.value)
+    res.applyDynamic("setHeader")(HttpHeader.CacheControl, "no-cache")
+    res.applyDynamic("setHeader")(HttpHeader.Connection, "keep-alive")
     response
       .headers
       .entries

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
@@ -104,10 +104,15 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
 
       val uri = req.url.asInstanceOf[String]
 
-      // rawHeaders is a flat [k, v, k, v, ...] array, preserving duplicate header names.
+      // rawHeaders is a flat [k, v, k, v, ...] array, preserving duplicate header names. Guard
+      // against a non-standard/mock request object that lacks it.
       val headersBuilder = HttpMultiMap.newBuilder
-      val rawHeaders     = req.rawHeaders.asInstanceOf[js.Array[String]]
-      var i              = 0
+      val rawHeaders     =
+        if js.isUndefined(req.rawHeaders) || req.rawHeaders == null then
+          js.Array[String]()
+        else
+          req.rawHeaders.asInstanceOf[js.Array[String]]
+      var i = 0
       while i + 1 < rawHeaders.length do
         headersBuilder.add(rawHeaders(i), rawHeaders(i + 1))
         i += 2
@@ -201,21 +206,29 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
         case e: Throwable =>
           debug(s"SSE end failed: ${e.getMessage}")
 
-    // A `var` (not `lazy val`): RxRunner.run can emit synchronously (e.g. Rx.fromSeq), so a
-    // callback that touches `subscription` during construction sees the no-op placeholder rather
-    // than triggering lazy-val re-entrancy.
-    var subscription: Cancelable = Cancelable.empty
-    subscription =
+    // RxRunner.run can emit synchronously (e.g. Rx.fromSeq), so a write failure may fire a callback
+    // before run() returns and the real subscription is assigned. A delegate Cancelable lets us
+    // both flip a `cancelled` flag (so subsequent synchronous events are skipped) and forward to
+    // the real subscription once it exists — covering both the sync and async cases.
+    var realSubscription: Cancelable = Cancelable.empty
+    var cancelled                    = false
+    val subscription: Cancelable     = Cancelable { () =>
+      cancelled = true
+      realSubscription.cancel
+    }
+
+    realSubscription =
       RxRunner.run(response.events) {
         case OnNext(event) =>
           // write can throw ("write after end"/destroyed socket) if the client left mid-stream;
           // on the event loop that would crash the process, so cancel the stream instead.
-          try
-            res.applyDynamic("write")(event.asInstanceOf[ServerSentEvent].toContent)
-          catch
-            case e: Throwable =>
-              warn(s"SSE write failed, cancelling stream: ${e.getMessage}", e)
-              subscription.cancel
+          if !cancelled then
+            try
+              res.applyDynamic("write")(event.asInstanceOf[ServerSentEvent].toContent)
+            catch
+              case e: Throwable =>
+                warn(s"SSE write failed, cancelling stream: ${e.getMessage}", e)
+                subscription.cancel
         case OnError(e) =>
           warn(s"SSE stream error: ${e.getMessage}", e)
           endQuietly()

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
@@ -87,46 +87,54 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
   end start
 
   private def handleRequest(req: js.Dynamic, res: js.Dynamic): Unit =
-    // Node accepts arbitrary verbs; an unknown method must not crash the process (the throw would
-    // be uncaught here, outside the onEnd try). Respond with 400 instead.
-    val method =
-      HttpMethod.of(req.method.asInstanceOf[String]) match
-        case Some(m) =>
-          m
-        case None =>
-          writeResponse(res, Response.badRequest(s"Unsupported HTTP method: ${req.method}"))
-          return
-    val uri = req.url.asInstanceOf[String]
+    // The whole synchronous setup runs in the createServer callback, outside any later async
+    // try/catch, so guard it: an error here (an unknown verb, a null/missing field, ...) must
+    // produce a response, not an uncaught exception that crashes the Node process.
+    try
+      // Node accepts arbitrary verbs; an unknown method is a client error, not a server crash.
+      val method =
+        HttpMethod.of(req.method.asInstanceOf[String]) match
+          case Some(m) =>
+            m
+          case None =>
+            writeResponse(res, Response.badRequest(s"Unsupported HTTP method: ${req.method}"))
+            return
 
-    // rawHeaders is a flat [k, v, k, v, ...] array, preserving duplicate header names.
-    val headersBuilder = HttpMultiMap.newBuilder
-    val rawHeaders     = req.rawHeaders.asInstanceOf[js.Array[String]]
-    var i              = 0
-    while i + 1 < rawHeaders.length do
-      headersBuilder.add(rawHeaders(i), rawHeaders(i + 1))
-      i += 2
-    val headers = headersBuilder.result()
+      val uri = req.url.asInstanceOf[String]
 
-    val bodyChunks = Array.newBuilder[Byte]
+      // rawHeaders is a flat [k, v, k, v, ...] array, preserving duplicate header names.
+      val headersBuilder = HttpMultiMap.newBuilder
+      val rawHeaders     = req.rawHeaders.asInstanceOf[js.Array[String]]
+      var i              = 0
+      while i + 1 < rawHeaders.length do
+        headersBuilder.add(rawHeaders(i), rawHeaders(i + 1))
+        i += 2
+      val headers = headersBuilder.result()
 
-    val onData: js.Function1[js.Dynamic, Unit] =
-      (chunk: js.Dynamic) =>
-        bodyChunks ++= toBytes(chunk)
-        ()
+      val bodyChunks = Array.newBuilder[Byte]
 
-    val onEnd: js.Function0[Unit] =
-      () =>
-        try
-          val content = HttpContent.fromBytes(bodyChunks.result(), headers)
-          val request = Request(method = method, uri = uri, headers = headers, content = content)
-          runResponse(res, handler.handle(request))
-        catch
-          case e: Throwable =>
-            warn(s"Error handling request: ${e.getMessage}", e)
-            writeResponse(res, Response.internalServerError(e.getMessage))
+      val onData: js.Function1[js.Dynamic, Unit] =
+        (chunk: js.Dynamic) =>
+          bodyChunks ++= toBytes(chunk)
+          ()
 
-    req.applyDynamic("on")("data", onData)
-    req.applyDynamic("on")("end", onEnd)
+      val onEnd: js.Function0[Unit] =
+        () =>
+          try
+            val content = HttpContent.fromBytes(bodyChunks.result(), headers)
+            val request = Request(method = method, uri = uri, headers = headers, content = content)
+            runResponse(res, handler.handle(request))
+          catch
+            case e: Throwable =>
+              warn(s"Error handling request: ${e.getMessage}", e)
+              writeResponse(res, Response.internalServerError(e.getMessage))
+
+      req.applyDynamic("on")("data", onData)
+      req.applyDynamic("on")("end", onEnd)
+    catch
+      case e: Throwable =>
+        warn(s"Error initializing request: ${e.getMessage}", e)
+        writeResponse(res, Response.internalServerError(e.getMessage))
 
   end handleRequest
 
@@ -184,15 +192,23 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
       }
     res.updateDynamic("statusCode")(response.status.code)
 
-    RxRunner.run(response.events) {
-      case OnNext(event) =>
-        res.applyDynamic("write")(event.asInstanceOf[ServerSentEvent].toContent)
-      case OnError(e) =>
-        warn(s"SSE stream error: ${e.getMessage}", e)
-        res.applyDynamic("end")()
-      case OnCompletion =>
-        res.applyDynamic("end")()
-    }
+    val subscription =
+      RxRunner.run(response.events) {
+        case OnNext(event) =>
+          res.applyDynamic("write")(event.asInstanceOf[ServerSentEvent].toContent)
+        case OnError(e) =>
+          warn(s"SSE stream error: ${e.getMessage}", e)
+          res.applyDynamic("end")()
+        case OnCompletion =>
+          res.applyDynamic("end")()
+      }
+
+    // If the client disconnects before the stream finishes, cancel the subscription so the
+    // publisher stops running and we don't write to a closed response.
+    val onClose: js.Function0[Unit] = () => subscription.cancel
+    res.applyDynamic("on")("close", onClose)
+
+  end writeSseResponse
 
   /**
     * Set response headers, preserving duplicate header names (e.g. multiple `Set-Cookie`) by

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
@@ -14,7 +14,7 @@
 package wvlet.uni.http
 
 import wvlet.uni.log.LogSupport
-import wvlet.uni.rx.{OnCompletion, OnError, OnNext, Rx, RxRunner}
+import wvlet.uni.rx.{Cancelable, OnCompletion, OnError, OnNext, Rx, RxRunner}
 
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.scalajs.js
@@ -41,6 +41,8 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
   private var started: Boolean = false
   // Set on the async `listening` event; cleared on stop().
   private var running: Boolean = false
+  // Guards stop() so it is idempotent (avoids a double `server.close()`).
+  private var stopped: Boolean = false
 
   private val readyPromise = Promise[NodeHttpServer]()
 
@@ -139,43 +141,43 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
   end handleRequest
 
   private def runResponse(res: js.Dynamic, rx: Rx[Response]): Unit =
-    RxRunner.runOnce(rx) { event =>
-      // For async handlers this runs later on the microtask queue, outside handleRequest's
-      // try/catch, so guard the write itself: a failed write (e.g. client gone, headers already
-      // sent) must be logged, not thrown uncaught (which would crash the Node process).
-      try
-        event match
-          case OnNext(response) =>
-            writeResponse(res, response.asInstanceOf[Response])
-          case OnError(e) =>
-            warn(s"Error in Rx handler: ${e.getMessage}", e)
-            writeResponse(res, Response.internalServerError(e.getMessage))
-          case OnCompletion =>
-            writeResponse(res, Response.notFound)
-      catch
-        case e: Throwable =>
-          warn(s"Failed to write response: ${e.getMessage}", e)
+    RxRunner.runOnce(rx) {
+      case OnNext(response) =>
+        writeResponse(res, response.asInstanceOf[Response])
+      case OnError(e) =>
+        warn(s"Error in Rx handler: ${e.getMessage}", e)
+        writeResponse(res, Response.internalServerError(e.getMessage))
+      case OnCompletion =>
+        writeResponse(res, Response.notFound)
     }
 
   private def writeResponse(res: js.Dynamic, response: Response): Unit =
-    if response.isEventStream then
-      writeSseResponse(res, response)
-    else
-      setHeaders(res, response.headers)
-      response
-        .content
-        .contentType
-        .foreach { ct =>
-          res.applyDynamic("setHeader")(HttpHeader.ContentType, ct.value)
-        }
-      res.updateDynamic("statusCode")(response.status.code)
-      val bytes = response.content.toContentBytes
-      if bytes.isEmpty then
-        res.applyDynamic("end")()
+    // setHeader/end can throw if the client already disconnected (destroyed socket, headers
+    // already sent). For async handlers this runs on the event loop outside any caller's try, so
+    // an uncaught throw would crash the Node process — guard the whole write here. Every caller
+    // (runResponse, handleRequest's catch blocks, the 400 path) relies on this not throwing.
+    try
+      if response.isEventStream then
+        writeSseResponse(res, response)
       else
-        // Node sets Content-Length automatically for a buffered body. The body must be a
-        // Uint8Array/Buffer (Node rejects Int8Array), so view the bytes as unsigned.
-        res.applyDynamic("end")(toUint8Array(bytes))
+        setHeaders(res, response.headers)
+        response
+          .content
+          .contentType
+          .foreach { ct =>
+            res.applyDynamic("setHeader")(HttpHeader.ContentType, ct.value)
+          }
+        res.updateDynamic("statusCode")(response.status.code)
+        val bytes = response.content.toContentBytes
+        if bytes.isEmpty then
+          res.applyDynamic("end")()
+        else
+          // Node sets Content-Length automatically for a buffered body. The body must be a
+          // Uint8Array/Buffer (Node rejects Int8Array), so view the bytes as unsigned.
+          res.applyDynamic("end")(toUint8Array(bytes))
+    catch
+      case e: Throwable =>
+        warn(s"Failed to write response: ${e.getMessage}", e)
 
   private def writeSseResponse(res: js.Dynamic, response: Response): Unit =
     // Stream Server-Sent Events. Node uses chunked transfer encoding automatically when no
@@ -192,15 +194,33 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
       }
     res.updateDynamic("statusCode")(response.status.code)
 
-    val subscription =
+    def endQuietly(): Unit =
+      try
+        res.applyDynamic("end")()
+      catch
+        case e: Throwable =>
+          debug(s"SSE end failed: ${e.getMessage}")
+
+    // A `var` (not `lazy val`): RxRunner.run can emit synchronously (e.g. Rx.fromSeq), so a
+    // callback that touches `subscription` during construction sees the no-op placeholder rather
+    // than triggering lazy-val re-entrancy.
+    var subscription: Cancelable = Cancelable.empty
+    subscription =
       RxRunner.run(response.events) {
         case OnNext(event) =>
-          res.applyDynamic("write")(event.asInstanceOf[ServerSentEvent].toContent)
+          // write can throw ("write after end"/destroyed socket) if the client left mid-stream;
+          // on the event loop that would crash the process, so cancel the stream instead.
+          try
+            res.applyDynamic("write")(event.asInstanceOf[ServerSentEvent].toContent)
+          catch
+            case e: Throwable =>
+              warn(s"SSE write failed, cancelling stream: ${e.getMessage}", e)
+              subscription.cancel
         case OnError(e) =>
           warn(s"SSE stream error: ${e.getMessage}", e)
-          res.applyDynamic("end")()
+          endQuietly()
         case OnCompletion =>
-          res.applyDynamic("end")()
+          endQuietly()
       }
 
     // If the client disconnects before the stream finishes, cancel the subscription so the
@@ -243,9 +263,19 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
     Uint8Array(i8.buffer, i8.byteOffset, i8.length)
 
   override def stop(): Unit =
-    if running && server != null then
-      server.applyDynamic("close")()
+    // Check `started`, not `running`: stop() may race a pending bind (started but not yet
+    // listening), and the server handle must still be closed and any whenReady waiter unblocked.
+    if started && !stopped && server != null then
+      stopped = true
+      try
+        server.applyDynamic("close")()
+      catch
+        case e: Throwable =>
+          debug(s"Node server close failed: ${e.getMessage}")
       running = false
+      // If stopped before the bind completed, fail readiness so startAndAwait/whenReady don't hang.
+      if !readyPromise.isCompleted then
+        readyPromise.failure(IllegalStateException("Server stopped before it finished starting"))
       debug(s"Node server stopped")
 
   override def awaitTermination(): Unit =

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
@@ -37,7 +37,10 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
   private val handler: RxHttpHandler = config.effectiveHandler
 
   private var server: js.Dynamic = null
-  private var running: Boolean   = false
+  // Set synchronously in start() so a second start() before the async bind completes is rejected.
+  private var started: Boolean = false
+  // Set on the async `listening` event; cleared on stop().
+  private var running: Boolean = false
 
   private val readyPromise = Promise[NodeHttpServer]()
 
@@ -45,8 +48,9 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
   override def whenReady: Rx[NodeHttpServer] = Rx.future(readyPromise.future)
 
   def start(): Unit =
-    if running then
-      throw IllegalStateException("Server is already running")
+    if started then
+      throw IllegalStateException("Server is already started")
+    started = true
 
     val http = NodeModules.builtin("http")
     server =
@@ -58,20 +62,40 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
         ]
       )
 
+    // A bind failure (EADDRINUSE/EACCES) emits `error`, not `listening`. Without this handler the
+    // error is uncaught (process crash) and readyPromise never completes, hanging startAndAwait.
+    val onError: js.Function1[js.Dynamic, Unit] =
+      (err: js.Dynamic) =>
+        val message =
+          if js.isUndefined(err) || err == null then
+            "unknown error"
+          else
+            s"${err}"
+        warn(s"Node server error: ${message}")
+        if !readyPromise.isCompleted then
+          readyPromise.failure(RuntimeException(s"Node server failed to start: ${message}"))
+
     val onListening: js.Function0[Unit] =
       () =>
         running = true
         debug(s"Node server started at ${localAddress}")
         readyPromise.success(this)
 
+    server.applyDynamic("on")("error", onError)
     server.applyDynamic("listen")(config.port, config.host, onListening)
 
   end start
 
   private def handleRequest(req: js.Dynamic, res: js.Dynamic): Unit =
-    val method = HttpMethod
-      .of(req.method.asInstanceOf[String])
-      .getOrElse(throw IllegalArgumentException(s"Unsupported HTTP method: ${req.method}"))
+    // Node accepts arbitrary verbs; an unknown method must not crash the process (the throw would
+    // be uncaught here, outside the onEnd try). Respond with 400 instead.
+    val method =
+      HttpMethod.of(req.method.asInstanceOf[String]) match
+        case Some(m) =>
+          m
+        case None =>
+          writeResponse(res, Response.badRequest(s"Unsupported HTTP method: ${req.method}"))
+          return
     val uri = req.url.asInstanceOf[String]
 
     // rawHeaders is a flat [k, v, k, v, ...] array, preserving duplicate header names.
@@ -107,14 +131,22 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
   end handleRequest
 
   private def runResponse(res: js.Dynamic, rx: Rx[Response]): Unit =
-    RxRunner.runOnce(rx) {
-      case OnNext(response) =>
-        writeResponse(res, response.asInstanceOf[Response])
-      case OnError(e) =>
-        warn(s"Error in Rx handler: ${e.getMessage}", e)
-        writeResponse(res, Response.internalServerError(e.getMessage))
-      case OnCompletion =>
-        writeResponse(res, Response.notFound)
+    RxRunner.runOnce(rx) { event =>
+      // For async handlers this runs later on the microtask queue, outside handleRequest's
+      // try/catch, so guard the write itself: a failed write (e.g. client gone, headers already
+      // sent) must be logged, not thrown uncaught (which would crash the Node process).
+      try
+        event match
+          case OnNext(response) =>
+            writeResponse(res, response.asInstanceOf[Response])
+          case OnError(e) =>
+            warn(s"Error in Rx handler: ${e.getMessage}", e)
+            writeResponse(res, Response.internalServerError(e.getMessage))
+          case OnCompletion =>
+            writeResponse(res, Response.notFound)
+      catch
+        case e: Throwable =>
+          warn(s"Failed to write response: ${e.getMessage}", e)
     }
 
   private def writeResponse(res: js.Dynamic, response: Response): Unit =
@@ -206,17 +238,33 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
 
   override def isRunning: Boolean = running
 
-  override def localPort: Int =
+  // The bound address object (`{address, port, family}`), or null before start() / before the
+  // `listening` event fires (Node's `server.address()` returns null until then).
+  private def boundAddress: js.Dynamic =
     if server == null then
-      -1
+      null
     else
       val addr = server.applyDynamic("address")()
-      if js.isUndefined(addr) || addr == null then
-        -1
+      if js.isUndefined(addr) then
+        null
       else
-        addr.port.asInstanceOf[Int]
+        addr
 
-  override def localAddress: String = s"${config.host}:${localPort}"
+  override def localPort: Int =
+    val addr = boundAddress
+    if addr == null then
+      -1
+    else
+      addr.port.asInstanceOf[Int]
+
+  // Report the actually-bound host:port (matching Netty), falling back to the configured host
+  // before the server is listening.
+  override def localAddress: String =
+    val addr = boundAddress
+    if addr == null then
+      s"${config.host}:${localPort}"
+    else
+      s"${addr.address.asInstanceOf[String]}:${addr.port.asInstanceOf[Int]}"
 
 end NodeHttpServer
 

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeModules.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeModules.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import scala.scalajs.js
+
+/**
+  * Helpers for loading Node.js built-in modules from Scala.js.
+  */
+private[http] object NodeModules:
+
+  /**
+    * Load a Node built-in module lazily at call time rather than via a static `@JSImport`.
+    * `process.getBuiltinModule` (Node 20.16+ / 22.3+) works in both CommonJS and ESM; the global
+    * `require` is the fallback for older Node / NoModule builds. Being a runtime call, this is
+    * invisible to browser bundlers — a browser bundle still builds and simply never reaches here
+    * because [[isNode]] is false.
+    */
+  def builtin(name: String): js.Dynamic =
+    val process = js.Dynamic.global.process
+    if !js.isUndefined(process) && !js.isUndefined(process.getBuiltinModule) then
+      process.applyDynamic("getBuiltinModule")(name)
+    else
+      js.Dynamic.global.applyDynamic("require")(name)
+
+  /**
+    * True on a Node-compatible runtime, detected by `process.versions.node`. Bun and Deno both set
+    * it (they target Node compatibility); browsers — including web workers — lack it.
+    */
+  def isNode: Boolean =
+    !js.isUndefined(js.Dynamic.global.process) &&
+      !js.isUndefined(js.Dynamic.global.process.versions) &&
+      !js.isUndefined(js.Dynamic.global.process.versions.node)
+
+end NodeModules

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeServer.scala
@@ -82,13 +82,4 @@ case class NodeServerConfig(
     server.start()
     server
 
-  /**
-    * Start the server, wait until it is listening, run the given async block, then stop the server
-    * once the block's Rx completes (or fails). This is the recommended way to use a Node server,
-    * since binding is asynchronous.
-    */
-  def startAndAwait[A](block: NodeHttpServer => Rx[A]): Rx[A] =
-    val server = start()
-    server.whenReady.flatMap(block).tap(_ => server.stop()).tapOnFailure(_ => server.stop())
-
 end NodeServerConfig

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeServer.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.rx.Rx
+
+/**
+  * Entry point for creating a Node.js-based HTTP server on Scala.js. This is the Node counterpart
+  * of `NettyServer` (JVM); both produce an [[HttpServer]] from a shared [[HttpServerConfig]], so
+  * handler and filter code is identical across platforms.
+  *
+  * Requires a Node-compatible runtime (Node.js, Bun, Deno) — it uses the built-in `http` module.
+  */
+object NodeServer:
+
+  def withPort(port: Int): NodeServerConfig = NodeServerConfig().withPort(port)
+
+  def withHandler(handler: HttpHandler): NodeServerConfig = NodeServerConfig().withHandler(handler)
+
+  def withHandler(f: Request => Response): NodeServerConfig = NodeServerConfig().withHandler(f)
+
+  def withRxHandler(handler: RxHttpHandler): NodeServerConfig = NodeServerConfig().withRxHandler(
+    handler
+  )
+
+  def withRxHandler(f: Request => Rx[Response]): NodeServerConfig = NodeServerConfig()
+    .withRxHandler(f)
+
+/**
+  * Configuration for [[NodeHttpServer]] with a builder pattern, mirroring `NettyServerConfig`'s
+  * common surface.
+  */
+case class NodeServerConfig(
+    name: String = "node-server",
+    host: String = "0.0.0.0",
+    port: Int = 8080,
+    handler: RxHttpHandler = RxHttpHandler.notFound,
+    filters: Seq[RxHttpFilter] = Seq.empty
+) extends HttpServerConfig:
+
+  def withName(name: String): NodeServerConfig = copy(name = name)
+  def withHost(host: String): NodeServerConfig = copy(host = host)
+  def withPort(port: Int): NodeServerConfig    = copy(port = port)
+
+  def withHandler(handler: HttpHandler): NodeServerConfig = copy(handler =
+    RxHttpHandler.fromSync(handler)
+  )
+
+  def withHandler(f: Request => Response): NodeServerConfig = copy(handler =
+    RxHttpHandler.fromFunction(f)
+  )
+
+  def withRxHandler(handler: RxHttpHandler): NodeServerConfig = copy(handler = handler)
+
+  def withRxHandler(f: Request => Rx[Response]): NodeServerConfig = copy(handler = RxHttpHandler(f))
+
+  def withFilter(filter: RxHttpFilter): NodeServerConfig = copy(filters = filters :+ filter)
+
+  def withFilters(filters: Seq[RxHttpFilter]): NodeServerConfig = copy(filters =
+    this.filters ++ filters
+  )
+
+  /**
+    * Start the server and return the running server instance. Note that on Node.js the socket bind
+    * is asynchronous: use [[NodeHttpServer.whenReady]] (or [[startAndAwait]]) before reading
+    * [[NodeHttpServer.localPort]] or connecting a client, since the OS-assigned port (port 0) is
+    * not known until the underlying `listening` event fires.
+    */
+  override def start(): NodeHttpServer =
+    val server = NodeHttpServer(this)
+    server.start()
+    server
+
+  /**
+    * Start the server, wait until it is listening, run the given async block, then stop the server
+    * once the block's Rx completes (or fails). This is the recommended way to use a Node server,
+    * since binding is asynchronous.
+    */
+  def startAndAwait[A](block: NodeHttpServer => Rx[A]): Rx[A] =
+    val server = start()
+    server.whenReady.flatMap(block).tap(_ => server.stop()).tapOnFailure(_ => server.stop())
+
+end NodeServerConfig

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeServer.scala
@@ -82,4 +82,13 @@ case class NodeServerConfig(
     server.start()
     server
 
+  /**
+    * Unsupported on Node.js: the synchronous `start(block)` runs the block before the asynchronous
+    * bind completes, so the server would not yet be listening. Use [[startAndAwait]] instead.
+    */
+  override def start[A](block: HttpServer => A): A =
+    throw UnsupportedOperationException(
+      "NodeServer binds asynchronously; use startAndAwait { server => Rx[...] } instead of start(block)."
+    )
+
 end NodeServerConfig

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeSyncHttpChannel.scala
@@ -195,27 +195,14 @@ object NodeSyncHttpChannel:
   // thread gives up waiting.
   private final val WorkerGraceMillis = 5000
 
-  // Load Node's `worker_threads` lazily at call time rather than via a static `@JSImport`.
-  // `process.getBuiltinModule` (Node 20.16+ / 22.3+) works in both CommonJS and ESM; the global
-  // `require` is the fallback for older Node / NoModule builds. Being a runtime call, this is
-  // invisible to browser bundlers — a browser bundle that links `JSHttpChannelFactory` still
-  // builds, and simply never reaches here because `isNode` is false.
-  private[http] def workerThreads: js.Dynamic =
-    val process = js.Dynamic.global.process
-    if !js.isUndefined(process) && !js.isUndefined(process.getBuiltinModule) then
-      process.applyDynamic("getBuiltinModule")("worker_threads")
-    else
-      js.Dynamic.global.applyDynamic("require")("worker_threads")
+  // Load Node's `worker_threads` lazily at call time (see NodeModules.builtin for why).
+  private[http] def workerThreads: js.Dynamic = NodeModules.builtin("worker_threads")
 
   /**
-    * True on a Node-compatible runtime, detected by `process.versions.node`. Bun and Deno both set
-    * it (they target Node compatibility) and run this channel fine; browsers — including web
-    * workers — lack it.
+    * True on a Node-compatible runtime (Node, Bun, Deno). Browsers — including web workers — lack
+    * it.
     */
-  def isNode: Boolean =
-    !js.isUndefined(js.Dynamic.global.process) &&
-      !js.isUndefined(js.Dynamic.global.process.versions) &&
-      !js.isUndefined(js.Dynamic.global.process.versions.node)
+  def isNode: Boolean = NodeModules.isNode
 
   // `SharedArrayBuffer` has no typed binding in scalajs-library, so it's accessed via js.Dynamic.
   // Scala.js disallows loading `js.Dynamic.global` itself as a value, so resolve it lazily.

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeServerTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeServerTest.scala
@@ -23,6 +23,9 @@ import wvlet.uni.test.UniTest
   */
 class NodeServerTest extends UniTest:
 
+  private given scala.concurrent.ExecutionContext =
+    scala.scalajs.concurrent.JSExecutionContext.queue
+
   private def asyncClient(server: HttpServer): HttpAsyncClient =
     Http.client.withBaseUri(s"http://localhost:${server.localPort}").newAsyncClient
 
@@ -96,6 +99,36 @@ class NodeServerTest extends UniTest:
           (server.localPort > 0) shouldBe true
           server.isRunning shouldBe true
         }
+      }
+  }
+
+  test("should stream Server-Sent Events") {
+    import wvlet.uni.rx.{OnCompletion, OnError, OnNext, Rx, RxRunner}
+    import scala.concurrent.Promise
+
+    val events = Seq(ServerSentEvent.data("hello"), ServerSentEvent.data("world"))
+    NodeServer
+      .withRxHandler { _ =>
+        Rx.single(Response.eventStream(Rx.fromSeq(events)))
+      }
+      .withPort(0)
+      .startAndAwait { server =>
+        // Collect the streamed events into a single terminal value (the test framework completes
+        // on the first emission, so aggregate via the stream's OnCompletion).
+        val received = Promise[Seq[String]]()
+        val buffer   = scala.collection.mutable.ListBuffer.empty[String]
+        RxRunner.run(asyncClient(server).sendSSE(Request.get("/events"))) {
+          case OnNext(event) =>
+            buffer += event.asInstanceOf[ServerSentEvent].data
+          case OnError(e) =>
+            received.failure(e)
+          case OnCompletion =>
+            received.success(buffer.toSeq)
+        }
+        Rx.future(received.future)
+          .map { data =>
+            data shouldBe Seq("hello", "world")
+          }
       }
   }
 

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeServerTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeServerTest.scala
@@ -102,6 +102,17 @@ class NodeServerTest extends UniTest:
       }
   }
 
+  test("should reject the synchronous start(block) on Node") {
+    // Node binds asynchronously, so the sync block form would run before the server is listening.
+    intercept[UnsupportedOperationException] {
+      NodeServer
+        .withPort(0)
+        .start { _ =>
+          ()
+        }
+    }
+  }
+
   test("should stream Server-Sent Events") {
     import wvlet.uni.rx.{OnCompletion, OnError, OnNext, Rx, RxRunner}
     import scala.concurrent.Promise

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeServerTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeServerTest.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.test.UniTest
+
+/**
+  * Verifies the Node.js HTTP server backend against the cross-platform async (Fetch) client. Each
+  * test starts a server on an ephemeral port, waits for the asynchronous bind via `startAndAwait`,
+  * then exercises it with `Http.client.newAsyncClient` (async only — the sync client would block
+  * the single Node event loop and deadlock against an in-process server).
+  */
+class NodeServerTest extends UniTest:
+
+  private def asyncClient(server: NodeHttpServer): HttpAsyncClient =
+    Http.client.withBaseUri(s"http://localhost:${server.localPort}").newAsyncClient
+
+  test("should handle a GET request") {
+    NodeServer
+      .withHandler { request =>
+        Response.ok(s"Hello from ${request.path}")
+      }
+      .withPort(0)
+      .startAndAwait { server =>
+        asyncClient(server)
+          .send(Request.get("/test"))
+          .map { response =>
+            response.statusCode shouldBe 200
+            response.contentAsString shouldBe Some("Hello from /test")
+          }
+      }
+  }
+
+  test("should handle a POST request with a body") {
+    NodeServer
+      .withHandler { request =>
+        Response.ok(s"Received: ${request.content.toContentString}")
+      }
+      .withPort(0)
+      .startAndAwait { server =>
+        asyncClient(server)
+          .send(Request.post("/data").withContent(HttpContent.text("payload")))
+          .map { response =>
+            response.statusCode shouldBe 200
+            response.contentAsString shouldBe Some("Received: payload")
+          }
+      }
+  }
+
+  test("should round-trip request and response headers") {
+    NodeServer
+      .withHandler { request =>
+        val echoed = request.header("X-Echo").getOrElse("none")
+        Response.ok("ok").addHeader("X-Echoed", echoed)
+      }
+      .withPort(0)
+      .startAndAwait { server =>
+        asyncClient(server)
+          .send(Request.get("/headers").addHeader("X-Echo", "ping"))
+          .map { response =>
+            response.statusCode shouldBe 200
+            response.header("X-Echoed") shouldBe Some("ping")
+          }
+      }
+  }
+
+  test("should return 404 from the default handler") {
+    NodeServer
+      .withPort(0)
+      .startAndAwait { server =>
+        asyncClient(server)
+          .send(Request.get("/missing"))
+          .map { response =>
+            response.statusCode shouldBe 404
+          }
+      }
+  }
+
+  test("should report a bound ephemeral port once ready") {
+    NodeServer
+      .withPort(0)
+      .startAndAwait { server =>
+        import wvlet.uni.rx.Rx
+        Rx.single {
+          (server.localPort > 0) shouldBe true
+          server.isRunning shouldBe true
+        }
+      }
+  }
+
+end NodeServerTest

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeServerTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeServerTest.scala
@@ -23,7 +23,7 @@ import wvlet.uni.test.UniTest
   */
 class NodeServerTest extends UniTest:
 
-  private def asyncClient(server: NodeHttpServer): HttpAsyncClient =
+  private def asyncClient(server: HttpServer): HttpAsyncClient =
     Http.client.withBaseUri(s"http://localhost:${server.localPort}").newAsyncClient
 
   test("should handle a GET request") {

--- a/uni/src/main/scala/wvlet/uni/http/HttpContent.scala
+++ b/uni/src/main/scala/wvlet/uni/http/HttpContent.scala
@@ -120,6 +120,21 @@ object HttpContent:
     else
       ByteContent(b, Some(contentType))
 
+  /**
+    * Build byte content from a request/response body and its headers, resolving the content type
+    * from the `Content-Type` header (falling back to `application/octet-stream`). Shared by HTTP
+    * server backends when converting an inbound request body.
+    */
+  def fromBytes(data: Array[Byte], headers: HttpMultiMap): HttpContent =
+    if data.isEmpty then
+      Empty
+    else
+      val ct = headers
+        .get(HttpHeader.ContentType)
+        .flatMap(ContentType.parse)
+        .getOrElse(ContentType.ApplicationOctetStream)
+      ByteContent(data, Some(ct))
+
   def json(j: JSONValue): HttpContent = JsonContent(j)
 
   def multipart(mp: Multipart): HttpContent = MultipartContent(mp)

--- a/uni/src/main/scala/wvlet/uni/http/HttpServer.scala
+++ b/uni/src/main/scala/wvlet/uni/http/HttpServer.scala
@@ -13,12 +13,23 @@
  */
 package wvlet.uni.http
 
+import wvlet.uni.rx.Rx
+
 /**
   * Platform-neutral HTTP server lifecycle. Each backend (Netty on JVM, Node.js on Scala.js, and a
   * future posix-socket server on Native) provides its own implementation, but applications interact
   * with the server through this common interface.
   */
 trait HttpServer extends AutoCloseable:
+
+  /**
+    * Completes once the server is listening and ready to accept connections, yielding this server
+    * with [[localPort]] resolved. Backends that bind synchronously (Netty) complete immediately;
+    * backends that bind asynchronously (Node.js) complete on the underlying `listening` event. Use
+    * this (or `HttpServerConfig.startAndAwait`) before reading [[localPort]] or connecting a
+    * client.
+    */
+  def whenReady: Rx[HttpServer]
 
   /**
     * The bound local address as `host:port`. On an ephemeral binding (port 0) this reflects the

--- a/uni/src/main/scala/wvlet/uni/http/HttpServer.scala
+++ b/uni/src/main/scala/wvlet/uni/http/HttpServer.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+/**
+  * Platform-neutral HTTP server lifecycle. Each backend (Netty on JVM, Node.js on Scala.js, and a
+  * future posix-socket server on Native) provides its own implementation, but applications interact
+  * with the server through this common interface.
+  */
+trait HttpServer extends AutoCloseable:
+
+  /**
+    * The bound local address as `host:port`. On an ephemeral binding (port 0) this reflects the
+    * actually-assigned port once the server has started.
+    */
+  def localAddress: String
+
+  /**
+    * The actually-bound local port. Resolves the OS-assigned port when started with port 0.
+    */
+  def localPort: Int
+
+  def isRunning: Boolean
+
+  def stop(): Unit
+
+  /**
+    * Block until the server terminates. On runtimes without blocking semantics (e.g. Node.js) this
+    * returns immediately; the event loop keeps the process alive while the server is listening.
+    */
+  def awaitTermination(): Unit
+
+  override def close(): Unit = stop()
+
+end HttpServer

--- a/uni/src/main/scala/wvlet/uni/http/HttpServerConfig.scala
+++ b/uni/src/main/scala/wvlet/uni/http/HttpServerConfig.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+/**
+  * Platform-neutral HTTP server configuration. Backend-specific configs (e.g. `NettyServerConfig`,
+  * `NodeServerConfig`) implement this trait so the common surface — name/host/port, the request
+  * handler, filters, and the start lifecycle — is identical across platforms. Backend-specific
+  * tuning (Netty transport options, Node.js options, ...) lives on the concrete config.
+  */
+trait HttpServerConfig:
+  def name: String
+  def host: String
+  def port: Int
+  def handler: RxHttpHandler
+  def filters: Seq[RxHttpFilter]
+
+  /**
+    * The request handler with all configured filters applied, in order. Shared by every backend so
+    * filter semantics stay consistent across platforms.
+    */
+  def effectiveHandler: RxHttpHandler =
+    if filters.isEmpty then
+      handler
+    else
+      val chained = RxHttpFilter.chain(filters)
+      RxHttpHandler { request =>
+        chained.apply(request, handler)
+      }
+
+  /**
+    * Start the server and return the running server instance. Backends override this with a
+    * covariant return type (e.g. `NettyHttpServer`).
+    */
+  def start(): HttpServer
+
+  /**
+    * Start the server, run the given block, then stop the server.
+    */
+  def start[A](block: HttpServer => A): A =
+    val server = start()
+    try block(server)
+    finally server.stop()
+
+end HttpServerConfig

--- a/uni/src/main/scala/wvlet/uni/http/HttpServerConfig.scala
+++ b/uni/src/main/scala/wvlet/uni/http/HttpServerConfig.scala
@@ -66,11 +66,16 @@ trait HttpServerConfig:
     */
   def startAndAwait[A](block: HttpServer => Rx[A]): Rx[A] =
     val server = start()
-    server
-      .whenReady
-      .flatMap(block)
-      .tapOn { case _ =>
+    // Stop the server once the block's stream TERMINATES, not on each emitted value:
+    //  - on failure: tapOnFailure stops (concat won't run a failed source's tail)
+    //  - on normal completion (including zero emissions): the appended cleanup runs stop and emits
+    //    nothing, so a block returning Rx.empty still shuts the server down.
+    val cleanup = Rx
+      .single(())
+      .flatMap { _ =>
         server.stop()
+        Rx.empty[A]
       }
+    server.whenReady.flatMap(block).tapOnFailure(_ => server.stop()).concat(cleanup)
 
 end HttpServerConfig

--- a/uni/src/main/scala/wvlet/uni/http/HttpServerConfig.scala
+++ b/uni/src/main/scala/wvlet/uni/http/HttpServerConfig.scala
@@ -13,6 +13,8 @@
  */
 package wvlet.uni.http
 
+import wvlet.uni.rx.Rx
+
 /**
   * Platform-neutral HTTP server configuration. Backend-specific configs (e.g. `NettyServerConfig`,
   * `NodeServerConfig`) implement this trait so the common surface — name/host/port, the request
@@ -46,11 +48,29 @@ trait HttpServerConfig:
   def start(): HttpServer
 
   /**
-    * Start the server, run the given block, then stop the server.
+    * Start the server, run the given block, then stop the server. The block runs as soon as
+    * `start()` returns, so this is only safe on backends that bind synchronously (Netty). On
+    * asynchronously-binding backends (Node.js) use [[startAndAwait]] instead, which waits for the
+    * server to be ready before running the block.
     */
   def start[A](block: HttpServer => A): A =
     val server = start()
     try block(server)
     finally server.stop()
+
+  /**
+    * Start the server, wait until it is listening, run the given async block, then stop the server
+    * once the block's Rx completes (or fails). This works uniformly across backends — including
+    * Node.js, whose bind is asynchronous — so it is the portable way to run a server in tests and
+    * apps.
+    */
+  def startAndAwait[A](block: HttpServer => Rx[A]): Rx[A] =
+    val server = start()
+    server
+      .whenReady
+      .flatMap(block)
+      .tapOn { case _ =>
+        server.stop()
+      }
 
 end HttpServerConfig

--- a/uni/src/main/scala/wvlet/uni/http/RxHttpHandler.scala
+++ b/uni/src/main/scala/wvlet/uni/http/RxHttpHandler.scala
@@ -11,13 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package wvlet.uni.http.netty
+package wvlet.uni.http
 
-import wvlet.uni.http.{HttpFilter, HttpHandler, Request, Response}
 import wvlet.uni.rx.Rx
 
 /**
-  * Async HTTP handler that returns Rx[Response]
+  * Async HTTP handler that returns Rx[Response]. This is the platform-neutral server-side contract
+  * implemented by every backend (Netty on JVM, Node.js on Scala.js, ...).
   */
 trait RxHttpHandler:
   def handle(request: Request): Rx[Response]


### PR DESCRIPTION
## Why

Uni's HTTP server lived only in the JVM-only `uni-netty` module, with the core server contract (`RxHttpHandler`/`RxHttpFilter`) trapped inside it. The motivating goal is **WebSocket support**: a WebSocket server is an HTTP server with an `Upgrade` handshake, so a *cross-platform* WS server is impossible without a *cross-platform* HTTP server first.

This PR delivers that foundation (WebSocket itself is a follow-up).

## What

- **Lift the server abstraction into shared `uni`** (`wvlet.uni.http`):
  - Move `RxHttpHandler` / `RxHttpFilter` out of `uni-netty` into the cross-built module.
  - New `HttpServer` (lifecycle: `localAddress`/`localPort`/`isRunning`/`stop`/`awaitTermination`/`close`).
  - New `HttpServerConfig` (common `name`/`host`/`port`/`handler`/`filters` surface + shared filter-chaining `effectiveHandler` + `start[A](block)`).
- **Refactor `uni-netty` onto the shared abstraction** — `NettyServerConfig extends HttpServerConfig`, `NettyHttpServer extends HttpServer`. Behavior-preserving: all 23 `NettyServerTest` cases pass unchanged.
- **Add a Node.js (Scala.js) backend** — `NodeServer`/`NodeHttpServer` over Node's built-in `http` module: GET/POST, request/response header round-trip, 404 default handler, SSE chunked streaming, and ephemeral-port (`port 0`) binding. The Node builtin-module loader is factored into `NodeModules` and reused by `NodeSyncHttpChannel`.

Programming model is now identical across platforms:

```scala
// JVM
NettyServer.withPort(0).withRxHandler(h).start { server => ... }
// Node.js (Scala.js) — bind is async, so wait for readiness
NodeServer.withPort(0).withRxHandler(h).startAndAwait { server => rxAssertions }
```

## Design notes

- The shared `start()` is synchronous, but Node's socket bind is async — bridged via `NodeHttpServer.whenReady: Rx[...]` + `NodeServerConfig.startAndAwait`.
- Native server is intentionally deferred; the abstraction assumes neither Netty nor Node specifics so a future posix-socket backend slots in.
- Plan + learnings: `plans/2026-06-18-cross-platform-http-server.md`.

## Out of scope (follow-ups)
- WebSocket handlers/routes (server + cross-platform client).
- Scala Native HTTP server.

## Testing
- `netty/test` — 23/23 pass (JVM refactor regression).
- New `uni/.js` `NodeServerTest` — 5/5 pass.
- Full suites: JVM 1622, JS 1371 green; Native compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)