### PR TITLE
feature: Add Scala Native HTTP server (POSIX sockets)

### DIFF
--- a/plans/2026-06-18-native-http-server.md
+++ b/plans/2026-06-18-native-http-server.md
@@ -145,9 +145,23 @@ Reuse: shared `HttpServer`/`HttpServerConfig`/`RxHttpHandler`/`Request`/`Respons
   therefore uses a raw POSIX-socket client** (a stronger end-to-end check anyway). Fixing/auditing
   the Native curl client is a separate follow-up (see below).
 
+- **Review hardening (/code-review + Gemini):** reject unparseable/oversized and conflicting
+  duplicate `Content-Length` headers (request-smuggling defense); suppress the body for HEAD and
+  204/304/1xx responses; bound the handler `Rx` await with a timeout (→503) so a never-completing
+  handler can't wedge a worker; guard the accept-loop `execute` against `RejectedExecutionException`
+  (close the fd, don't kill the accept thread); validate the port range and reject an unparseable
+  bind host (`inet_addr` INADDR_NONE); switch the per-connection read buffer to an `ArrayBuffer`
+  (amortized O(1)) to kill an O(n²) DoS amplifier. Added regression tests for the security fixes.
+- **SO_RCVTIMEO read timeout attempted and dropped:** posixlib declares `suseconds_t = CLong`, but
+  macOS's `timeval.tv_usec` is a 4-byte `__int32_t`, so the posixlib `timeval` is the wrong layout
+  there and `setsockopt(SO_RCVTIMEO, ...)` made `recv` return immediately. Dropped for the MVP
+  (worker threads are daemon threads, so shutdown can't hang the process; handler-await is bounded).
+  A portable read/idle timeout is a follow-up.
+
 ## Out of scope (follow-ups)
 - **Investigate the Native libcurl client `CURLE_URL_MALFORMAT` bug** (variadic `curl_easy_setopt`
   binding) discovered while testing — likely affects all Native client requests.
+- A portable per-connection **read/idle timeout** (the posixlib `timeval` layout is wrong on macOS).
 - SSE (`Response.events`) + chunked transfer encoding on Native (parallel to Netty/Node).
 - WebSocket on Native (would build on this server, like the JVM WS server builds on Netty).
 - A `poll`-based non-blocking event loop / TLS.

--- a/plans/2026-06-18-native-http-server.md
+++ b/plans/2026-06-18-native-http-server.md
@@ -1,0 +1,153 @@
+# Scala Native HTTP Server (POSIX sockets)
+
+## Context
+
+The cross-platform HTTP server abstraction (`HttpServer`/`HttpServerConfig`/`RxHttpHandler`, shared in
+`uni`) has JVM (Netty) and Node.js backends; Scala Native has only an HTTP *client* (libcurl). This is
+the planned third backend so the server runs on JVM + Node + **Native**, completing the cross-platform
+goal set when the foundation landed (#572).
+
+**Feasibility (confirmed):**
+- Scala Native **0.5.12** is multithreaded — `java.lang.Thread`, `Executors`, `Future`/`Promise`,
+  `LinkedBlockingQueue`, `AtomicBoolean` are all already used on Native in this repo
+  (`uni-core/.native/.../io/IOCompat.scala`, `.../rx/compat.scala`, `uni/.native/.../rx/schedulerCompat.scala`).
+- **POSIX TCP sockets** (`socket`/`setsockopt`/`bind`/`listen`/`accept`/`recv`/`send`/`getsockname`/`close`)
+  come from Scala Native's bundled `posixlib` (`scala.scalanative.posix.*`) — **no new dependency and no
+  linker flag** (sockets are in libc). posixlib is already used on Native (`FileSystemImpl`, `compat`).
+- A Native test can start the server and drive it with the **in-module libcurl sync client**
+  (`Http.client...newSyncClient` → `CurlChannel`); the server uses its own threads, so the blocking
+  client doesn't deadlock (unlike Node's single event loop).
+
+**Approach (decided):** hand-written HTTP/1.1 over POSIX sockets — consistent with uni's minimal-deps
+ethos and the libcurl precedent, and free of the licensing problems of C server libs (mongoose = GPL/
+commercial, libmicrohttpd = LGPL; both incompatible with Apache-2.0).
+
+**Scope (MVP):** blocking accept thread + worker thread pool; HTTP/1.1 request/response with
+`Content-Length` bodies, headers, keep-alive, ephemeral port. SSE/chunked streaming and WebSocket are
+follow-ups.
+
+## Design
+
+All new code in `uni/.native/src/main/scala/wvlet/uni/http/`, mirroring the `NodeServer`/`NettyServer`
+shape. No shared-module changes (server backends are selected by using their config directly; there is
+no factory registry).
+
+### 1. `NativeServer.scala` — entry + config
+- `object NativeServer` with `withPort/withHandler/withRxHandler` (mirrors `NodeServer`).
+- `case class NativeServerConfig(name, host, port, handler, filters, backlog = 128,
+  maxRequestSize = 1MB, workerThreads = ...) extends HttpServerConfig` with the common
+  `withName/withHost/withPort/withHandler/withRxHandler/withFilter/withFilters` builders plus
+  native knobs (`withBacklog`, `withMaxRequestSize`, `withWorkerThreads`), and
+  `override def start(): NativeHttpServer`. Binding is synchronous, so the inherited
+  `start[A](block)` is safe (no override needed, unlike Node).
+
+### 2. POSIX socket usage (prefer posixlib; thin helpers only where needed)
+Use `scala.scalanative.posix.sys.socket.*`, `netinet.in.*`, `netinet.inOps.*`, `arpa.inet.*`
+(`htons`), `unistd.*`, and `scala.scalanative.posix.poll` if needed. Memory via `stackalloc`
+(sockaddr structs, out-params) and `Zone`/`malloc` for buffers — the pattern established by
+`CurlBindings.scala`/`CurlChannel.scala`. Add a small `@extern`/`@name` binding **only** for any
+symbol posixlib lacks (decided by a short compile spike — see Risks). No `@link` needed (libc).
+
+### 3. `NativeHttpServer.scala` — `extends HttpServer`
+- `start()`:
+  - `socket(AF_INET, SOCK_STREAM, 0)`; `setsockopt(SO_REUSEADDR)`; fill `sockaddr_in`
+    (`htons(port)`, host); `bind`; `listen(backlog)`.
+  - Resolve the bound port via `getsockname` (so `withPort(0)` ephemeral works) → store it.
+  - Spawn a **daemon accept thread**; mark `running = true`.
+- Accept loop (accept thread): `accept()` in a loop while `running`; hand each connection fd to a
+  worker pool (`Executors.newFixedThreadPool(workerThreads)`). A failed `accept` while `!running`
+  means shutdown (listen fd closed) → exit the loop; otherwise log and continue.
+- Per-connection (worker thread):
+  1. Read+parse the request (§4) into a uni `Request`.
+  2. Run `config.effectiveHandler.handle(request): Rx[Response]` and **block for the single result**
+     via `RxRunner.runOnce` + a `CountDownLatch`/`AtomicReference` (the cross-platform Rx-await
+     pattern already in `uni-core/.native/.../rx/compat.scala`). `OnError` → 500; `OnCompletion`
+     without a value → 404.
+  3. Serialize the `Response` (§5) and `send` it.
+  4. Keep-alive: loop for the next request unless `Connection: close` or a read error/EOF; then
+     `close`.
+- `localPort`/`localAddress` from the stored bound address; `isRunning` from the flag; `whenReady`
+  returns `Rx.single(this)` (synchronous bind, like Netty); `stop()` sets `running = false`, closes
+  the listen fd (unblocks `accept`), and shuts down the worker pool with a timeout;
+  `awaitTermination()` joins the accept thread.
+
+### 4. `HttpRequestParser` (hand-written HTTP/1.1)
+- Read from the socket into a growing buffer until the header terminator `\r\n\r\n` (bounded by
+  `maxRequestSize`), tolerating partial `recv`s.
+- Parse the request line (`METHOD SP target SP HTTP/1.1`), then headers into `HttpMultiMap`
+  (`HttpMultiMap.newBuilder`), then read exactly `Content-Length` body bytes. Build the body with
+  the shared `HttpContent.fromBytes(bytes, headers)` (reused from the Netty/Node backends).
+- Map the method via `HttpMethod.of(...)`; an unknown verb or malformed request → a 400 written
+  directly (never throws past the worker). Chunked **request** bodies are out of MVP scope —
+  respond `400`/`411` (documented).
+
+### 5. `HttpResponseWriter`
+- Serialize `Response` → `HTTP/1.1 <code> <reason>\r\n`, headers, `Content-Type` (from
+  `content.contentType`), `Content-Length` (from `content.toContentBytes.length`), the keep-alive/
+  close `Connection` header, `\r\n\r\n`, then the body bytes. Reuses `HttpStatus.code`/`.reason`.
+
+### 6. No build.sbt / dependency changes
+posixlib + threads are bundled; sockets are libc. Nothing to add.
+
+## Files
+
+| Action | Path |
+|---|---|
+| Add | `uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala` (object + `NativeServerConfig`) |
+| Add | `uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala` (`HttpServer` impl: sockets + accept loop + workers) |
+| Add | `uni/.native/src/main/scala/wvlet/uni/http/NativeHttpProtocol.scala` (request parser + response writer; or split into two files) |
+| Add | `uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala` (NEW native test tree) |
+
+Reuse: shared `HttpServer`/`HttpServerConfig`/`RxHttpHandler`/`Request`/`Response`/`HttpContent.fromBytes`/
+`HttpMultiMap`/`HttpStatus`/`RxRunner`; the `CurlBindings.scala` extern/memory pattern; the
+`NodeServerConfig`/`NettyServerConfig` builder shape; the `rx/compat.scala` Rx-await pattern.
+
+## Verification
+- **Compile spike first** (de-risks the one unknown): a tiny `uniNative/compile` that calls
+  `socket/bind/listen/getsockname` to pin the exact posixlib symbol names/signatures in SN 0.5.12,
+  before building the full server.
+- `./sbt scalafmtAll` then `./sbt uniNative/compile`.
+- New `uni/.native` `NativeServerTest`: `NativeServer.withPort(0).withHandler(...).start { server => ... }`,
+  then hit it with the in-module libcurl **sync** client
+  (`Http.client.withBaseUri(s"http://localhost:${server.localPort}").newSyncClient`): assert GET body+
+  status, POST echoes the body, request/response headers round-trip, unmatched path → 404, and the
+  ephemeral port is reported. Run `./sbt uniNative/test`.
+- Regression: `./sbt uniJVM/test uniJS/test netty/test` stay green (no shared changes expected).
+- Native binaries build per-platform on CI ("Scala Native" job) — the new test exercises a real
+  socket round-trip there.
+
+## Risks / notes
+- **posixlib API surface** is the one unknown (exact names for `getsockname`, `sockaddr_in` field
+  ops, `htons`). Mitigated by the upfront compile spike; fall back to a minimal `@extern`/`@name`
+  binding for any missing symbol (libc, no `@link`).
+- **HTTP/1.1 correctness** is owned by us: scope to `Content-Length` bodies + basic keep-alive;
+  reject malformed/chunked-request with 400/411; never let a parse error escape a worker thread.
+- **Concurrency**: handlers may run on multiple worker threads concurrently (same contract as Netty);
+  the accept loop must survive per-connection errors and shut down cleanly when the listen fd closes.
+- **Blocking I/O**: MVP uses blocking `recv`/`send` on worker threads (simple, correct). A `poll`/
+  event-loop model is a possible later optimization, not needed for MVP.
+
+## Implementation notes / learnings
+
+- **posixlib socket API (SN 0.5.12)**: all calls came from `scala.scalanative.posix.sys.socket`,
+  `netinet.in`/`inOps`, `arpa.inet`, `unistd` — no extern bindings or linker flags needed. The one
+  non-obvious bit: `in_addr` is `CStruct1[in_addr_t]`, so set the address via `ia._1 = inet_addr(...)`
+  (the `inOps` `s_addr` setter is value-based, not Ptr-based). Use the `sockaddr_inOps` setters
+  (`sin_family_=`/`sin_port_=`/`sin_addr_=`) so BSD/macOS `sin_len` is handled; `memset` the struct
+  first since `stackalloc` is not zeroed.
+- **Threading** worked exactly as expected on SN 0.5.12: a daemon accept `Thread` + an
+  `Executors.newFixedThreadPool`; `RxRunner.runOnce` + a `CountDownLatch`/`AtomicReference` blocks a
+  worker for the handler's single `Rx[Response]`.
+- **The Native libcurl *client* is currently broken on a loopback request** — `CurlChannel.send`
+  returns curl error 3 (CURLE_URL_MALFORMAT) for a perfectly valid `http://localhost:PORT/...` URL,
+  i.e. the URL isn't reaching libcurl (likely the variadic `curl_easy_setopt` fixed-arity binding).
+  There is no existing Native HTTP round-trip test, so this was never exercised. **The server test
+  therefore uses a raw POSIX-socket client** (a stronger end-to-end check anyway). Fixing/auditing
+  the Native curl client is a separate follow-up (see below).
+
+## Out of scope (follow-ups)
+- **Investigate the Native libcurl client `CURLE_URL_MALFORMAT` bug** (variadic `curl_easy_setopt`
+  binding) discovered while testing — likely affects all Native client requests.
+- SSE (`Response.events`) + chunked transfer encoding on Native (parallel to Netty/Node).
+- WebSocket on Native (would build on this server, like the JVM WS server builds on Netty).
+- A `poll`-based non-blocking event loop / TLS.

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpProtocol.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpProtocol.scala
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import java.nio.charset.StandardCharsets
+
+/**
+  * Result of reading one request from a keep-alive connection.
+  */
+private[http] enum ReadResult:
+  case Req(request: Request)
+  case BadRequest(message: String)
+  case Closed
+
+/**
+  * A minimal HTTP/1.1 request reader over a byte-chunk source. Handles keep-alive (multiple
+  * requests per connection) by retaining any bytes read past the current request. Bodies are read
+  * by `Content-Length`; chunked request bodies are not supported (MVP) and yield a `BadRequest`.
+  *
+  * @param readChunk
+  *   reads the next batch of bytes from the socket; an empty array means EOF.
+  */
+private[http] class HttpConnectionReader(readChunk: () => Array[Byte], maxRequestSize: Int):
+
+  private var buf: Array[Byte] = Array.emptyByteArray
+
+  /** Append another chunk to the buffer. Returns false on EOF. */
+  private def fill(): Boolean =
+    val chunk = readChunk()
+    if chunk.isEmpty then
+      false
+    else
+      buf = buf ++ chunk
+      true
+
+  /** Index just past the `\r\n\r\n` header terminator, or -1 if not yet present. */
+  private def headerEnd: Int =
+    var i = 0
+    val n = buf.length - 3
+    while i < n do
+      if buf(i) == '\r' && buf(i + 1) == '\n' && buf(i + 2) == '\r' && buf(i + 3) == '\n' then
+        return i + 4
+      i += 1
+    -1
+
+  def readRequest(): ReadResult =
+    // Accumulate until the header block is complete.
+    var endIdx = headerEnd
+    while endIdx < 0 do
+      if buf.length > maxRequestSize then
+        return ReadResult.BadRequest("Request header too large")
+      if !fill() then
+        // Clean EOF with no pending bytes = connection closed; partial data = malformed.
+        return if buf.isEmpty then
+          ReadResult.Closed
+        else
+          ReadResult.BadRequest("Incomplete request")
+      endIdx = headerEnd
+
+    // Header block is bytes [0, endIdx-4); headers are ASCII/Latin-1.
+    val headerText = new String(buf, 0, endIdx - 4, StandardCharsets.ISO_8859_1)
+    val lines      = headerText.split("\r\n", -1)
+    if lines.isEmpty || lines(0).isEmpty then
+      return ReadResult.BadRequest("Empty request line")
+
+    val requestLine = lines(0).split(" ")
+    if requestLine.length < 2 then
+      return ReadResult.BadRequest("Malformed request line")
+    val methodName = requestLine(0)
+    val target     = requestLine(1)
+
+    val headerBuilder = HttpMultiMap.newBuilder
+    var li            = 1
+    while li < lines.length do
+      val line = lines(li)
+      if line.nonEmpty then
+        val colon = line.indexOf(':')
+        if colon > 0 then
+          headerBuilder.add(line.substring(0, colon).trim, line.substring(colon + 1).trim)
+      li += 1
+    val headers = headerBuilder.result()
+
+    if headers.get(HttpHeader.TransferEncoding).exists(_.toLowerCase.contains("chunked")) then
+      return ReadResult.BadRequest("Chunked request bodies are not supported")
+
+    val contentLength = headers.get(HttpHeader.ContentLength).flatMap(_.toIntOption).getOrElse(0)
+    if contentLength < 0 || contentLength > maxRequestSize then
+      return ReadResult.BadRequest("Invalid Content-Length")
+
+    // Ensure the full body is buffered.
+    while buf.length - endIdx < contentLength do
+      if !fill() then
+        return ReadResult.BadRequest("Incomplete request body")
+
+    val body = buf.slice(endIdx, endIdx + contentLength)
+    // Retain any bytes past this request for the next (pipelined/keep-alive) read.
+    buf = buf.drop(endIdx + contentLength)
+
+    HttpMethod.of(methodName) match
+      case Some(method) =>
+        val content = HttpContent.fromBytes(body, headers)
+        ReadResult.Req(Request(method = method, uri = target, headers = headers, content = content))
+      case None =>
+        ReadResult.BadRequest(s"Unsupported HTTP method: ${methodName}")
+
+  end readRequest
+
+end HttpConnectionReader
+
+/**
+  * Serializes a [[Response]] to HTTP/1.1 wire bytes.
+  */
+private[http] object HttpResponseWriter:
+
+  def serialize(response: Response, keepAlive: Boolean): Array[Byte] =
+    val body = response.content.toContentBytes
+    val sb   = StringBuilder()
+    sb.append("HTTP/1.1 ")
+      .append(response.status.code)
+      .append(" ")
+      .append(response.status.reason)
+      .append("\r\n")
+
+    // Copy response headers, but skip the ones we set explicitly below to avoid duplicates.
+    response
+      .headers
+      .entries
+      .foreach { case (name, value) =>
+        if !isManagedHeader(name) then
+          sb.append(name).append(": ").append(value).append("\r\n")
+      }
+
+    response
+      .content
+      .contentType
+      .foreach { ct =>
+        sb.append(HttpHeader.ContentType).append(": ").append(ct.value).append("\r\n")
+      }
+    sb.append(HttpHeader.ContentLength).append(": ").append(body.length).append("\r\n")
+    sb.append(HttpHeader.Connection)
+      .append(": ")
+      .append(
+        if keepAlive then
+          "keep-alive"
+        else
+          "close"
+      )
+      .append("\r\n")
+    sb.append("\r\n")
+
+    val head = sb.toString.getBytes(StandardCharsets.ISO_8859_1)
+    if body.isEmpty then
+      head
+    else
+      head ++ body
+
+  end serialize
+
+  private def isManagedHeader(name: String): Boolean =
+    name.equalsIgnoreCase(HttpHeader.ContentType) ||
+      name.equalsIgnoreCase(HttpHeader.ContentLength) ||
+      name.equalsIgnoreCase(HttpHeader.Connection)
+
+end HttpResponseWriter

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpProtocol.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpProtocol.scala
@@ -14,6 +14,7 @@
 package wvlet.uni.http
 
 import java.nio.charset.StandardCharsets
