### PR TITLE
feature: Add SSE / chunked streaming to the Native HTTP server

### DIFF
--- a/plans/2026-06-19-native-sse-streaming.md
+++ b/plans/2026-06-19-native-sse-streaming.md
@@ -1,0 +1,77 @@
+# Native HTTP server — SSE / chunked streaming (PR 1 of 2)
+
+## Context
+
+The Scala Native HTTP server (#574) handles request/response with `Content-Length` bodies but does
+**not** stream: a `Response.eventStream(...)` (Server-Sent Events) would be serialized as an empty
+body. The JVM (Netty) and Node.js backends both stream SSE. This PR adds chunked transfer encoding +
+SSE streaming to the Native backend, closing that cross-platform gap. (WebSocket on Native is the
+separate follow-up PR 2.)
+
+## Design
+
+All changes in `uni/.native/src/main/scala/wvlet/uni/http/`, reusing the shared `Response`
+(`events: Rx[ServerSentEvent]`, `isEventStream`), `ServerSentEvent.toContent`, `Rx`/`RxRunner`, and
+`Cancelable` — all cross-platform and already used on Native.
+
+### 1. `HttpResponseWriter` (NativeHttpProtocol.scala) — chunked helpers
+- `serializeSseHeaders(response): Array[Byte]` — status line + the response's custom headers (minus
+  managed ones) + `Content-Type: text/event-stream`, `Cache-Control: no-cache`,
+  `Transfer-Encoding: chunked`, the keep-alive/close `Connection` header, and the blank line. No
+  `Content-Length` (chunked). Mirrors `NodeHttpServer.writeSseResponse`/`NettyRequestHandler.sendSseResponse`.
+- `chunk(data: Array[Byte]): Array[Byte]` — one chunk: `"<hex-len>\r\n"` + data + `"\r\n"`.
+- `finalChunk: Array[Byte]` — `"0\r\n\r\n"` (end of chunked body).
+
+### 2. `NativeHttpServer` — stream when `response.isEventStream`
+In `handleConnection`, branch the `ReadResult.Req` case: if `response.isEventStream`, call
+`streamSse(clientFd, response)` instead of the buffered `serialize` path.
+
+`streamSse(clientFd, response): Boolean`:
+- Write `serializeSseHeaders(response)`.
+- Subscribe to `response.events` with `RxRunner.run` (not `runOnce` — many events), blocking the
+  worker on a `CountDownLatch` until terminal:
+  - `OnNext(event)` → `sendAll(clientFd, chunk(event.toContent bytes))`; if the write fails (client
+    gone) cancel the subscription and finish.
+  - `OnError` → log and finish; `OnCompletion` → finish.
+  - Use the **delegate-`Cancelable` + `cancelled`-flag** pattern (as in `NodeHttpServer.writeSseResponse`)
+    so a write failure during a *synchronous* emission (`Rx.fromSeq`) cancels correctly before the
+    subscription handle is assigned.
+- After the stream terminates, write `finalChunk` (best-effort) and return whether all writes
+  succeeded.
+- The connection then follows the normal keep-alive decision (chunked framing delimits the message,
+  so keep-alive is valid); a dead client (`sent == false`) closes it.
+
+Note: an SSE connection occupies its worker thread for the stream's lifetime (no handler-await
+timeout is applied to the streaming phase — SSE is long-lived by design); a client disconnect is
+detected via a failed chunk write and cancels the stream.
+
+### 3. SHA-1/Base64, sockets — unchanged
+No new dependency, no config change. (The WebSocket PR will add a pure-Scala SHA-1 + `java.util.Base64`
+handshake — `java.security.MessageDigest` is **not** available on Native; that's PR 2.)
+
+## Files
+| Action | Path |
+|---|---|
+| Edit | `uni/.native/.../http/NativeHttpProtocol.scala` (`HttpResponseWriter`: `serializeSseHeaders` + `chunk`/`finalChunk`) |
+| Edit | `uni/.native/.../http/NativeHttpServer.scala` (`handleConnection` SSE branch + `streamSse`) |
+| Add | `uni/.native/src/test/.../NativeServerSseTest.scala` (or extend `NativeServerTest`) |
+
+## Verification
+- `./sbt scalafmtAll` then `./sbt uniNative/compile`.
+- New test: `NativeServer.withRxHandler(_ => Rx.single(Response.eventStream(Rx.fromSeq(events)))).start { ... }`,
+  then a raw POSIX-socket client (the existing `NativeServerTest` pattern, reusing `NativeSocket`)
+  reads the full response and **de-chunks** it (parse `<hex>\r\n<data>\r\n` … `0\r\n\r\n`), asserting
+  the SSE wire form (`data: hello`, `data: world`, etc.) and `Transfer-Encoding: chunked`. (The
+  in-module libcurl client can't be used — it has the `CURLE_URL_MALFORMAT` bug found in #574.)
+- `./sbt uniNative/test` (full Native suite stays green); the existing non-streaming tests are
+  unaffected (the SSE branch only triggers for `isEventStream`).
+
+## Follow-up: PR 2 — Native WebSocket (sketch)
+- `withWebSocketRoute` on `NativeServerConfig` consuming the shared `webSocketRoutes`
+  (`HttpServerConfig`, default Nil); detect the `Upgrade: websocket` request in `handleConnection`.
+- Handshake: `Sec-WebSocket-Accept = Base64(SHA1(key + GUID))` — **pure-Scala SHA-1** (~60 lines,
+  dependency-free; `MessageDigest` is absent on Native) + `java.util.Base64` (present on Native);
+  write `101 Switching Protocols`.
+- RFC 6455 framing over the raw socket: parse masked client frames (FIN/opcode, mask key, payload),
+  unmask; handle text/binary/close/ping(→pong)/pong; write unmasked server frames; bridge to the
+  shared `WebSocketContext`/`WebSocketHandler` (reuse from #573, mirroring `NettyWebSocketHandler`).

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpProtocol.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpProtocol.scala
@@ -200,4 +200,61 @@ private[http] object HttpResponseWriter:
       name.equalsIgnoreCase(HttpHeader.ContentLength) ||
       name.equalsIgnoreCase(HttpHeader.Connection)
 
+  /**
+    * Serialize the status line + headers for a streaming (SSE) response: `text/event-stream` with
+    * `Transfer-Encoding: chunked` and no `Content-Length`. The body is then written as chunks via
+    * [[chunk]] / [[finalChunk]]. Mirrors the Netty/Node SSE response.
+    */
+  def serializeSseHeaders(response: Response, keepAlive: Boolean): Array[Byte] =
+    val sb = StringBuilder()
+    sb.append("HTTP/1.1 ")
+      .append(response.status.code)
+      .append(" ")
+      .append(response.status.reason)
+      .append("\r\n")
+    response
+      .headers
+      .entries
+      .foreach { case (name, value) =>
+        if !isManagedHeader(name) && !name.equalsIgnoreCase(HttpHeader.TransferEncoding) &&
+          !name.equalsIgnoreCase(HttpHeader.CacheControl)
+        then
+          sb.append(name).append(": ").append(value).append("\r\n")
+      }
+    sb.append(HttpHeader.ContentType)
+      .append(": ")
+      .append(ContentType.TextEventStream.value)
+      .append("\r\n")
+    sb.append(HttpHeader.CacheControl).append(": no-cache\r\n")
+    sb.append(HttpHeader.TransferEncoding).append(": chunked\r\n")
+    sb.append(HttpHeader.Connection)
+      .append(": ")
+      .append(
+        if keepAlive then
+          "keep-alive"
+        else
+          "close"
+      )
+      .append("\r\n")
+    sb.append("\r\n")
+    sb.toString.getBytes(StandardCharsets.ISO_8859_1)
+
+  end serializeSseHeaders
+
+  /**
+    * One HTTP chunked-transfer chunk: `<hex-length>\r\n<data>\r\n`. Empty data yields no bytes (a
+    * zero-length chunk would prematurely terminate the body).
+    */
+  def chunk(data: Array[Byte]): Array[Byte] =
+    if data.isEmpty then
+      Array.emptyByteArray
+    else
+      val header = s"${Integer.toHexString(data.length)}\r\n".getBytes(StandardCharsets.ISO_8859_1)
+      header ++ data ++ CRLF
+
+  /** The terminating zero-length chunk that ends a chunked body. */
+  val finalChunk: Array[Byte] = "0\r\n\r\n".getBytes(StandardCharsets.ISO_8859_1)
+
+  private val CRLF: Array[Byte] = "\r\n".getBytes(StandardCharsets.ISO_8859_1)
+
 end HttpResponseWriter

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
@@ -117,18 +117,26 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
           case ReadResult.Req(request) =>
             val response  = runHandler(request)
             val keepAlive = clientWantsKeepAlive(request)
+            val isHead    = request.method == HttpMethod.HEAD
             val sent      =
               if response.isEventStream then
-                streamSse(clientFd, response, keepAlive)
+                if isHead then
+                  // HEAD: send the streaming response headers but no event body.
+                  NativeSocket.sendAll(
+                    clientFd,
+                    HttpResponseWriter.serializeSseHeaders(response, keepAlive)
+                  )
+                else
+                  streamSse(clientFd, response, keepAlive)
               else
                 // A HEAD response carries headers (incl. Content-Length) but no body.
-                val includeBody = request.method != HttpMethod.HEAD
                 NativeSocket.sendAll(
                   clientFd,
-                  HttpResponseWriter.serialize(response, keepAlive, includeBody)
+                  HttpResponseWriter.serialize(response, keepAlive, includeBody = !isHead)
                 )
             if !keepAlive || !sent then
               continue = false
+      end while
     catch
       case NonFatal(e) =>
         debug(s"Connection handling error: ${e.getMessage}")
@@ -142,8 +150,12 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
     * Stream a Server-Sent Events response with chunked transfer encoding. Each `ServerSentEvent` is
     * written as one chunk; the worker thread blocks until the event stream terminates (SSE is
     * long-lived by design, so no handler-await timeout is applied here). A failed chunk write
-    * (client gone) cancels the subscription. Returns whether the connection is still usable for
-    * keep-alive.
+    * cancels the subscription. Returns whether the connection is still usable for keep-alive.
+    *
+    * Limitation (blocking model): a client that disconnects while the stream is *idle* (no event to
+    * write) is not detected until the next event fails to write, so the worker stays parked in
+    * `done.await()` — each live stream pins one worker thread. A portable idle/read timeout is a
+    * follow-up (see the SSE-streaming plan).
     */
   private def streamSse(clientFd: Int, response: Response, keepAlive: Boolean): Boolean =
     if !NativeSocket.sendAll(clientFd, HttpResponseWriter.serializeSseHeaders(response, keepAlive))
@@ -152,18 +164,19 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
     else
       val done = CountDownLatch(1)
       val ok   = AtomicBoolean(true)
-      // Delegate Cancelable + `cancelled` flag: RxRunner.run can emit synchronously (Rx.fromSeq), so
-      // a write failure may fire before the real subscription handle is assigned.
-      var realSubscription: Cancelable = Cancelable.empty
-      var cancelled                    = false
-      val subscription: Cancelable     = Cancelable { () =>
-        cancelled = true
-        realSubscription.cancel
+      // Delegate Cancelable: RxRunner.run can emit synchronously (Rx.fromSeq) before the real
+      // subscription handle is assigned, and an async source may emit on another thread — so the
+      // cancel flag and handle are atomics for correct cross-thread visibility.
+      val cancelled                = AtomicBoolean(false)
+      val realSubscription         = AtomicReference[Cancelable](Cancelable.empty)
+      val subscription: Cancelable = Cancelable { () =>
+        cancelled.set(true)
+        realSubscription.get().cancel
       }
-      realSubscription =
+      realSubscription.set(
         RxRunner.run(response.events) {
           case OnNext(event) =>
-            if !cancelled then
+            if !cancelled.get() then
               val data = event
                 .asInstanceOf[ServerSentEvent]
                 .toContent
@@ -179,6 +192,7 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
           case OnCompletion =>
             done.countDown()
         }
+      )
       done.await()
       // Terminate the chunked body if the client is still there.
       ok.get() && NativeSocket.sendAll(clientFd, HttpResponseWriter.finalChunk)

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
@@ -14,8 +14,9 @@
 package wvlet.uni.http
 
 import wvlet.uni.log.LogSupport
-import wvlet.uni.rx.{OnCompletion, OnError, OnNext, Rx, RxRunner}
+import wvlet.uni.rx.{Cancelable, OnCompletion, OnError, OnNext, Rx, RxRunner}
 
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.{CountDownLatch, ExecutorService, Executors, ThreadFactory, TimeUnit}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import scala.util.control.NonFatal
@@ -116,12 +117,16 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
           case ReadResult.Req(request) =>
             val response  = runHandler(request)
             val keepAlive = clientWantsKeepAlive(request)
-            // A HEAD response carries headers (incl. Content-Length) but no body.
-            val includeBody = request.method != HttpMethod.HEAD
-            val sent        = NativeSocket.sendAll(
-              clientFd,
-              HttpResponseWriter.serialize(response, keepAlive, includeBody)
-            )
+            val sent      =
+              if response.isEventStream then
+                streamSse(clientFd, response, keepAlive)
+              else
+                // A HEAD response carries headers (incl. Content-Length) but no body.
+                val includeBody = request.method != HttpMethod.HEAD
+                NativeSocket.sendAll(
+                  clientFd,
+                  HttpResponseWriter.serialize(response, keepAlive, includeBody)
+                )
             if !keepAlive || !sent then
               continue = false
     catch
@@ -132,6 +137,51 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
 
   private def clientWantsKeepAlive(request: Request): Boolean =
     !request.header(HttpHeader.Connection).exists(_.equalsIgnoreCase("close"))
+
+  /**
+    * Stream a Server-Sent Events response with chunked transfer encoding. Each `ServerSentEvent` is
+    * written as one chunk; the worker thread blocks until the event stream terminates (SSE is
+    * long-lived by design, so no handler-await timeout is applied here). A failed chunk write
+    * (client gone) cancels the subscription. Returns whether the connection is still usable for
+    * keep-alive.
+    */
+  private def streamSse(clientFd: Int, response: Response, keepAlive: Boolean): Boolean =
+    if !NativeSocket.sendAll(clientFd, HttpResponseWriter.serializeSseHeaders(response, keepAlive))
+    then
+      false
+    else
+      val done = CountDownLatch(1)
+      val ok   = AtomicBoolean(true)
+      // Delegate Cancelable + `cancelled` flag: RxRunner.run can emit synchronously (Rx.fromSeq), so
+      // a write failure may fire before the real subscription handle is assigned.
+      var realSubscription: Cancelable = Cancelable.empty
+      var cancelled                    = false
+      val subscription: Cancelable     = Cancelable { () =>
+        cancelled = true
+        realSubscription.cancel
+      }
+      realSubscription =
+        RxRunner.run(response.events) {
+          case OnNext(event) =>
+            if !cancelled then
+              val data = event
+                .asInstanceOf[ServerSentEvent]
+                .toContent
+                .getBytes(StandardCharsets.UTF_8)
+              if !NativeSocket.sendAll(clientFd, HttpResponseWriter.chunk(data)) then
+                ok.set(false)
+                subscription.cancel
+                done.countDown()
+          case OnError(e) =>
+            warn(s"SSE stream error: ${e.getMessage}", e)
+            ok.set(false)
+            done.countDown()
+          case OnCompletion =>
+            done.countDown()
+        }
+      done.await()
+      // Terminate the chunked body if the client is still there.
+      ok.get() && NativeSocket.sendAll(clientFd, HttpResponseWriter.finalChunk)
 
   /**
     * Run the handler and block for its single response. The handler may be asynchronous (Rx), so

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
@@ -264,6 +264,24 @@ class NativeServerTest extends UniTest:
       }
   }
 
+  test("should not stream a body for HEAD on an SSE endpoint") {
+    import wvlet.uni.rx.Rx
+    NativeServer
+      .withRxHandler(_ =>
+        Rx.single(Response.eventStream(Rx.fromSeq(Seq(ServerSentEvent.data("x")))))
+      )
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "HEAD /events HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 200
+        response.headers.get("content-type") shouldBe Some("text/event-stream")
+        response.body shouldBe ""
+      }
+  }
+
   test("should report a bound ephemeral port") {
     NativeServer
       .withPort(0)

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
@@ -76,6 +76,27 @@ class NativeServerTest extends UniTest:
         .toMap
     RawResponse(statusCode, headers, body)
 
+  /**
+    * Decode an HTTP chunked-transfer body (`<hex>\r\n<data>\r\n` … `0\r\n\r\n`) into its payload.
+    */
+  private def dechunk(body: String): String =
+    val sb       = StringBuilder()
+    var rest     = body
+    var continue = true
+    while continue do
+      val nl = rest.indexOf("\r\n")
+      if nl < 0 then
+        continue = false
+      else
+        val size = Integer.parseInt(rest.substring(0, nl).trim, 16)
+        if size == 0 then
+          continue = false
+        else
+          val dataStart = nl + 2
+          sb.append(rest.substring(dataStart, dataStart + size))
+          rest = rest.substring(dataStart + size + 2) // skip the chunk data + its trailing CRLF
+    sb.toString
+
   private def connectLoopback(port: Int): Int =
     val fd = csocket.socket(csocket.AF_INET, csocket.SOCK_STREAM, 0)
     if fd < 0 then
@@ -220,6 +241,26 @@ class NativeServerTest extends UniTest:
         )
         response.status shouldBe 200
         response.headers.get("content-type") shouldBe Some("application/json")
+      }
+  }
+
+  test("should stream Server-Sent Events with chunked encoding") {
+    import wvlet.uni.rx.Rx
+    val events = Seq(ServerSentEvent.data("hello"), ServerSentEvent.data("world"))
+    NativeServer
+      .withRxHandler(_ => Rx.single(Response.eventStream(Rx.fromSeq(events))))
+      .withPort(0)
+      .start { server =>
+        val response = request(
+          server.localPort,
+          "GET /events HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        )
+        response.status shouldBe 200
+        response.headers.get("content-type") shouldBe Some("text/event-stream")
+        response.headers.get("transfer-encoding") shouldBe Some("chunked")
+        val decoded = dechunk(response.body)
+        decoded shouldContain "data: hello"
+        decoded shouldContain "data: world"
       }
   }
 


### PR DESCRIPTION
## Why

The Scala Native HTTP server (#574) handled buffered request/response but didn't stream — a `Response.eventStream(...)` was serialized with an empty body. The JVM (Netty) and Node.js backends both stream SSE; this closes that gap on Native. **First of two PRs** (Native WebSocket is the follow-up).

## What

- **`HttpResponseWriter`**: `serializeSseHeaders` (`text/event-stream` + `Transfer-Encoding: chunked`, no `Content-Length`), `chunk(data)` (`<hex>\r\n<data>\r\n`), and `finalChunk` (`0\r\n\r\n`).
- **`NativeHttpServer`**: when `response.isEventStream`, stream `Response.events` as chunks via `RxRunner.run`; the worker blocks until the stream terminates (SSE is long-lived by design, so the handler-await timeout is not applied to the streaming phase). A failed chunk write (client gone) cancels the subscription — using the delegate-`Cancelable` + `cancelled`-flag pattern so a *synchronous* emission (`Rx.fromSeq`) write failure cancels correctly. The connection then follows the normal keep-alive decision (chunked framing delimits the message).

```scala
NativeServer
  .withRxHandler(_ => Rx.single(Response.eventStream(events)))
  .start { server => /* streams text/event-stream, chunked */ }
```

## Testing
- New `NativeServerTest` case: a raw POSIX-socket client reads the response and **de-chunks** it, asserting the SSE wire form (`data: hello`, `data: world`) and `Transfer-Encoding: chunked`. (The in-module libcurl client can't be used — the `CURLE_URL_MALFORMAT` bug found in #574.)
- Full Native suite: **1372 tests, 1363 passed, 9 pending, 0 failed**. Non-streaming responses are unaffected (the SSE branch only triggers for `isEventStream`). No new dependency.

Plan: `plans/2026-06-19-native-sse-streaming.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)