### PR TITLE
feature: Add WebSocket support to the Native HTTP server

### DIFF
--- a/plans/2026-06-19-native-websocket.md
+++ b/plans/2026-06-19-native-websocket.md
@@ -1,0 +1,53 @@
+# Native HTTP server — WebSocket (PR 2 of 2)
+
+## Context
+
+Completes WebSocket support across all server backends (Netty #573, and now Native). Builds on the
+Native HTTP server (#574) and its SSE streaming (#575), reusing the shared `WebSocketContext`/
+`WebSocketHandler`/`WebSocketRoute` traits from #573.
+
+`java.security.MessageDigest` is **absent** on Scala Native, so the handshake uses a small pure-Scala
+SHA-1 + `java.util.Base64` (present on Native). Framing is hand-written RFC 6455 over the raw POSIX
+socket (no dependency).
+
+## Design (all in `uni/.native/.../http/`)
+
+- **`Sha1`** — dependency-free SHA-1 (RFC 3174) for the accept key.
+- **`NativeWebSocket`** — `acceptKey(key)` = base64(SHA1(key + GUID)); `encodeFrame(opcode, payload)`
+  (unmasked server frames); `serve(fd, request, handler, maxFrameSize)`: delivers `onOpen`, then a
+  read loop that parses masked client frames (FIN/opcode, 7/16/64-bit length, mask key, unmask),
+  reassembles fragments, dispatches text/binary, auto-replies to ping, ignores pong, echoes/handles
+  close, and guarantees `onClose` exactly once. `NativeWebSocketContext` writes frames under a lock
+  (so `send`/`close` are thread-safe alongside the loop's pong/close writes) and drops sends after
+  close. Oversized frames → close 1009.
+- **`NativeServerConfig`** — `webSocketRoutes` (override, default Nil) + `webSocketMaxFrameSize` +
+  `withWebSocketRoute(path[, filter])(factory)`; the `NativeServer` object exposes the same entry
+  points.
+- **`NativeHttpServer`** — `handleConnection` detects an `Upgrade: websocket` request matching a
+  route; `handleWebSocketUpgrade` gates it through the route filter (2xx allows, else the response
+  rejects — reusing an extracted `awaitRx`), writes the `101 Switching Protocols` handshake, then
+  hands the connection to `NativeWebSocket.serve` (which owns the worker for the connection's life).
+- **`HttpHeader`** (shared) — added `Sec-WebSocket-Key/Accept/Version/Protocol` constants.
+
+## Files
+| Action | Path |
+|---|---|
+| Add | `uni/.native/.../http/Sha1.scala` |
+| Add | `uni/.native/.../http/NativeWebSocket.scala` (framing + handshake + context + serve loop) |
+| Edit | `uni/.native/.../http/NativeServer.scala` (WS config fields + builders + object entry points) |
+| Edit | `uni/.native/.../http/NativeHttpServer.scala` (upgrade detect + filter-gate + handshake; `awaitRx`) |
+| Edit | `uni/src/main/scala/wvlet/uni/http/HttpHeader.scala` (Sec-WebSocket-* constants) |
+| Edit | `uni/.native/src/test/.../NativeServerTest.scala` (raw-socket `WsClient` + WS tests) |
+
+## Verification
+- `./sbt scalafmtAll`, `uniNative/test`; `uniJVM/compile uniJS/compile netty/compile` for the shared
+  `HttpHeader` change.
+- WS tests via a raw-socket `WsClient` (handshake, masked text frame, server-frame read): accept-key
+  matches the RFC 6455 example vector, text echo, server push on `onOpen`, `onOpen`/`onClose`
+  lifecycle (latches), and filter-rejected upgrade (403). Native suite: 1378 tests, 0 failed.
+
+## Limitations / follow-ups (inherited from the blocking model)
+- A WebSocket connection pins a worker thread for its lifetime; an idle client disconnect is detected
+  only on the next read/write (a portable idle/read timeout is the standing follow-up — posixlib's
+  `timeval` is mislaid out on macOS, see #574/#575 notes).
+- No per-message compression (permessage-deflate) or client-side WebSocket.

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
@@ -114,38 +114,46 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
               )
             )
             continue = false
-          case ReadResult.Req(request) if webSocketRouteFor(request).isDefined =>
-            // WebSocket upgrade: the WS handler owns the connection until it closes.
-            handleWebSocketUpgrade(clientFd, request, webSocketRouteFor(request).get)
-            continue = false
           case ReadResult.Req(request) =>
-            val response  = runHandler(request)
-            val keepAlive = clientWantsKeepAlive(request)
-            val isHead    = request.method == HttpMethod.HEAD
-            val sent      =
-              if response.isEventStream then
-                if isHead then
-                  // HEAD: send the streaming response headers but no event body.
-                  NativeSocket.sendAll(
-                    clientFd,
-                    HttpResponseWriter.serializeSseHeaders(response, keepAlive)
-                  )
-                else
-                  streamSse(clientFd, response, keepAlive)
-              else
-                // A HEAD response carries headers (incl. Content-Length) but no body.
-                NativeSocket.sendAll(
-                  clientFd,
-                  HttpResponseWriter.serialize(response, keepAlive, includeBody = !isHead)
-                )
-            if !keepAlive || !sent then
-              continue = false
+            webSocketRouteFor(request) match
+              case Some(route) =>
+                // WebSocket upgrade: the WS handler owns the connection until it closes.
+                handleWebSocketUpgrade(clientFd, request, route)
+                continue = false
+              case None =>
+                if !handleHttpRequest(clientFd, request) then
+                  continue = false
       end while
     catch
       case NonFatal(e) =>
         debug(s"Connection handling error: ${e.getMessage}")
     finally
       NativeSocket.close(clientFd)
+
+  /**
+    * Handle one non-WebSocket request. Returns whether the connection may stay open (keep-alive).
+    */
+  private def handleHttpRequest(clientFd: Int, request: Request): Boolean =
+    val response  = runHandler(request)
+    val keepAlive = clientWantsKeepAlive(request)
+    val isHead    = request.method == HttpMethod.HEAD
+    val sent      =
+      if response.isEventStream then
+        if isHead then
+          // HEAD: send the streaming response headers but no event body.
+          NativeSocket.sendAll(
+            clientFd,
+            HttpResponseWriter.serializeSseHeaders(response, keepAlive)
+          )
+        else
+          streamSse(clientFd, response, keepAlive)
+      else
+        // A HEAD response carries headers (incl. Content-Length) but no body.
+        NativeSocket.sendAll(
+          clientFd,
+          HttpResponseWriter.serialize(response, keepAlive, includeBody = !isHead)
+        )
+    keepAlive && sent
 
   private def clientWantsKeepAlive(request: Request): Boolean =
     !request.header(HttpHeader.Connection).exists(_.equalsIgnoreCase("close"))
@@ -255,34 +263,50 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
     * worker for the WebSocket's lifetime).
     */
   private def handleWebSocketUpgrade(clientFd: Int, request: Request, route: WebSocketRoute): Unit =
-    val gate    = RxHttpHandler(_ => Rx.single(Response.ok))
-    val verdict =
-      try
-        awaitRx(route.filter.apply(request, gate))
-      catch
-        case NonFatal(e) =>
-          warn(s"WebSocket upgrade filter error: ${e.getMessage}", e)
-          Response.internalServerError(e.getMessage)
-    if !verdict.isSuccessful then
-      NativeSocket.sendAll(
-        clientFd,
-        HttpResponseWriter.serialize(verdict, keepAlive = false, includeBody = true)
-      )
-    else
-      val accept = NativeWebSocket.acceptKey(
-        request.header(HttpHeader.SecWebSocketKey).getOrElse("")
-      )
-      val handshake =
-        s"HTTP/1.1 101 Switching Protocols\r\n" + s"${HttpHeader.Upgrade}: websocket\r\n" +
-          s"${HttpHeader.Connection}: Upgrade\r\n" +
-          s"${HttpHeader.SecWebSocketAccept}: ${accept}\r\n\r\n"
-      if NativeSocket.sendAll(clientFd, handshake.getBytes(StandardCharsets.ISO_8859_1)) then
-        NativeWebSocket.serve(
+    request.header(HttpHeader.SecWebSocketKey).filter(_.nonEmpty) match
+      case None =>
+        // A WebSocket upgrade without a Sec-WebSocket-Key is a malformed handshake (RFC 6455 §4.2.1).
+        NativeSocket.sendAll(
           clientFd,
-          request,
-          route.handlerFactory(request),
-          config.webSocketMaxFrameSize
+          HttpResponseWriter.serialize(
+            Response.badRequest("Missing Sec-WebSocket-Key"),
+            keepAlive = false,
+            includeBody = true
+          )
         )
+      case Some(key) =>
+        // Capture the request as threaded through the filter, so attributes a filter adds during
+        // the handshake reach the WebSocketContext (matching the Netty backend).
+        val upgradeRequest = AtomicReference[Request](request)
+        val gate           = RxHttpHandler { req =>
+          upgradeRequest.set(req)
+          Rx.single(Response.ok)
+        }
+        val verdict =
+          try
+            awaitRx(route.filter.apply(request, gate))
+          catch
+            case NonFatal(e) =>
+              warn(s"WebSocket upgrade filter error: ${e.getMessage}", e)
+              Response.internalServerError(e.getMessage)
+        if !verdict.isSuccessful then
+          NativeSocket.sendAll(
+            clientFd,
+            HttpResponseWriter.serialize(verdict, keepAlive = false, includeBody = true)
+          )
+        else
+          val handshake =
+            s"HTTP/1.1 101 Switching Protocols\r\n" + s"${HttpHeader.Upgrade}: websocket\r\n" +
+              s"${HttpHeader.Connection}: Upgrade\r\n" +
+              s"${HttpHeader.SecWebSocketAccept}: ${NativeWebSocket.acceptKey(key)}\r\n\r\n"
+          if NativeSocket.sendAll(clientFd, handshake.getBytes(StandardCharsets.ISO_8859_1)) then
+            val accepted = upgradeRequest.get()
+            NativeWebSocket.serve(
+              clientFd,
+              accepted,
+              route.handlerFactory(accepted),
+              config.webSocketMaxFrameSize
+            )
 
   private def daemonThreadFactory(name: String): ThreadFactory =
     (r: Runnable) =>

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
@@ -114,6 +114,10 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
               )
             )
             continue = false
+          case ReadResult.Req(request) if webSocketRouteFor(request).isDefined =>
+            // WebSocket upgrade: the WS handler owns the connection until it closes.
+            handleWebSocketUpgrade(clientFd, request, webSocketRouteFor(request).get)
+            continue = false
           case ReadResult.Req(request) =>
             val response  = runHandler(request)
             val keepAlive = clientWantsKeepAlive(request)
@@ -203,31 +207,82 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
     */
   private def runHandler(request: Request): Response =
     try
-      val latch  = CountDownLatch(1)
-      val result = AtomicReference[Response]()
-      RxRunner.runOnce(handler.handle(request)) {
-        case OnNext(response) =>
-          result.set(response.asInstanceOf[Response])
-          latch.countDown()
-        case OnError(e) =>
-          warn(s"Error in handler: ${e.getMessage}", e)
-          result.set(Response.internalServerError(e.getMessage))
-          latch.countDown()
-        case OnCompletion =>
-          // Completed without emitting a response.
-          result.compareAndSet(null, Response.notFound)
-          latch.countDown()
-      }
-      // Bound the wait so a handler whose Rx never completes can't wedge the worker thread forever.
-      if latch.await(config.handlerTimeoutMillis, TimeUnit.MILLISECONDS) then
-        result.get()
-      else
-        warn(s"Handler timed out after ${config.handlerTimeoutMillis} ms")
-        Response.serviceUnavailable
+      awaitRx(handler.handle(request))
     catch
       case NonFatal(e) =>
         warn(s"Error handling request: ${e.getMessage}", e)
         Response.internalServerError(e.getMessage)
+
+  /**
+    * Block for the single Response produced by an Rx (the request handler, or a WebSocket upgrade
+    * filter gate), bounded by the handler timeout so a never-completing Rx can't wedge the worker.
+    */
+  private def awaitRx(rx: Rx[Response]): Response =
+    val latch  = CountDownLatch(1)
+    val result = AtomicReference[Response]()
+    RxRunner.runOnce(rx) {
+      case OnNext(response) =>
+        result.set(response.asInstanceOf[Response])
+        latch.countDown()
+      case OnError(e) =>
+        warn(s"Error in handler: ${e.getMessage}", e)
+        result.set(Response.internalServerError(e.getMessage))
+        latch.countDown()
+      case OnCompletion =>
+        // Completed without emitting a response.
+        result.compareAndSet(null, Response.notFound)
+        latch.countDown()
+    }
+    if latch.await(config.handlerTimeoutMillis, TimeUnit.MILLISECONDS) then
+      result.get()
+    else
+      warn(s"Handler timed out after ${config.handlerTimeoutMillis} ms")
+      Response.serviceUnavailable
+
+  private def webSocketRouteFor(request: Request): Option[WebSocketRoute] =
+    if config.webSocketRoutes.isEmpty || !isWebSocketUpgrade(request) then
+      None
+    else
+      config.webSocketRoutes.find(_.path == request.path)
+
+  private def isWebSocketUpgrade(request: Request): Boolean =
+    request.header(HttpHeader.Connection).exists(_.toLowerCase.contains("upgrade")) &&
+      request.header(HttpHeader.Upgrade).exists(_.equalsIgnoreCase("websocket"))
+
+  /**
+    * Gate the upgrade through the route's filter (2xx allows; anything else rejects), then write
+    * the 101 handshake and hand the connection to [[NativeWebSocket.serve]] (which blocks this
+    * worker for the WebSocket's lifetime).
+    */
+  private def handleWebSocketUpgrade(clientFd: Int, request: Request, route: WebSocketRoute): Unit =
+    val gate    = RxHttpHandler(_ => Rx.single(Response.ok))
+    val verdict =
+      try
+        awaitRx(route.filter.apply(request, gate))
+      catch
+        case NonFatal(e) =>
+          warn(s"WebSocket upgrade filter error: ${e.getMessage}", e)
+          Response.internalServerError(e.getMessage)
+    if !verdict.isSuccessful then
+      NativeSocket.sendAll(
+        clientFd,
+        HttpResponseWriter.serialize(verdict, keepAlive = false, includeBody = true)
+      )
+    else
+      val accept = NativeWebSocket.acceptKey(
+        request.header(HttpHeader.SecWebSocketKey).getOrElse("")
+      )
+      val handshake =
+        s"HTTP/1.1 101 Switching Protocols\r\n" + s"${HttpHeader.Upgrade}: websocket\r\n" +
+          s"${HttpHeader.Connection}: Upgrade\r\n" +
+          s"${HttpHeader.SecWebSocketAccept}: ${accept}\r\n\r\n"
+      if NativeSocket.sendAll(clientFd, handshake.getBytes(StandardCharsets.ISO_8859_1)) then
+        NativeWebSocket.serve(
+          clientFd,
+          request,
+          route.handlerFactory(request),
+          config.webSocketMaxFrameSize
+        )
 
   private def daemonThreadFactory(name: String): ThreadFactory =
     (r: Runnable) =>

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
@@ -40,14 +40,6 @@ object NativeServer:
   def withRxHandler(f: Request => Rx[Response]): NativeServerConfig = NativeServerConfig()
     .withRxHandler(f)
 
-  def withWebSocketRoute(path: String)(
-      handlerFactory: Request => WebSocketHandler
-  ): NativeServerConfig = NativeServerConfig().withWebSocketRoute(path)(handlerFactory)
-
-  def withWebSocketRoute(path: String, filter: RxHttpFilter)(
-      handlerFactory: Request => WebSocketHandler
-  ): NativeServerConfig = NativeServerConfig().withWebSocketRoute(path, filter)(handlerFactory)
-
 /**
   * Configuration for [[NativeHttpServer]], mirroring `NettyServerConfig`/`NodeServerConfig`'s
   * common surface plus a few Native-specific knobs.

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
@@ -40,6 +40,14 @@ object NativeServer:
   def withRxHandler(f: Request => Rx[Response]): NativeServerConfig = NativeServerConfig()
     .withRxHandler(f)
 
+  def withWebSocketRoute(path: String)(
+      handlerFactory: Request => WebSocketHandler
+  ): NativeServerConfig = NativeServerConfig().withWebSocketRoute(path)(handlerFactory)
+
+  def withWebSocketRoute(path: String, filter: RxHttpFilter)(
+      handlerFactory: Request => WebSocketHandler
+  ): NativeServerConfig = NativeServerConfig().withWebSocketRoute(path, filter)(handlerFactory)
+
 /**
   * Configuration for [[NativeHttpServer]], mirroring `NettyServerConfig`/`NodeServerConfig`'s
   * common surface plus a few Native-specific knobs.
@@ -57,7 +65,11 @@ case class NativeServerConfig(
     // Size of the worker thread pool that handles connections
     workerThreads: Int = 16,
     // Max time to wait for a handler's Rx to produce a response before returning 503
-    handlerTimeoutMillis: Long = 30000
+    handlerTimeoutMillis: Long = 30000,
+    // WebSocket routes, matched by path during the HTTP upgrade handshake
+    override val webSocketRoutes: Seq[WebSocketRoute] = Nil,
+    // Maximum size (bytes) of an inbound WebSocket message
+    webSocketMaxFrameSize: Int = 1024 * 1024
 ) extends HttpServerConfig:
 
   def withName(name: String): NativeServerConfig = copy(name = name)
@@ -99,6 +111,22 @@ case class NativeServerConfig(
   def withHandlerTimeoutMillis(millis: Long): NativeServerConfig =
     require(millis > 0, "handlerTimeoutMillis must be positive")
     copy(handlerTimeoutMillis = millis)
+
+  /** Register a WebSocket route; the factory creates a fresh handler per accepted connection. */
+  def withWebSocketRoute(path: String)(
+      handlerFactory: Request => WebSocketHandler
+  ): NativeServerConfig = withWebSocketRoute(path, RxHttpFilter.identity)(handlerFactory)
+
+  /** Register a WebSocket route with a filter that gates the upgrade handshake (e.g. for auth). */
+  def withWebSocketRoute(path: String, filter: RxHttpFilter)(
+      handlerFactory: Request => WebSocketHandler
+  ): NativeServerConfig = copy(webSocketRoutes =
+    webSocketRoutes :+ WebSocketRoute(path, handlerFactory, filter)
+  )
+
+  def withWebSocketMaxFrameSize(sizeInBytes: Int): NativeServerConfig =
+    require(sizeInBytes > 0, "webSocketMaxFrameSize must be positive")
+    copy(webSocketMaxFrameSize = sizeInBytes)
 
   /**
     * Start the server and return the running instance. Binding is synchronous, so the inherited

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
@@ -1,0 +1,264 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.log.LogSupport
+
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+/**
+  * Native WebSocket (RFC 6455) over a raw POSIX socket: handshake accept-key, frame encode/decode,
+  * and the per-connection read loop bridging frames to a [[WebSocketHandler]].
+  */
+private[http] object NativeWebSocket extends LogSupport:
+
+  final val OpContinuation = 0x0
+  final val OpText         = 0x1
+  final val OpBinary       = 0x2
+  final val OpClose        = 0x8
+  final val OpPing         = 0x9
+  final val OpPong         = 0xa
+
+  private final val MagicGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+  /** `Sec-WebSocket-Accept` = base64(SHA1(key + GUID)). */
+  def acceptKey(key: String): String = Base64
+    .getEncoder
+    .encodeToString(Sha1.digest((key + MagicGuid).getBytes(StandardCharsets.US_ASCII)))
+
+  /** Encode an unmasked server frame (FIN set). */
+  def encodeFrame(opcode: Int, payload: Array[Byte]): Array[Byte] =
+    val len    = payload.length
+    val b0     = (0x80 | opcode).toByte
+    val header =
+      if len < 126 then
+        Array[Byte](b0, len.toByte)
+      else if len < 65536 then
+        Array[Byte](b0, 126.toByte, ((len >>> 8) & 0xff).toByte, (len & 0xff).toByte)
+      else
+        val h = new Array[Byte](10)
+        h(0) = b0
+        h(1) = 127.toByte
+        val l = len.toLong
+        var i = 0
+        while i < 8 do
+          h(2 + i) = ((l >>> ((7 - i) * 8)) & 0xff).toByte
+          i += 1
+        h
+    header ++ payload
+
+  /**
+    * Run a WebSocket connection: deliver `onOpen`, then read/dispatch frames until the peer closes
+    * or the socket ends, guaranteeing `onClose` exactly once. Runs on the calling worker thread.
+    */
+  def serve(clientFd: Int, request: Request, handler: WebSocketHandler, maxFrameSize: Int): Unit =
+    val ctx                 = NativeWebSocketContext(clientFd, request)
+    val closeNotified       = AtomicBoolean(false)
+    def notifyClose(): Unit =
+      if closeNotified.compareAndSet(false, true) then
+        try
+          handler.onClose(ctx)
+        catch
+          case NonFatal(e) =>
+            warn(s"onClose error: ${e.getMessage}")
+
+    val buf             = mutable.ArrayBuffer.empty[Byte]
+    def fill(): Boolean =
+      val c = NativeSocket.recvChunk(clientFd)
+      if c.isEmpty then
+        false
+      else
+        buf ++= c
+        true
+    def ensure(n: Int): Boolean =
+      while buf.length < n do
+        if !fill() then
+          return false
+      true
+    def take(n: Int): Array[Byte] =
+      val a = buf.slice(0, n).toArray
+      buf.remove(0, n)
+      a
+
+    try
+      try
+        handler.onOpen(ctx)
+      catch
+        case NonFatal(e) =>
+          safeOnError(handler, ctx, e)
+
+      val fragments      = mutable.ArrayBuffer.empty[Byte]
+      var fragmentOpcode = -1
+      var open           = true
+      while open do
+        if !ensure(2) then
+          open = false
+        else
+          val b0     = buf(0) & 0xff
+          val b1     = buf(1) & 0xff
+          val fin    = (b0 & 0x80) != 0
+          val opcode = b0 & 0x0f
+          val masked = (b1 & 0x80) != 0
+          var len    = b1 & 0x7f
+          var header = 2
+          if len == 126 then
+            if !ensure(4) then
+              open = false
+            else
+              len = ((buf(2) & 0xff) << 8) | (buf(3) & 0xff)
+              header = 4
+          else if len == 127 then
+            if !ensure(10) then
+              open = false
+            else
+              var l = 0L
+              var i = 0
+              while i < 8 do
+                l = (l << 8) | (buf(2 + i) & 0xff).toLong
+                i += 1
+              if l > maxFrameSize then
+                len = -1 // signal too-big below
+              else
+                len = l.toInt
+              header = 10
+
+          if open && (len < 0 || len > maxFrameSize) then
+            ctx.close(1009, "message too big")
+            open = false
+          else if open then
+            val maskLen =
+              if masked then
+                4
+              else
+                0
+            if !ensure(header + maskLen + len) then
+              open = false
+            else
+              buf.remove(0, header)
+              val mask =
+                if masked then
+                  take(4)
+                else
+                  Array.emptyByteArray
+              val payload = take(len)
+              if masked then
+                var i = 0
+                while i < payload.length do
+                  payload(i) = (payload(i) ^ mask(i % 4)).toByte
+                  i += 1
+              opcode match
+                case OpText | OpBinary =>
+                  if fin then
+                    deliver(handler, ctx, opcode, payload)
+                  else
+                    fragmentOpcode = opcode
+                    fragments.clear()
+                    fragments ++= payload
+                case OpContinuation =>
+                  fragments ++= payload
+                  if fin then
+                    deliver(handler, ctx, fragmentOpcode, fragments.toArray)
+                    fragments.clear()
+                    fragmentOpcode = -1
+                case OpClose =>
+                  notifyClose()
+                  ctx.close()
+                  open = false
+                case OpPing =>
+                  ctx.sendPong(payload)
+                case OpPong =>
+                // ignore unsolicited pongs
+                case _ =>
+                  debug(s"Ignoring unsupported WebSocket opcode: ${opcode}")
+            end if
+          end if
+      end while
+    catch
+      case NonFatal(e) =>
+        safeOnError(handler, ctx, e)
+    finally
+      notifyClose()
+    end try
+
+  end serve
+
+  private def deliver(
+      handler: WebSocketHandler,
+      ctx: NativeWebSocketContext,
+      opcode: Int,
+      payload: Array[Byte]
+  ): Unit =
+    try
+      if opcode == OpText then
+        handler.onTextMessage(ctx, new String(payload, StandardCharsets.UTF_8))
+      else
+        handler.onBinaryMessage(ctx, payload)
+    catch
+      case NonFatal(e) =>
+        safeOnError(handler, ctx, e)
+
+  private def safeOnError(handler: WebSocketHandler, ctx: WebSocketContext, e: Throwable): Unit =
+    try
+      handler.onError(ctx, e)
+    catch
+      case NonFatal(e2) =>
+        warn(s"onError error: ${e2.getMessage}")
+
+end NativeWebSocket
+
+/**
+  * Native [[WebSocketContext]]. Writes are serialized so `send`/`close` are safe from any thread
+  * (the read loop also writes pong/close frames).
+  */
+private[http] class NativeWebSocketContext(clientFd: Int, override val request: Request)
+    extends WebSocketContext:
+
+  private val writeLock = Object()
+  private val closed    = AtomicBoolean(false)
+
+  override def send(text: String): Unit = sendFrameIfOpen(
+    NativeWebSocket.OpText,
+    text.getBytes(StandardCharsets.UTF_8)
+  )
+
+  override def send(data: Array[Byte]): Unit = sendFrameIfOpen(NativeWebSocket.OpBinary, data)
+
+  override def close(): Unit = close(1000, "")
+
+  override def close(statusCode: Int, reason: String): Unit =
+    if closed.compareAndSet(false, true) then
+      val reasonBytes = reason.getBytes(StandardCharsets.UTF_8)
+      val payload     = new Array[Byte](2 + reasonBytes.length)
+      payload(0) = ((statusCode >>> 8) & 0xff).toByte
+      payload(1) = (statusCode & 0xff).toByte
+      System.arraycopy(reasonBytes, 0, payload, 2, reasonBytes.length)
+      writeFrame(NativeWebSocket.OpClose, payload)
+
+  private[http] def sendPong(payload: Array[Byte]): Unit =
+    if !closed.get() then
+      writeFrame(NativeWebSocket.OpPong, payload)
+
+  private def sendFrameIfOpen(opcode: Int, payload: Array[Byte]): Unit =
+    if !closed.get() then
+      writeFrame(opcode, payload)
+
+  private def writeFrame(opcode: Int, payload: Array[Byte]): Unit = writeLock.synchronized {
+    NativeSocket.sendAll(clientFd, NativeWebSocket.encodeFrame(opcode, payload))
+  }
+
+end NativeWebSocketContext

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
@@ -109,13 +109,15 @@ private[http] object NativeWebSocket extends LogSupport:
         if !ensure(2) then
           open = false
         else
-          val b0     = buf(0) & 0xff
-          val b1     = buf(1) & 0xff
-          val fin    = (b0 & 0x80) != 0
-          val opcode = b0 & 0x0f
-          val masked = (b1 & 0x80) != 0
-          var len    = b1 & 0x7f
-          var header = 2
+          val b0        = buf(0) & 0xff
+          val b1        = buf(1) & 0xff
+          val fin       = (b0 & 0x80) != 0
+          val rsv       = b0 & 0x70
+          val opcode    = b0 & 0x0f
+          val masked    = (b1 & 0x80) != 0
+          val isControl = (opcode & 0x8) != 0
+          var len       = b1 & 0x7f
+          var header    = 2
           if len == 126 then
             if !ensure(4) then
               open = false
@@ -140,51 +142,67 @@ private[http] object NativeWebSocket extends LogSupport:
           if open && (len < 0 || len > maxFrameSize) then
             ctx.close(1009, "message too big")
             open = false
+          else if open && (rsv != 0 || !masked) then
+            // RSV must be 0 (no extension negotiated); client frames MUST be masked (RFC 6455 §5).
+            ctx.close(1002, "protocol error")
+            open = false
+          else if open && isControl && (!fin || len > 125) then
+            // Control frames must be final and at most 125 bytes (RFC 6455 §5.5).
+            ctx.close(1002, "invalid control frame")
+            open = false
           else if open then
-            val maskLen =
-              if masked then
-                4
-              else
-                0
-            if !ensure(header + maskLen + len) then
+            if !ensure(header + 4 + len) then
               open = false
             else
               buf.remove(0, header)
-              val mask =
-                if masked then
-                  take(4)
-                else
-                  Array.emptyByteArray
+              val mask    = take(4) // client frames are masked (validated above)
               val payload = take(len)
-              if masked then
-                var i = 0
-                while i < payload.length do
-                  payload(i) = (payload(i) ^ mask(i % 4)).toByte
-                  i += 1
+              var i       = 0
+              while i < payload.length do
+                payload(i) = (payload(i) ^ mask(i % 4)).toByte
+                i += 1
               opcode match
                 case OpText | OpBinary =>
-                  if fin then
+                  if fragmentOpcode != -1 then
+                    ctx.close(1002, "data frame during a fragmented message")
+                    open = false
+                  else if fin then
                     deliver(handler, ctx, opcode, payload)
                   else
                     fragmentOpcode = opcode
                     fragments.clear()
                     fragments ++= payload
                 case OpContinuation =>
-                  fragments ++= payload
-                  if fin then
-                    deliver(handler, ctx, fragmentOpcode, fragments.toArray)
-                    fragments.clear()
-                    fragmentOpcode = -1
+                  if fragmentOpcode == -1 then
+                    ctx.close(1002, "continuation without a start frame")
+                    open = false
+                  else
+                    fragments ++= payload
+                    if fragments.length > maxFrameSize then
+                      ctx.close(1009, "message too big")
+                      open = false
+                    else if fin then
+                      deliver(handler, ctx, fragmentOpcode, fragments.toArray)
+                      fragments.clear()
+                      fragmentOpcode = -1
                 case OpClose =>
                   notifyClose()
-                  ctx.close()
+                  // Echo the peer's close code (RFC 6455 §5.5.1).
+                  val code =
+                    if payload.length >= 2 then
+                      ((payload(0) & 0xff) << 8) | (payload(1) & 0xff)
+                    else
+                      1000
+                  ctx.close(code, "")
                   open = false
                 case OpPing =>
                   ctx.sendPong(payload)
                 case OpPong =>
                 // ignore unsolicited pongs
                 case _ =>
-                  debug(s"Ignoring unsupported WebSocket opcode: ${opcode}")
+                  ctx.close(1002, s"unsupported opcode ${opcode}")
+                  open = false
+              end match
             end if
           end if
       end while

--- a/uni/.native/src/main/scala/wvlet/uni/http/Sha1.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/Sha1.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import scala.collection.mutable
+
+/**
+  * A small, dependency-free SHA-1 (RFC 3174) used for the WebSocket handshake accept key.
+  * `java.security.MessageDigest` is not available on Scala Native, so this provides the digest; the
+  * result is base64-encoded with `java.util.Base64` (which is available on Native).
+  */
+private[http] object Sha1:
+
+  def digest(message: Array[Byte]): Array[Byte] =
+    var h0 = 0x67452301
+    var h1 = 0xefcdab89
+    var h2 = 0x98badcfe
+    var h3 = 0x10325476
+    var h4 = 0xc3d2e1f0
+
+    val bitLen = message.length.toLong * 8
+    val padded = mutable.ArrayBuffer.from(message)
+    padded += 0x80.toByte
+    while padded.length % 64 != 56 do
+      padded += 0.toByte
+    var s = 7
+    while s >= 0 do
+      padded += ((bitLen >>> (s * 8)) & 0xff).toByte
+      s -= 1
+
+    val w     = new Array[Int](80)
+    var chunk = 0
+    while chunk < padded.length do
+      var t = 0
+      while t < 16 do
+        val off = chunk + t * 4
+        w(t) =
+          ((padded(off) & 0xff) << 24) |
+            ((padded(off + 1) & 0xff) << 16) |
+            ((padded(off + 2) & 0xff) << 8) |
+            (padded(off + 3) & 0xff)
+        t += 1
+      while t < 80 do
+        w(t) = Integer.rotateLeft(w(t - 3) ^ w(t - 8) ^ w(t - 14) ^ w(t - 16), 1)
+        t += 1
+
+      var a = h0
+      var b = h1
+      var c = h2
+      var d = h3
+      var e = h4
+      var j = 0
+      while j < 80 do
+        var f = 0
+        var k = 0
+        if j < 20 then
+          f = (b & c) | (~b & d);
+          k = 0x5a827999
+        else if j < 40 then
+          f = b ^ c ^ d;
+          k = 0x6ed9eba1
+        else if j < 60 then
+          f = (b & c) | (b & d) | (c & d);
+          k = 0x8f1bbcdc
+        else
+          f = b ^ c ^ d;
+          k = 0xca62c1d6
+        val tmp = Integer.rotateLeft(a, 5) + f + e + k + w(j)
+        e = d
+        d = c
+        c = Integer.rotateLeft(b, 30)
+        b = a
+        a = tmp
+        j += 1
+
+      h0 += a
+      h1 += b
+      h2 += c
+      h3 += d
+      h4 += e
+      chunk += 64
+    end while
+
+    val hs  = Array(h0, h1, h2, h3, h4)
+    val out = new Array[Byte](20)
+    var x   = 0
+    while x < 5 do
+      out(x * 4) = ((hs(x) >>> 24) & 0xff).toByte
+      out(x * 4 + 1) = ((hs(x) >>> 16) & 0xff).toByte
+      out(x * 4 + 2) = ((hs(x) >>> 8) & 0xff).toByte
+      out(x * 4 + 3) = (hs(x) & 0xff).toByte
+      x += 1
+    out
+
+  end digest
+
+end Sha1

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
@@ -121,6 +121,7 @@ class NativeServerTest extends UniTest:
       .withHandler { req =>
         Response.ok(s"Hello from ${req.path}")
       }
+      .withPort(0)
       .start { server =>
         val response = request(
           server.localPort,
@@ -136,6 +137,7 @@ class NativeServerTest extends UniTest:
       .withHandler { req =>
         Response.ok(s"Received: ${req.content.toContentString}")
       }
+      .withPort(0)
       .start { server =>
         val response = request(
           server.localPort,
@@ -151,6 +153,7 @@ class NativeServerTest extends UniTest:
       .withHandler { req =>
         Response.ok("ok").addHeader("X-Echoed", req.header("X-Echo").getOrElse("none"))
       }
+      .withPort(0)
       .start { server =>
         val response = request(
           server.localPort,

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
@@ -121,7 +121,6 @@ class NativeServerTest extends UniTest:
       .withHandler { req =>
         Response.ok(s"Hello from ${req.path}")
       }
-      .withPort(0)
       .start { server =>
         val response = request(
           server.localPort,
@@ -137,7 +136,6 @@ class NativeServerTest extends UniTest:
       .withHandler { req =>
         Response.ok(s"Received: ${req.content.toContentString}")
       }
-      .withPort(0)
       .start { server =>
         val response = request(
           server.localPort,
@@ -153,7 +151,6 @@ class NativeServerTest extends UniTest:
       .withHandler { req =>
         Response.ok("ok").addHeader("X-Echoed", req.header("X-Echo").getOrElse("none"))
       }
-      .withPort(0)
       .start { server =>
         val response = request(
           server.localPort,
@@ -372,13 +369,13 @@ class NativeServerTest extends UniTest:
 
   test("WebSocket echoes text messages") {
     NativeServer
+      .withPort(0)
       .withWebSocketRoute("/ws/echo") { _ =>
         new WebSocketHandler:
           override def onTextMessage(ctx: WebSocketContext, message: String): Unit = ctx.send(
             s"echo:${message}"
           )
       }
-      .withPort(0)
       .start { server =>
         val client = WsClient(connectLoopback(server.localPort))
         try
@@ -394,11 +391,11 @@ class NativeServerTest extends UniTest:
 
   test("WebSocket can push a message on open") {
     NativeServer
+      .withPort(0)
       .withWebSocketRoute("/ws/push") { _ =>
         new WebSocketHandler:
           override def onOpen(ctx: WebSocketContext): Unit = ctx.send("welcome")
       }
-      .withPort(0)
       .start { server =>
         val client = WsClient(connectLoopback(server.localPort))
         try
@@ -413,12 +410,12 @@ class NativeServerTest extends UniTest:
     val opened = CountDownLatch(1)
     val closed = CountDownLatch(1)
     NativeServer
+      .withPort(0)
       .withWebSocketRoute("/ws/life") { _ =>
         new WebSocketHandler:
           override def onOpen(ctx: WebSocketContext): Unit  = opened.countDown()
           override def onClose(ctx: WebSocketContext): Unit = closed.countDown()
       }
-      .withPort(0)
       .start { server =>
         val client = WsClient(connectLoopback(server.localPort))
         client.handshake("/ws/life", "dGhlIHNhbXBsZSBub25jZQ==").status shouldBe 101
@@ -428,15 +425,30 @@ class NativeServerTest extends UniTest:
       }
   }
 
+  test("WebSocket upgrade without a key is rejected with 400") {
+    NativeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws") { _ =>
+        new WebSocketHandler {}
+      }
+      .start { server =>
+        val resp = request(
+          server.localPort,
+          "GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
+        )
+        resp.status shouldBe 400
+      }
+  }
+
   test("WebSocket upgrade can be rejected by a filter") {
     val deny = RxHttpFilter { (_, _) =>
       wvlet.uni.rx.Rx.single(Response.forbidden)
     }
     NativeServer
+      .withPort(0)
       .withWebSocketRoute("/ws/secure", deny) { _ =>
         new WebSocketHandler {}
       }
-      .withPort(0)
       .start { server =>
         val client = WsClient(connectLoopback(server.localPort))
         try client.handshake("/ws/secure", "dGhlIHNhbXBsZSBub25jZQ==").status shouldBe 403

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
@@ -16,6 +16,7 @@ package wvlet.uni.http
 import wvlet.uni.test.UniTest
 
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 import scala.scalanative.libc.string as cstring
 import scala.scalanative.posix.arpa.inet
 import scala.scalanative.posix.netinet.in.{in_addr, sockaddr_in}
@@ -288,6 +289,158 @@ class NativeServerTest extends UniTest:
       .start { server =>
         (server.localPort > 0) shouldBe true
         server.isRunning shouldBe true
+      }
+  }
+
+  // ---- WebSocket ----
+
+  /**
+    * A minimal raw-socket WebSocket client: upgrade handshake, masked text send, server-frame read.
+    */
+  private class WsClient(fd: Int):
+    private val buf = scala.collection.mutable.ArrayBuffer.empty[Byte]
+
+    private def ensure(n: Int): Unit =
+      while buf.length < n do
+        val c = NativeSocket.recvChunk(fd)
+        if c.isEmpty then
+          throw RuntimeException("WebSocket connection closed unexpectedly")
+        buf ++= c
+
+    private def headerEnd: Int =
+      var i = 0
+      while i + 3 < buf.length do
+        if buf(i) == '\r' && buf(i + 1) == '\n' && buf(i + 2) == '\r' && buf(i + 3) == '\n' then
+          return i
+        i += 1
+      -1
+
+    /**
+      * Send the upgrade request and return the parsed handshake response (leftover frames
+      * buffered).
+      */
+    def handshake(path: String, key: String): RawResponse =
+      val req =
+        s"GET ${path} HTTP/1.1\r\nHost: localhost\r\n" +
+          s"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+          s"Sec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+      NativeSocket.sendAll(fd, req.getBytes(StandardCharsets.ISO_8859_1))
+      var idx = headerEnd
+      while idx < 0 do
+        val c = NativeSocket.recvChunk(fd)
+        if c.isEmpty then
+          throw RuntimeException("no handshake response")
+        buf ++= c
+        idx = headerEnd
+      val head = new String(buf.slice(0, idx).toArray, StandardCharsets.ISO_8859_1)
+      buf.remove(0, idx + 4)
+      parse(head)
+
+    def sendText(text: String): Unit =
+      val payload = text.getBytes(StandardCharsets.UTF_8)
+      val mask    = Array[Byte](0x12, 0x34, 0x56, 0x78)
+      val masked  = new Array[Byte](payload.length)
+      var i       = 0
+      while i < payload.length do
+        masked(i) = (payload(i) ^ mask(i % 4)).toByte
+        i += 1
+      val header = Array[Byte](0x81.toByte, (0x80 | payload.length).toByte)
+      NativeSocket.sendAll(fd, header ++ mask ++ masked)
+
+    /** Read one server frame and return its UTF-8 text payload. */
+    def readText(): String =
+      ensure(2)
+      var len    = buf(1) & 0x7f
+      var header = 2
+      if len == 126 then
+        ensure(4)
+        len = ((buf(2) & 0xff) << 8) | (buf(3) & 0xff)
+        header = 4
+      ensure(header + len)
+      buf.remove(0, header)
+      val payload = buf.slice(0, len).toArray
+      buf.remove(0, len)
+      new String(payload, StandardCharsets.UTF_8)
+
+    def close(): Unit = NativeSocket.close(fd)
+
+  end WsClient
+
+  test("acceptKey matches the RFC 6455 example") {
+    NativeWebSocket.acceptKey("dGhlIHNhbXBsZSBub25jZQ==") shouldBe "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+  }
+
+  test("WebSocket echoes text messages") {
+    NativeServer
+      .withWebSocketRoute("/ws/echo") { _ =>
+        new WebSocketHandler:
+          override def onTextMessage(ctx: WebSocketContext, message: String): Unit = ctx.send(
+            s"echo:${message}"
+          )
+      }
+      .withPort(0)
+      .start { server =>
+        val client = WsClient(connectLoopback(server.localPort))
+        try
+          val resp = client.handshake("/ws/echo", "dGhlIHNhbXBsZSBub25jZQ==")
+          resp.status shouldBe 101
+          resp.headers.get("sec-websocket-accept") shouldBe Some("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
+          client.sendText("hello")
+          client.readText() shouldBe "echo:hello"
+        finally
+          client.close()
+      }
+  }
+
+  test("WebSocket can push a message on open") {
+    NativeServer
+      .withWebSocketRoute("/ws/push") { _ =>
+        new WebSocketHandler:
+          override def onOpen(ctx: WebSocketContext): Unit = ctx.send("welcome")
+      }
+      .withPort(0)
+      .start { server =>
+        val client = WsClient(connectLoopback(server.localPort))
+        try
+          client.handshake("/ws/push", "dGhlIHNhbXBsZSBub25jZQ==").status shouldBe 101
+          client.readText() shouldBe "welcome"
+        finally
+          client.close()
+      }
+  }
+
+  test("WebSocket fires onOpen and onClose") {
+    val opened = CountDownLatch(1)
+    val closed = CountDownLatch(1)
+    NativeServer
+      .withWebSocketRoute("/ws/life") { _ =>
+        new WebSocketHandler:
+          override def onOpen(ctx: WebSocketContext): Unit  = opened.countDown()
+          override def onClose(ctx: WebSocketContext): Unit = closed.countDown()
+      }
+      .withPort(0)
+      .start { server =>
+        val client = WsClient(connectLoopback(server.localPort))
+        client.handshake("/ws/life", "dGhlIHNhbXBsZSBub25jZQ==").status shouldBe 101
+        opened.await(5, TimeUnit.SECONDS) shouldBe true
+        client.close()
+        closed.await(5, TimeUnit.SECONDS) shouldBe true
+      }
+  }
+
+  test("WebSocket upgrade can be rejected by a filter") {
+    val deny = RxHttpFilter { (_, _) =>
+      wvlet.uni.rx.Rx.single(Response.forbidden)
+    }
+    NativeServer
+      .withWebSocketRoute("/ws/secure", deny) { _ =>
+        new WebSocketHandler {}
+      }
+      .withPort(0)
+      .start { server =>
+        val client = WsClient(connectLoopback(server.localPort))
+        try client.handshake("/ws/secure", "dGhlIHNhbXBsZSBub25jZQ==").status shouldBe 403
+        finally client.close()
       }
   }
 

--- a/uni/src/main/scala/wvlet/uni/http/HttpHeader.scala
+++ b/uni/src/main/scala/wvlet/uni/http/HttpHeader.scala
@@ -36,6 +36,12 @@ object HttpHeader:
   val Via: String              = "Via"
   val Warning: String          = "Warning"
 
+  // WebSocket handshake headers (RFC 6455)
+  val SecWebSocketKey: String      = "Sec-WebSocket-Key"
+  val SecWebSocketAccept: String   = "Sec-WebSocket-Accept"
+  val SecWebSocketVersion: String  = "Sec-WebSocket-Version"
+  val SecWebSocketProtocol: String = "Sec-WebSocket-Protocol"
+
   // Request headers
   val Accept: String             = "Accept"
   val AcceptCharset: String      = "Accept-Charset"


### PR DESCRIPTION
## Why

Completes WebSocket support across all server backends — JVM/Netty (#573) and now **Scala Native**. Builds on the Native HTTP server (#574) and SSE streaming (#575), reusing the shared `WebSocketContext`/`WebSocketHandler`/`WebSocketRoute` traits. **Second of two PRs** (SSE/chunked streaming was #575).

## Approach

Hand-written RFC 6455 over the raw POSIX socket (no dependency). `java.security.MessageDigest` is **absent on Scala Native**, so the handshake uses a small **pure-Scala SHA-1** + `java.util.Base64` (which *is* present).

## What

- **`Sha1`** — dependency-free SHA-1 (RFC 3174) for the accept key.
- **`NativeWebSocket`** — `acceptKey` (`base64(SHA1(key + GUID))`), an unmasked server-frame encoder, and `serve(...)`: `onOpen`, then a read loop parsing masked client frames (7/16/64-bit lengths, unmasking), fragment reassembly, text/binary dispatch, ping→pong, close handling, `onClose` exactly once. `NativeWebSocketContext` serializes writes so `send`/`close` are thread-safe alongside the loop's pong/close; oversized frames → close 1009.
- **`NativeServerConfig`/`NativeServer`** — `webSocketRoutes` + `withWebSocketRoute(path[, filter])(factory)` + `withWebSocketMaxFrameSize`.
- **`NativeHttpServer`** — detects the `Upgrade: websocket` request, gates it through the route filter (2xx allows, else the response rejects — via an extracted `awaitRx`), writes `101 Switching Protocols`, hands off to `NativeWebSocket.serve`.
- **`HttpHeader`** (shared) — `Sec-WebSocket-Key/Accept/Version/Protocol` constants.

```scala
NativeServer
  .withPort(0)
  .withWebSocketRoute("/ws"){ _ =>
    new WebSocketHandler:
      override def onTextMessage(ctx, m) = ctx.send(s"echo:${m}")
  }
  .start { server => ... }
```

## Testing
A raw-socket `WsClient` (handshake + masked text frame send + server-frame read) drives: **accept-key matches the RFC 6455 example vector**, text echo, server push on `onOpen`, `onOpen`/`onClose` lifecycle (latches), and a filter-rejected upgrade (403). Native suite: **1378 tests, 1369 passed, 9 pending, 0 failed**; JVM/JS/Netty compile clean with the shared `HttpHeader` addition. No new dependency.

## Limitations / follow-ups (blocking model)
- A WebSocket (like SSE) pins a worker thread for the connection's life; an idle disconnect is noticed only on the next read/write. A portable idle/read timeout is the standing follow-up (posixlib's `timeval` is mislaid out on macOS — see #574/#575).
- No permessage-deflate or client-side WebSocket.

Plan: `plans/2026-06-19-native-websocket.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)