+import scala.collection.mutable
 
 /**
   * Result of reading one request from a keep-alive connection.
@@ -33,7 +34,9 @@ private[http] enum ReadResult:
   */
 private[http] class HttpConnectionReader(readChunk: () => Array[Byte], maxRequestSize: Int):
 
-  private var buf: Array[Byte] = Array.emptyByteArray
+  // Amortized-O(1) append buffer (indexed scan, single slice per request) — avoids the O(n^2) of
+  // repeatedly concatenating Array[Byte].
+  private val buf = mutable.ArrayBuffer.empty[Byte]
 
   /** Append another chunk to the buffer. Returns false on EOF. */
   private def fill(): Boolean =
@@ -41,7 +44,7 @@ private[http] class HttpConnectionReader(readChunk: () => Array[Byte], maxReques
     if chunk.isEmpty then
       false
     else
-      buf = buf ++ chunk
+      buf ++= chunk
       true
 
   /** Index just past the `\r\n\r\n` header terminator, or -1 if not yet present. */
@@ -69,7 +72,7 @@ private[http] class HttpConnectionReader(readChunk: () => Array[Byte], maxReques
       endIdx = headerEnd
 
     // Header block is bytes [0, endIdx-4); headers are ASCII/Latin-1.
-    val headerText = new String(buf, 0, endIdx - 4, StandardCharsets.ISO_8859_1)
+    val headerText = new String(buf.slice(0, endIdx - 4).toArray, StandardCharsets.ISO_8859_1)
     val lines      = headerText.split("\r\n", -1)
     if lines.isEmpty || lines(0).isEmpty then
       return ReadResult.BadRequest("Empty request line")
@@ -94,18 +97,30 @@ private[http] class HttpConnectionReader(readChunk: () => Array[Byte], maxReques
     if headers.get(HttpHeader.TransferEncoding).exists(_.toLowerCase.contains("chunked")) then
       return ReadResult.BadRequest("Chunked request bodies are not supported")
 
-    val contentLength = headers.get(HttpHeader.ContentLength).flatMap(_.toIntOption).getOrElse(0)
-    if contentLength < 0 || contentLength > maxRequestSize then
-      return ReadResult.BadRequest("Invalid Content-Length")
+    // Resolve Content-Length defensively: reject an unparseable/oversized value or conflicting
+    // duplicate headers, rather than silently treating the body as empty (which would leave the
+    // declared body in the buffer and desync the next keep-alive read — request smuggling).
+    val contentLengthValues = headers.getAll(HttpHeader.ContentLength).distinct
+    val contentLength       =
+      if contentLengthValues.isEmpty then
+        0
+      else if contentLengthValues.sizeIs > 1 then
+        return ReadResult.BadRequest("Conflicting Content-Length headers")
+      else
+        contentLengthValues.head.toIntOption match
+          case Some(n) if n >= 0 && n <= maxRequestSize =>
+            n
+          case _ =>
+            return ReadResult.BadRequest("Invalid Content-Length")
 
     // Ensure the full body is buffered.
     while buf.length - endIdx < contentLength do
       if !fill() then
         return ReadResult.BadRequest("Incomplete request body")
 
-    val body = buf.slice(endIdx, endIdx + contentLength)
-    // Retain any bytes past this request for the next (pipelined/keep-alive) read.
-    buf = buf.drop(endIdx + contentLength)
+    val body = buf.slice(endIdx, endIdx + contentLength).toArray
+    // Drop the consumed bytes, retaining any leftover for the next (pipelined/keep-alive) request.
+    buf.remove(0, endIdx + contentLength)
 
     HttpMethod.of(methodName) match
       case Some(method) =>
@@ -123,14 +138,19 @@ end HttpConnectionReader
   */
 private[http] object HttpResponseWriter:
 
-  def serialize(response: Response, keepAlive: Boolean): Array[Byte] =
-    val body = response.content.toContentBytes
-    val sb   = StringBuilder()
-    sb.append("HTTP/1.1 ")
-      .append(response.status.code)
-      .append(" ")
-      .append(response.status.reason)
-      .append("\r\n")
+  /**
+    * @param includeBody
+    *   false for responses to HEAD requests — headers (incl. Content-Length) are written but the
+    *   body bytes are omitted, per RFC 9110.
+    */
+  def serialize(response: Response, keepAlive: Boolean, includeBody: Boolean): Array[Byte] =
+    val code = response.status.code
+    // 1xx, 204, and 304 responses must not carry a message body or Content-Length.
+    val bodyForbidden = code == 204 || code == 304 || (code >= 100 && code < 200)
+    val body          = response.content.toContentBytes
+
+    val sb = StringBuilder()
+    sb.append("HTTP/1.1 ").append(code).append(" ").append(response.status.reason).append("\r\n")
 
     // Copy response headers, but skip the ones we set explicitly below to avoid duplicates.
     response
@@ -141,13 +161,15 @@ private[http] object HttpResponseWriter:
           sb.append(name).append(": ").append(value).append("\r\n")
       }
 
-    response
-      .content
-      .contentType
-      .foreach { ct =>
-        sb.append(HttpHeader.ContentType).append(": ").append(ct.value).append("\r\n")
-      }
-    sb.append(HttpHeader.ContentLength).append(": ").append(body.length).append("\r\n")
+    if !bodyForbidden then
+      response
+        .content
+        .contentType
+        .foreach { ct =>
+          sb.append(HttpHeader.ContentType).append(": ").append(ct.value).append("\r\n")
+        }
+      sb.append(HttpHeader.ContentLength).append(": ").append(body.length).append("\r\n")
+
     sb.append(HttpHeader.Connection)
       .append(": ")
       .append(
@@ -160,10 +182,10 @@ private[http] object HttpResponseWriter:
     sb.append("\r\n")
 
     val head = sb.toString.getBytes(StandardCharsets.ISO_8859_1)
-    if body.isEmpty then
-      head
-    else
+    if includeBody && !bodyForbidden && body.nonEmpty then
       head ++ body
+    else
+      head
 
   end serialize
 

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpProtocol.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpProtocol.scala
@@ -47,6 +47,8 @@ private[http] class HttpConnectionReader(readChunk: () => Array[Byte], maxReques
       buf ++= chunk
       true
 
+  private def isHttpWhitespace(b: Byte): Boolean = b == '\r' || b == '\n' || b == ' ' || b == '\t'
+
   /** Index just past the `\r\n\r\n` header terminator, or -1 if not yet present. */
   private def headerEnd: Int =
     var i = 0
@@ -64,8 +66,9 @@ private[http] class HttpConnectionReader(readChunk: () => Array[Byte], maxReques
       if buf.length > maxRequestSize then
         return ReadResult.BadRequest("Request header too large")
       if !fill() then
-        // Clean EOF with no pending bytes = connection closed; partial data = malformed.
-        return if buf.isEmpty then
+        // Clean EOF: an empty or whitespace-only buffer (e.g. a trailing CRLF after a keep-alive
+        // request) means the connection closed; anything else is a truncated request.
+        return if buf.forall(isHttpWhitespace) then
           ReadResult.Closed
         else
           ReadResult.BadRequest("Incomplete request")
@@ -73,8 +76,9 @@ private[http] class HttpConnectionReader(readChunk: () => Array[Byte], maxReques
 
     // Header block is bytes [0, endIdx-4); headers are ASCII/Latin-1.
     val headerText = new String(buf.slice(0, endIdx - 4).toArray, StandardCharsets.ISO_8859_1)
-    val lines      = headerText.split("\r\n", -1)
-    if lines.isEmpty || lines(0).isEmpty then
+    // Per RFC 7230, tolerate empty line(s) before the request line.
+    val lines = headerText.split("\r\n", -1).dropWhile(_.isEmpty)
+    if lines.isEmpty then
       return ReadResult.BadRequest("Empty request line")
 
     val requestLine = lines(0).split(" ")
@@ -162,12 +166,14 @@ private[http] object HttpResponseWriter:
       }
 
     if !bodyForbidden then
-      response
-        .content
-        .contentType
-        .foreach { ct =>
-          sb.append(HttpHeader.ContentType).append(": ").append(ct.value).append("\r\n")
-        }
+      // Prefer an explicitly-set Content-Type header over the content's default type.
+      val contentType = response
+        .headers
+        .get(HttpHeader.ContentType)
+        .orElse(response.content.contentType.map(_.value))
+      contentType.foreach { ct =>
+        sb.append(HttpHeader.ContentType).append(": ").append(ct).append("\r\n")
+      }
       sb.append(HttpHeader.ContentLength).append(": ").append(body.length).append("\r\n")
 
     sb.append(HttpHeader.Connection)

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
@@ -75,9 +75,11 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
       val clientFd = NativeSocket.accept(serverFd)
       if clientFd < 0 then
         // A failed accept while still running is logged; while stopping it means the listening
-        // socket was closed, so exit the loop.
+        // socket was closed, so exit the loop. Sleep briefly to avoid a 100% CPU spin on a
+        // persistent error (e.g. EMFILE — too many open files).
         if running.get() then
-          debug("accept() failed; continuing")
+          debug("accept() failed; retrying")
+          Thread.sleep(NativeHttpServer.AcceptErrorBackoffMillis)
       else
         val pool = workerPool
         if pool != null && running.get() then
@@ -182,9 +184,14 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
     if !stopped.compareAndSet(false, true) then
       return
     running.set(false)
-    // Closing the listening socket unblocks accept() so the accept thread can exit.
+    // Closing the listening socket unblocks accept() so the accept thread can exit. Guard it so a
+    // close failure can't abort the rest of shutdown.
     if serverFd >= 0 then
-      NativeSocket.close(serverFd)
+      try
+        NativeSocket.close(serverFd)
+      catch
+        case NonFatal(e) =>
+          debug(s"Error closing server socket: ${e.getMessage}")
     Option(workerPool).foreach { pool =>
       pool.shutdown()
       if !pool.awaitTermination(NativeHttpServer.ShutdownTimeoutMillis, TimeUnit.MILLISECONDS) then
@@ -198,4 +205,5 @@ end NativeHttpServer
 
 object NativeHttpServer:
   private final val ShutdownTimeoutMillis                 = 5000L
+  private final val AcceptErrorBackoffMillis              = 10L
   def apply(config: NativeServerConfig): NativeHttpServer = new NativeHttpServer(config)

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
@@ -81,7 +81,12 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
       else
         val pool = workerPool
         if pool != null && running.get() then
-          pool.execute(() => handleConnection(clientFd))
+          // execute can be rejected if stop() raced in between; close the fd rather than leak it.
+          try
+            pool.execute(() => handleConnection(clientFd))
+          catch
+            case NonFatal(_) =>
+              NativeSocket.close(clientFd)
         else
           NativeSocket.close(clientFd)
 
@@ -99,15 +104,21 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
           case ReadResult.BadRequest(message) =>
             NativeSocket.sendAll(
               clientFd,
-              HttpResponseWriter.serialize(Response.badRequest(message), keepAlive = false)
+              HttpResponseWriter.serialize(
+                Response.badRequest(message),
+                keepAlive = false,
+                includeBody = true
+              )
             )
             continue = false
           case ReadResult.Req(request) =>
             val response  = runHandler(request)
             val keepAlive = clientWantsKeepAlive(request)
-            val sent      = NativeSocket.sendAll(
+            // A HEAD response carries headers (incl. Content-Length) but no body.
+            val includeBody = request.method != HttpMethod.HEAD
+            val sent        = NativeSocket.sendAll(
               clientFd,
-              HttpResponseWriter.serialize(response, keepAlive)
+              HttpResponseWriter.serialize(response, keepAlive, includeBody)
             )
             if !keepAlive || !sent then
               continue = false
@@ -141,8 +152,12 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
           result.compareAndSet(null, Response.notFound)
           latch.countDown()
       }
-      latch.await()
-      result.get()
+      // Bound the wait so a handler whose Rx never completes can't wedge the worker thread forever.
+      if latch.await(config.handlerTimeoutMillis, TimeUnit.MILLISECONDS) then
+        result.get()
+      else
+        warn(s"Handler timed out after ${config.handlerTimeoutMillis} ms")
+        Response.serviceUnavailable
     catch
       case NonFatal(e) =>
         warn(s"Error handling request: ${e.getMessage}", e)

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.log.LogSupport
+import wvlet.uni.rx.{OnCompletion, OnError, OnNext, Rx, RxRunner}
+
+import java.util.concurrent.{CountDownLatch, ExecutorService, Executors, ThreadFactory, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import scala.util.control.NonFatal
+
+/**
+  * Scala Native HTTP server backed by POSIX TCP sockets. A daemon accept thread hands each accepted
+  * connection to a worker pool; workers parse HTTP/1.1 requests, run the (filter-composed) handler,
+  * and write responses, keeping the connection alive unless the client requests close.
+  *
+  * Binding is synchronous, so [[whenReady]] completes immediately (like the Netty backend).
+  */
+class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSupport:
+
+  private val handler: RxHttpHandler = config.effectiveHandler
+
+  private val started = AtomicBoolean(false)
+  private val running = AtomicBoolean(false)
+  private val stopped = AtomicBoolean(false)
+
+  @volatile
+  private var serverFd: Int = -1
+
+  @volatile
+  private var boundPort: Int = -1
+
+  @volatile
+  private var acceptThread: Thread = null
+
+  @volatile
+  private var workerPool: ExecutorService = null
+
+  def start(): Unit =
+    if !started.compareAndSet(false, true) then
+      throw IllegalStateException("Server is already started")
+
+    val (fd, port) = NativeSocket.bindAndListen(config.host, config.port, config.backlog)
+    serverFd = fd
+    boundPort = port
+
+    workerPool = Executors.newFixedThreadPool(
+      config.workerThreads,
+      daemonThreadFactory(s"${config.name}-worker")
+    )
+
+    running.set(true)
+    val t = Thread(() => acceptLoop())
+    t.setDaemon(true)
+    t.setName(s"${config.name}-acceptor")
+    t.start()
+    acceptThread = t
+    debug(s"Native server started at ${localAddress}")
+
+  end start
+
+  private def acceptLoop(): Unit =
+    while running.get() do
+      val clientFd = NativeSocket.accept(serverFd)
+      if clientFd < 0 then
+        // A failed accept while still running is logged; while stopping it means the listening
+        // socket was closed, so exit the loop.
+        if running.get() then
+          debug("accept() failed; continuing")
+      else
+        val pool = workerPool
+        if pool != null && running.get() then
+          pool.execute(() => handleConnection(clientFd))
+        else
+          NativeSocket.close(clientFd)
+
+  private def handleConnection(clientFd: Int): Unit =
+    try
+      val reader = HttpConnectionReader(
+        () => NativeSocket.recvChunk(clientFd),
+        config.maxRequestSize
+      )
+      var continue = true
+      while continue do
+        reader.readRequest() match
+          case ReadResult.Closed =>
+            continue = false
+          case ReadResult.BadRequest(message) =>
+            NativeSocket.sendAll(
+              clientFd,
+              HttpResponseWriter.serialize(Response.badRequest(message), keepAlive = false)
+            )
+            continue = false
+          case ReadResult.Req(request) =>
+            val response  = runHandler(request)
+            val keepAlive = clientWantsKeepAlive(request)
+            val sent      = NativeSocket.sendAll(
+              clientFd,
+              HttpResponseWriter.serialize(response, keepAlive)
+            )
+            if !keepAlive || !sent then
+              continue = false
+    catch
+      case NonFatal(e) =>
+        debug(s"Connection handling error: ${e.getMessage}")
+    finally
+      NativeSocket.close(clientFd)
+
+  private def clientWantsKeepAlive(request: Request): Boolean =
+    !request.header(HttpHeader.Connection).exists(_.equalsIgnoreCase("close"))
+
+  /**
+    * Run the handler and block for its single response. The handler may be asynchronous (Rx), so
+    * the worker thread waits on a latch for the first event.
+    */
+  private def runHandler(request: Request): Response =
+    try
+      val latch  = CountDownLatch(1)
+      val result = AtomicReference[Response]()
+      RxRunner.runOnce(handler.handle(request)) {
+        case OnNext(response) =>
+          result.set(response.asInstanceOf[Response])
+          latch.countDown()
+        case OnError(e) =>
+          warn(s"Error in handler: ${e.getMessage}", e)
+          result.set(Response.internalServerError(e.getMessage))
+          latch.countDown()
+        case OnCompletion =>
+          // Completed without emitting a response.
+          result.compareAndSet(null, Response.notFound)
+          latch.countDown()
+      }
+      latch.await()
+      result.get()
+    catch
+      case NonFatal(e) =>
+        warn(s"Error handling request: ${e.getMessage}", e)
+        Response.internalServerError(e.getMessage)
+
+  private def daemonThreadFactory(name: String): ThreadFactory =
+    (r: Runnable) =>
+      val t = Thread(r)
+      t.setDaemon(true)
+      t.setName(name)
+      t
+
+  override def whenReady: Rx[HttpServer] = Rx.single(this)
+
+  override def isRunning: Boolean = running.get() && !stopped.get()
+
+  override def localPort: Int = boundPort
+
+  override def localAddress: String = s"${config.host}:${boundPort}"
+
+  override def stop(): Unit =
+    if !stopped.compareAndSet(false, true) then
+      return
+    running.set(false)
+    // Closing the listening socket unblocks accept() so the accept thread can exit.
+    if serverFd >= 0 then
+      NativeSocket.close(serverFd)
+    Option(workerPool).foreach { pool =>
+      pool.shutdown()
+      if !pool.awaitTermination(NativeHttpServer.ShutdownTimeoutMillis, TimeUnit.MILLISECONDS) then
+        pool.shutdownNow()
+    }
+    debug(s"Native server stopped")
+
+  override def awaitTermination(): Unit = Option(acceptThread).foreach(_.join())
+
+end NativeHttpServer
+
+object NativeHttpServer:
+  private final val ShutdownTimeoutMillis                 = 5000L
+  def apply(config: NativeServerConfig): NativeHttpServer = new NativeHttpServer(config)

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
@@ -55,7 +55,9 @@ case class NativeServerConfig(
     // Maximum size (bytes) of request headers + body
     maxRequestSize: Int = 1024 * 1024,
     // Size of the worker thread pool that handles connections
-    workerThreads: Int = 16
+    workerThreads: Int = 16,
+    // Max time to wait for a handler's Rx to produce a response before returning 503
+    handlerTimeoutMillis: Long = 30000
 ) extends HttpServerConfig:
 
   def withName(name: String): NativeServerConfig = copy(name = name)
@@ -93,6 +95,10 @@ case class NativeServerConfig(
   def withWorkerThreads(threads: Int): NativeServerConfig =
     require(threads > 0, "workerThreads must be positive")
     copy(workerThreads = threads)
+
+  def withHandlerTimeoutMillis(millis: Long): NativeServerConfig =
+    require(millis > 0, "handlerTimeoutMillis must be positive")
+    copy(handlerTimeoutMillis = millis)
 
   /**
     * Start the server and return the running instance. Binding is synchronous, so the inherited

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.rx.Rx
+
+/**
+  * Entry point for creating a Scala Native HTTP server. This is the Native counterpart of
+  * `NettyServer` (JVM) and `NodeServer` (JS); all three produce an [[HttpServer]] from a shared
+  * [[HttpServerConfig]], so handler and filter code is identical across platforms.
+  *
+  * The server is built directly on POSIX TCP sockets (no external dependency): a daemon accept loop
+  * dispatches each connection to a worker thread pool, where requests are parsed, run through the
+  * handler, and answered with HTTP/1.1.
+  */
+object NativeServer:
+
+  def withPort(port: Int): NativeServerConfig = NativeServerConfig().withPort(port)
+
+  def withHandler(handler: HttpHandler): NativeServerConfig = NativeServerConfig().withHandler(
+    handler
+  )
+
+  def withHandler(f: Request => Response): NativeServerConfig = NativeServerConfig().withHandler(f)
+
+  def withRxHandler(handler: RxHttpHandler): NativeServerConfig = NativeServerConfig()
+    .withRxHandler(handler)
+
+  def withRxHandler(f: Request => Rx[Response]): NativeServerConfig = NativeServerConfig()
+    .withRxHandler(f)
+
+/**
+  * Configuration for [[NativeHttpServer]], mirroring `NettyServerConfig`/`NodeServerConfig`'s
+  * common surface plus a few Native-specific knobs.
+  */
+case class NativeServerConfig(
+    name: String = "native-server",
+    host: String = "0.0.0.0",
+    port: Int = 8080,
+    handler: RxHttpHandler = RxHttpHandler.notFound,
+    filters: Seq[RxHttpFilter] = Seq.empty,
+    // listen() backlog
+    backlog: Int = 128,
+    // Maximum size (bytes) of request headers + body
+    maxRequestSize: Int = 1024 * 1024,
+    // Size of the worker thread pool that handles connections
+    workerThreads: Int = 16
+) extends HttpServerConfig:
+
+  def withName(name: String): NativeServerConfig = copy(name = name)
+  def withHost(host: String): NativeServerConfig = copy(host = host)
+  def withPort(port: Int): NativeServerConfig    = copy(port = port)
+
+  def withHandler(handler: HttpHandler): NativeServerConfig = copy(handler =
+    RxHttpHandler.fromSync(handler)
+  )
+
+  def withHandler(f: Request => Response): NativeServerConfig = copy(handler =
+    RxHttpHandler.fromFunction(f)
+  )
+
+  def withRxHandler(handler: RxHttpHandler): NativeServerConfig = copy(handler = handler)
+
+  def withRxHandler(f: Request => Rx[Response]): NativeServerConfig = copy(handler =
+    RxHttpHandler(f)
+  )
+
+  def withFilter(filter: RxHttpFilter): NativeServerConfig = copy(filters = filters :+ filter)
+
+  def withFilters(filters: Seq[RxHttpFilter]): NativeServerConfig = copy(filters =
+    this.filters ++ filters
+  )
+
+  def withBacklog(backlog: Int): NativeServerConfig =
+    require(backlog > 0, "backlog must be positive")
+    copy(backlog = backlog)
+
+  def withMaxRequestSize(bytes: Int): NativeServerConfig =
+    require(bytes > 0, "maxRequestSize must be positive")
+    copy(maxRequestSize = bytes)
+
+  def withWorkerThreads(threads: Int): NativeServerConfig =
+    require(threads > 0, "workerThreads must be positive")
+    copy(workerThreads = threads)
+
+  /**
+    * Start the server and return the running instance. Binding is synchronous, so the inherited
+    * `start[A](block)` lifecycle form is safe.
+    */
+  override def start(): NativeHttpServer =
+    val server = NativeHttpServer(this)
+    server.start()
+    server
+
+end NativeServerConfig

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import scala.scalanative.libc.string as cstring
+import scala.scalanative.posix.arpa.inet
+import scala.scalanative.posix.netinet.in.{in_addr, sockaddr_in}
+import scala.scalanative.posix.netinet.inOps.*
+import scala.scalanative.posix.sys.socket as csocket
+import scala.scalanative.posix.sys.socket.{sockaddr, socklen_t}
+import scala.scalanative.posix.unistd
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
+
+/**
+  * Thin wrappers over POSIX TCP sockets (libc, via Scala Native's posixlib) for the Native HTTP
+  * server. No external dependency or linker flag is required.
+  */
+private[http] object NativeSocket:
+
+  private final val ChunkSize = 8192
+
+  /**
+    * Create a listening TCP socket bound to host:port (port 0 = OS-assigned). Returns the socket fd
+    * and the actually-bound port.
+    */
+  def bindAndListen(host: String, port: Int, backlog: Int): (Int, Int) =
+    val fd = csocket.socket(csocket.AF_INET, csocket.SOCK_STREAM, 0)
+    if fd < 0 then
+      throw HttpException.connectionFailed("Failed to create socket")
+
+    // SO_REUSEADDR so a restart can rebind the port immediately.
+    val optval = stackalloc[CInt]()
+    !optval = 1
+    csocket.setsockopt(
+      fd,
+      csocket.SOL_SOCKET,
+      csocket.SO_REUSEADDR,
+      optval.asInstanceOf[Ptr[Byte]],
+      sizeof[CInt].toUInt
+    )
+
+    val addr = stackalloc[sockaddr_in]()
+    cstring.memset(addr.asInstanceOf[Ptr[Byte]], 0, sizeof[sockaddr_in])
+    addr.sin_family = csocket.AF_INET.toUShort
+    addr.sin_port = inet.htons(port.toUShort)
+    setBindAddress(addr, host)
+
+    if csocket.bind(fd, addr.asInstanceOf[Ptr[sockaddr]], sizeof[sockaddr_in].toUInt) < 0 then
+      unistd.close(fd)
+      throw HttpException.connectionFailed(s"Failed to bind to ${host}:${port}")
+
+    if csocket.listen(fd, backlog) < 0 then
+      unistd.close(fd)
+      throw HttpException.connectionFailed(s"Failed to listen on ${host}:${port}")
+
+    (fd, resolveBoundPort(fd, port))
+
+  end bindAndListen
+
+  private def setBindAddress(addr: Ptr[sockaddr_in], host: String): Unit =
+    // INADDR_ANY (0) for wildcard; otherwise parse a dotted-quad. "localhost" maps to loopback.
+    val normalized =
+      if host == "localhost" then
+        "127.0.0.1"
+      else
+        host
+    if normalized.isEmpty || normalized == "0.0.0.0" then
+      () // already zeroed = INADDR_ANY
+    else
+      val ia = stackalloc[in_addr]()
+      Zone.acquire { implicit z =>
+        // in_addr is CStruct1[in_addr_t]; its single field is s_addr.
+        ia._1 = inet.inet_addr(toCString(normalized))
+      }
+      addr.sin_addr = !ia
+
+  private def resolveBoundPort(fd: Int, requestedPort: Int): Int =
+    if requestedPort != 0 then
+      requestedPort
+    else
+      val outAddr = stackalloc[sockaddr_in]()
+      val outLen  = stackalloc[socklen_t]()
+      !outLen = sizeof[sockaddr_in].toUInt
+      csocket.getsockname(fd, outAddr.asInstanceOf[Ptr[sockaddr]], outLen)
+      inet.ntohs(outAddr.sin_port).toInt
+
+  /**
+    * Accept a connection, returning the client fd (or a negative value on error / when the
+    * listening socket has been closed).
+    */
+  def accept(serverFd: Int): Int = csocket.accept(
+    serverFd,
+    null.asInstanceOf[Ptr[sockaddr]],
+    null.asInstanceOf[Ptr[socklen_t]]
+  )
+
+  /**
+    * Receive up to ChunkSize bytes. Returns an empty array on EOF or error (caller treats both as
+    * end-of-connection).
+    */
+  def recvChunk(fd: Int): Array[Byte] =
+    val cbuf = stackalloc[Byte](ChunkSize)
+    val n    = csocket.recv(fd, cbuf.asInstanceOf[Ptr[Byte]], ChunkSize.toUInt, 0)
+    if n <= 0 then
+      Array.emptyByteArray
+    else
+      val len = n.toInt
+      val arr = new Array[Byte](len)
+      var i   = 0
+      while i < len do
+        arr(i) = cbuf(i)
+        i += 1
+      arr
+
+  /**
+    * Send all of `data`, looping over partial writes. Returns false if the peer is gone.
+    */
+  def sendAll(fd: Int, data: Array[Byte]): Boolean =
+    val chunk = stackalloc[Byte](ChunkSize)
+    var pos   = 0
+    var ok    = true
+    val total = data.length
+    while ok && pos < total do
+      val n = math.min(ChunkSize, total - pos)
+      var i = 0
+      while i < n do
+        chunk(i) = data(pos + i)
+        i += 1
+      var sent = 0
+      while ok && sent < n do
+        val w = csocket.send(fd, (chunk + sent).asInstanceOf[Ptr[Byte]], (n - sent).toUInt, 0)
+        if w <= 0 then
+          ok = false
+        else
+          sent += w.toInt
+      pos += n
+    ok
+
+  def close(fd: Int): Unit = unistd.close(fd)
+
+end NativeSocket

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
@@ -36,6 +36,8 @@ private[http] object NativeSocket:
     * and the actually-bound port.
     */
   def bindAndListen(host: String, port: Int, backlog: Int): (Int, Int) =
+    if port < 0 || port > 65535 then
+      throw HttpException.connectionFailed(s"Invalid port: ${port}")
     val fd = csocket.socket(csocket.AF_INET, csocket.SOCK_STREAM, 0)
     if fd < 0 then
       throw HttpException.connectionFailed("Failed to create socket")
@@ -82,7 +84,11 @@ private[http] object NativeSocket:
       val ia = stackalloc[in_addr]()
       Zone.acquire { implicit z =>
         // in_addr is CStruct1[in_addr_t]; its single field is s_addr.
-        ia._1 = inet.inet_addr(toCString(normalized))
+        val parsed = inet.inet_addr(toCString(normalized))
+        // inet_addr returns INADDR_NONE (0xFFFFFFFF) for an unparseable address (no DNS here).
+        if parsed == 0xffffffff.toUInt then
+          throw HttpException.connectionFailed(s"Invalid bind host: ${host}")
+        ia._1 = parsed
       }
       addr.sin_addr = !ia
 

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
@@ -99,7 +99,11 @@ private[http] object NativeSocket:
       val outAddr = stackalloc[sockaddr_in]()
       val outLen  = stackalloc[socklen_t]()
       !outLen = sizeof[sockaddr_in].toUInt
-      csocket.getsockname(fd, outAddr.asInstanceOf[Ptr[sockaddr]], outLen)
+      // Check the return: on failure outAddr is unpopulated (stackalloc isn't zeroed), so reading
+      // sin_port would yield a garbage port.
+      if csocket.getsockname(fd, outAddr.asInstanceOf[Ptr[sockaddr]], outLen) < 0 then
+        unistd.close(fd)
+        throw HttpException.connectionFailed("Failed to resolve the bound port (getsockname)")
       inet.ntohs(outAddr.sin_port).toInt
 
   /**

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.test.UniTest
+
+import java.nio.charset.StandardCharsets
+import scala.scalanative.libc.string as cstring
+import scala.scalanative.posix.arpa.inet
+import scala.scalanative.posix.netinet.in.{in_addr, sockaddr_in}
+import scala.scalanative.posix.netinet.inOps.*
+import scala.scalanative.posix.sys.socket as csocket
+import scala.scalanative.posix.sys.socket.sockaddr
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
+
+/**
+  * Verifies the Scala Native HTTP server with a raw POSIX-socket client (a real loopback
+  * round-trip). The server runs on its own accept/worker threads, so the blocking client on the
+  * test thread does not deadlock.
+  */
+class NativeServerTest extends UniTest:
+
+  /** A parsed HTTP response: status code, headers (lower-cased keys), and body. */
+  private case class RawResponse(status: Int, headers: Map[String, String], body: String)
+
+  /** Connect to 127.0.0.1:port, send the raw request, read the full response, and parse it. */
+  private def request(port: Int, raw: String): RawResponse =
+    val fd = connectLoopback(port)
+    try
+      NativeSocket.sendAll(fd, raw.getBytes(StandardCharsets.ISO_8859_1))
+      val acc   = scala.collection.mutable.ArrayBuffer.empty[Byte]
+      var chunk = NativeSocket.recvChunk(fd)
+      while chunk.nonEmpty do
+        acc ++= chunk
+        chunk = NativeSocket.recvChunk(fd)
+      parse(new String(acc.toArray, StandardCharsets.ISO_8859_1))
+    finally
+      NativeSocket.close(fd)
+
+  private def parse(text: String): RawResponse =
+    val sep  = text.indexOf("\r\n\r\n")
+    val head =
+      if sep >= 0 then
+        text.substring(0, sep)
+      else
+        text
+    val body =
+      if sep >= 0 then
+        text.substring(sep + 4)
+      else
+        ""
+    val lines      = head.split("\r\n")
+    val statusCode = lines(0).split(" ")(1).toInt
+    val headers    =
+      lines
+        .drop(1)
+        .flatMap { line =>
+          val c = line.indexOf(':')
+          if c > 0 then
+            Some(line.substring(0, c).trim.toLowerCase -> line.substring(c + 1).trim)
+          else
+            None
+        }
+        .toMap
+    RawResponse(statusCode, headers, body)
+
+  private def connectLoopback(port: Int): Int =
+    val fd = csocket.socket(csocket.AF_INET, csocket.SOCK_STREAM, 0)
+    if fd < 0 then
+      throw RuntimeException("Failed to create client socket")
+    val addr = stackalloc[sockaddr_in]()
+    cstring.memset(addr.asInstanceOf[Ptr[Byte]], 0, sizeof[sockaddr_in])
+    addr.sin_family = csocket.AF_INET.toUShort
+    addr.sin_port = inet.htons(port.toUShort)
+    val ia = stackalloc[in_addr]()
+    Zone.acquire { implicit z =>
+      ia._1 = inet.inet_addr(toCString("127.0.0.1"))
+    }
+    addr.sin_addr = !ia
+    if csocket.connect(fd, addr.asInstanceOf[Ptr[sockaddr]], sizeof[sockaddr_in].toUInt) < 0 then
+      NativeSocket.close(fd)
+      throw RuntimeException(s"Failed to connect to 127.0.0.1:${port}")
+    fd
+
+  test("should handle a GET request") {
+    NativeServer
+      .withHandler { req =>
+        Response.ok(s"Hello from ${req.path}")
+      }
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "GET /test HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 200
+        response.body shouldBe "Hello from /test"
+      }
+  }
+
+  test("should handle a POST request with a body") {
+    NativeServer
+      .withHandler { req =>
+        Response.ok(s"Received: ${req.content.toContentString}")
+      }
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "POST /data HTTP/1.1\r\nHost: localhost\r\nContent-Length: 7\r\nConnection: close\r\n\r\npayload"
+        )
+        response.status shouldBe 200
+        response.body shouldBe "Received: payload"
+      }
+  }
+
+  test("should round-trip request and response headers") {
+    NativeServer
+      .withHandler { req =>
+        Response.ok("ok").addHeader("X-Echoed", req.header("X-Echo").getOrElse("none"))
+      }
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "GET /headers HTTP/1.1\r\nHost: localhost\r\nX-Echo: ping\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 200
+        response.headers.get("x-echoed") shouldBe Some("ping")
+      }
+  }
+
+  test("should return 404 from the default handler") {
+    NativeServer
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "GET /missing HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 404
+      }
+  }
+
+  test("should reject an unsupported HTTP method with 400") {
+    NativeServer
+      .withHandler(_ => Response.ok("ok"))
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "FROBNICATE /x HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 400
+      }
+  }
+
+  test("should report a bound ephemeral port") {
+    NativeServer
+      .withPort(0)
+      .start { server =>
+        (server.localPort > 0) shouldBe true
+        server.isRunning shouldBe true
+      }
+  }
+
+end NativeServerTest

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
@@ -209,6 +209,20 @@ class NativeServerTest extends UniTest:
       }
   }
 
+  test("should honor an explicitly-set response Content-Type") {
+    NativeServer
+      .withHandler(_ => Response.ok("{}").withContentType(ContentType.ApplicationJson))
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "GET /j HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 200
+        response.headers.get("content-type") shouldBe Some("application/json")
+      }
+  }
+
   test("should report a bound ephemeral port") {
     NativeServer
       .withPort(0)

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
@@ -167,6 +167,48 @@ class NativeServerTest extends UniTest:
       }
   }
 
+  test("should not send a body for a HEAD request") {
+    NativeServer
+      .withHandler(req => Response.ok(s"Hello from ${req.path}"))
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "HEAD /test HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 200
+        // Content-Length reflects the would-be body, but no body is sent (RFC 9110).
+        response.headers.get("content-length") shouldBe Some("16")
+        response.body shouldBe ""
+      }
+  }
+
+  test("should reject conflicting Content-Length headers with 400") {
+    NativeServer
+      .withHandler(_ => Response.ok("ok"))
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "POST /x HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nContent-Length: 5\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 400
+      }
+  }
+
+  test("should reject a non-numeric Content-Length with 400") {
+    NativeServer
+      .withHandler(_ => Response.ok("ok"))
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "POST /x HTTP/1.1\r\nHost: localhost\r\nContent-Length: abc\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 400
+      }
+  }
+
   test("should report a bound ephemeral port") {
     NativeServer
       .withPort(0)


### PR DESCRIPTION
## Why

Completes the cross-platform HTTP server — **JVM (Netty) + Node.js + Native** — on the shared `HttpServer`/`HttpServerConfig`/`RxHttpHandler` abstraction from #572. Native previously had only an HTTP *client* (libcurl).

## Approach

Hand-written HTTP/1.1 over **POSIX TCP sockets** via Scala Native's bundled `posixlib`. Chosen over binding a C HTTP-server library because:
- **No new dependency, no linker flag** (sockets are libc) — consistent with uni's minimal-deps ethos and the libcurl-client precedent.
- **Licensing**: the obvious C server libs are incompatible with Apache-2.0 (mongoose = GPL/commercial, libmicrohttpd = LGPL); raw libc has no such issue.

Scala Native 0.5.12 is multithreaded, so the server uses a daemon accept thread + a worker thread pool (the same shape as Netty/Node, just hand-rolled).

## What

- **`NativeSocket`** — thin posixlib wrappers (`socket`/`setsockopt`/`bind`/`listen`/`accept`/`getsockname`/`recv`/`send`/`close`), IPv4 TCP, ephemeral-port via `getsockname`.
- **`NativeHttpProtocol`** — a minimal HTTP/1.1 request reader (request line, headers, `Content-Length` body, keep-alive, leftover retention; chunked-request/oversized → `400`) reusing the shared `HttpContent.fromBytes`, plus a response writer.
- **`NativeHttpServer`** — daemon accept thread → worker pool; each request runs the filter-composed handler via `RxRunner.runOnce` + a latch; keep-alive unless the client sends `Connection: close`; `whenReady` completes immediately (synchronous bind).
- **`NativeServer`/`NativeServerConfig`** — mirror `NettyServer`/`NodeServer` with native knobs (`backlog`, `maxRequestSize`, `workerThreads`).

```scala
NativeServer
  .withPort(0)
  .withHandler(req => Response.ok(s"Hello ${req.path}"))
  .start { server => /* serving on server.localPort */ }
```

## Testing
- **`NativeServerTest`** (new `uni/.native` test tree) does real loopback round-trips with a **raw POSIX-socket client**: GET, POST body echo, request/response header round-trip, 404, 400 for an unknown method, ephemeral port.
- Full Native suite: **1367 tests, 1358 passed, 9 pending, 0 failed** (changes are purely additive in `uni/.native`; JVM/JS/Netty untouched). No new dependency or linker flag.

## Notable finding (follow-up)
While testing I found the **Native libcurl *client* returns `CURLE_URL_MALFORMAT` (curl error 3) on a valid loopback URL** — i.e. the URL isn't reaching libcurl (likely the variadic `curl_easy_setopt` fixed-arity binding). There was no prior Native HTTP round-trip test, so this was never exercised. The server test therefore uses raw sockets (a stronger check anyway); auditing/fixing the Native curl client is filed as a follow-up.

## Out of scope (follow-ups)
- Native SSE/chunked streaming and WebSocket (parallel to Netty/Node).
- Investigate the Native libcurl client `CURLE_URL_MALFORMAT` bug.

Plan + design notes: `plans/2026-06-18-native-http-server.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)