### PR TITLE
feature: Add WebSocket support to the Node.js HTTP server

### DIFF
--- a/plans/2026-06-19-node-websocket.md
+++ b/plans/2026-06-19-node-websocket.md
@@ -1,0 +1,131 @@
+# Node.js WebSocket server (shared RFC 6455 codec)
+
+## Context
+
+The cross-platform HTTP server now supports WebSocket on JVM (Netty, #573) and Scala Native (#576),
+but **not Node.js** — Node's `http.Server` has no built-in WebSocket, so it was deferred. This PR
+closes that gap: it adds a WebSocket server to the Node backend by hand-rolling the handshake +
+framing on the raw `'upgrade'` socket, exactly as the Native backend does.
+
+Rather than duplicate the intricate, security-sensitive RFC 6455 parser (the Native one accrued 7
+review findings), the plan **extracts a shared, tested frame codec** that both Native and Node drive
+— so there is one parser to maintain. Research confirmed `Sha1` (pure Scala) and `java.util.Base64`
+both compile/run on Scala.js 1.21, so the handshake accept-key is fully shareable.
+
+Outcome: all three server backends (JVM/Node/Native) support request/response, SSE streaming, and
+WebSocket on the one shared abstraction.
+
+## Design
+
+### 1. Shared codec — new files in `uni/src/main/scala/wvlet/uni/http/` (cross-compiled JVM/JS/Native)
+
+- **`Sha1.scala`** — **move** verbatim from `uni/.native/.../http/Sha1.scala` (pure `ArrayBuffer` +
+  `Integer.rotateLeft`). **Delete the Native copy in the same change** (two `wvlet.uni.http.Sha1`
+  on the Native classpath = duplicate-definition compile error).
+- **`WebSocketFrame.scala`** (`private[http] object`) — moved from `NativeWebSocket`: opcode
+  constants (`OpContinuation/OpText/OpBinary/OpClose/OpPing/OpPong`), `MagicGuid`,
+  `acceptKey(key)` = `Base64(Sha1(key+GUID))`, `encodeFrame(opcode, payload)` (unmasked server
+  frame), and `closePayload(code, reason)` (2-byte BE code + UTF-8 reason, extracted from
+  `NativeWebSocketContext.close`).
+- **`WebSocketFrameDecoder.scala`** (`private[http] class`, stateful) — the parser extracted from
+  the Native `serve` loop. Holds `buf`/`fragments`/`fragmentOpcode`/`terminated`.
+  ```scala
+  enum WsEvent:
+    case Message(opcode: Int, data: Array[Byte])  // OpText|OpBinary, reassembled
+    case Ping(data: Array[Byte]); case Pong(data: Array[Byte])
+    case PeerClose(code: Int, reason: String)     // close code pre-resolved (>=2 bytes ? BE16 : 1000)
+    case Fail(code: Int, reason: String)          // terminal protocol/size violation
+  def feed(bytes: Array[Byte])(emit: WsEvent => Unit): Boolean  // false once terminal
+  ```
+  **Behavior must match the current Native loop exactly:**
+  - **Truncated frame ⇒ buffer and return `true` (need more bytes), never `Fail`.** This is the key
+    regression trap — frames span multiple `recvChunk`/`data` chunks. Only emit `Fail`/`PeerClose`
+    on a fully-parsed violation/close.
+  - Internally loop over all complete frames in `buf` per `feed` (multiple frames per chunk).
+  - Masking is **hardcoded required** (server decodes only client→server). `!masked ⇒ Fail(1002)`.
+  - **Validation order (pin it):** `len<0 || len>maxFrameSize ⇒ Fail(1009)`; then `rsv!=0 ||
+    !masked ⇒ Fail(1002)`; then `isControl && (!fin || len>125) ⇒ Fail(1002)`. (Oversized+unmasked
+    ⇒ 1009, not 1002.)
+  - `maxFrameSize` is **both** per-frame (1009) **and** per-message reassembly cap (1009).
+  - Fragmentation: lone continuation ⇒ Fail(1002); data frame mid-fragmentation ⇒ Fail(1002).
+
+- **`HttpServerConfig.scala`** — update the now-stale `webSocketRoutes` doc comment (Native already
+  consumes it; Node will too). No code change.
+
+### 2. Native refactor — `uni/.native/.../http/NativeWebSocket.scala`
+
+- Drop local `Op*`/`MagicGuid`/`acceptKey`/`encodeFrame` → delegate to `WebSocketFrame`.
+- `serve(...)` becomes a thin driver: `onOpen`; `while open { chunk=recvChunk; if empty break; open
+  = decoder.feed(chunk){ ev => dispatch(ev) } }`; `finally notifyClose()` (keep the `AtomicBoolean`
+  exactly-once). Dispatch mapping (preserve order + reason strings):
+  | `WsEvent` | action |
+  |---|---|
+  | `Message(OpText,d)` / `Message(OpBinary,d)` | `deliver(...)` → `onTextMessage`/`onBinaryMessage` |
+  | `Ping(d)` | `ctx.sendPong(d)` |  `Pong` | ignore |
+  | `PeerClose(code,_)` | `notifyClose()` **then** `ctx.close(code,"")` (onClose before echo) |
+  | `Fail(code,reason)` | `ctx.close(code,reason)` (onClose via `finally`) |
+- `NativeWebSocketContext` keeps `writeLock`/`AtomicBoolean` (**Native is genuinely multi-threaded**);
+  swap `encodeFrame`/`Op*` → `WebSocketFrame.*`; `close` uses `WebSocketFrame.closePayload`.
+
+### 3. Node backend — `uni/.js/src/main/scala/wvlet/uni/http/`
+
+- **`NodeBytes.scala`** (new `private[http]`) — extract `toBytes(chunk): Array[Byte]` /
+  `toUint8Array(bytes): Uint8Array` out of `NodeHttpServer` so both it and `NodeWebSocket` reuse them.
+- **`NodeWebSocket.scala`** (new) — the `'upgrade'` handler + `NodeWebSocketContext`. Lifecycle:
+  1. Build `Request` from `req.method/url/rawHeaders` (reuse the `rawHeaders` loop; bodyless GET).
+  2. No matching route ⇒ `socket.destroy()`. Missing/empty `Sec-WebSocket-Key` ⇒ write `400` +
+     `socket.end()`.
+  3. Filter-gate via `RxRunner.runOnce(route.filter.apply(request, gate))` (Node is async — NOT the
+     blocking `awaitRx`). `gate` captures the filter-threaded request (plain `var`). `OnNext`
+     success ⇒ `accept()`; non-2xx ⇒ write that response + `end()`; `OnError` ⇒ 500 + `end()`;
+     `OnCompletion` (no verdict) ⇒ `socket.destroy()` (Netty parity).
+  4. `accept()`: write `101` (`WebSocketFrame.acceptKey(key)`); build `NodeWebSocketContext(socket,
+     req)`; `handler.onOpen(ctx)` **before** wiring data; if `head.length>0` feed it first; then
+     `socket.on("data", c => drive(toBytes(c)))`, `socket.on("close"/"error", _ => notifyClose())`.
+  5. `drive(bytes)`: `if !closed { if !decoder.feed(bytes)(dispatchNode) then socket.end() }`.
+  - `NodeWebSocketContext`: **plain `var closed`, no AtomicBoolean/lock** (single-threaded event
+    loop). `send`/`close`/`sendPong` write `socket.write(toUint8Array(WebSocketFrame.encodeFrame
+    (...)))` — **every write in try/catch** (an uncaught throw on the event loop crashes the
+    process — same discipline as `writeSseResponse`). Exactly-once `onClose` via one `var closed`.
+    On close, `socket.end()` (flush the close frame) — **not `destroy()`**.
+- **`NodeHttpServer.scala`** — in `start()`, after `createServer`, register `server.on("upgrade",
+  jsFn3)` (`js.Function3[js.Dynamic,js.Dynamic,js.Dynamic,Unit]`) → `NodeWebSocket`. Use
+  `NodeBytes.*`.
+- **`NodeServer.scala`** — `NodeServerConfig` gains `override val webSocketRoutes = Nil`,
+  `webSocketMaxFrameSize = 1024*1024`, and `withWebSocketRoute(path)(factory)` /
+  `withWebSocketRoute(path, filter)(factory)` / `withWebSocketMaxFrameSize(n)` — mirror
+  `NativeServerConfig` (NativeServer.scala:107-129).
+
+## Files
+| Action | Path |
+|---|---|
+| Move | `uni/.native/.../http/Sha1.scala` → `uni/src/main/scala/wvlet/uni/http/Sha1.scala` (delete Native copy) |
+| Add | `uni/src/main/scala/wvlet/uni/http/WebSocketFrame.scala` |
+| Add | `uni/src/main/scala/wvlet/uni/http/WebSocketFrameDecoder.scala` |
+| Edit | `uni/.native/.../http/NativeWebSocket.scala` (serve → driver; delegate to WebSocketFrame) |
+| Add | `uni/.js/.../http/NodeBytes.scala`, `uni/.js/.../http/NodeWebSocket.scala` |
+| Edit | `uni/.js/.../http/NodeHttpServer.scala` (on("upgrade"); use NodeBytes) |
+| Edit | `uni/.js/.../http/NodeServer.scala` (WS config + builders) |
+| Add | `uni/src/test/scala/wvlet/uni/http/WebSocketFrameDecoderTest.scala` |
+| Add | `uni/.js/src/test/scala/wvlet/uni/http/NodeWebSocketTest.scala` |
+
+## Verification
+- `./sbt scalafmtAll`; `uniJVM/compile uniJS/compile uniNative/compile netty/compile` (shared move).
+- **Decoder unit tests** (`uni/src/test`, cross-platform JVM/JS/Native) — the real regression guard:
+  feed crafted masked byte sequences, assert the emitted `WsEvent` list. Cover single text/binary,
+  fragmented (start+continuation+fin), interleaved-data ⇒ Fail(1002), lone-continuation ⇒ Fail(1002),
+  ping ⇒ Ping, pong ignored, close ⇒ PeerClose(code), unmasked ⇒ Fail(1002), rsv ⇒ Fail(1002),
+  oversized frame and oversized reassembly ⇒ Fail(1009), oversized/non-final control ⇒ Fail(1002),
+  and **split-buffer** (same stream one byte per `feed` ⇒ identical events).
+- **Node integration test** (`uni/.js/src/test`) — a manual `NodeWsClient` over
+  `NodeModules.builtin("net").createConnection(...)` (no `ws` npm dep), mirroring the Native
+  `WsClient` but async (return `Rx`/`Promise` like the existing Node SSE test): echo, binary echo,
+  push-on-open, onOpen/onClose latches, missing-key 400, filter-reject 403.
+- `uniNative/test` (the 18 cases, incl. 6 WS, stay green — exact-behavior preserved) and `uniJS/test`.
+
+## Known limitations / follow-ups
+- **Backpressure (Node):** `socket.write` returning `false` buffers in memory unbounded; acceptable
+  for correctness-first parity (Native's `sendAll` is naturally backpressured). Optional follow-up:
+  pause reading on `false`, resume on `drain`.
+- `Sec-WebSocket-Version` not validated (matches Native; Netty replies 426) — optional hardening.
+- No permessage-deflate; no client-side WebSocket (the standing cross-platform-client follow-up).

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeBytes.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeBytes.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters.*
+import scala.scalajs.js.typedarray.*
+
+/**
+  * Conversions between Node `Buffer`/`Uint8Array` chunks and JVM byte arrays, shared by the Node
+  * HTTP server and WebSocket backends.
+  */
+private[http] object NodeBytes:
+
+  /**
+    * Copy a Node `Buffer`/`Uint8Array` chunk into a JVM byte array. The chunk may be a view into a
+    * larger pooled buffer, so honor its `byteOffset`/`length`.
+    */
+  def toBytes(chunk: js.Dynamic): Array[Byte] =
+    val u8 = chunk.asInstanceOf[Uint8Array]
+    Int8Array(u8.buffer, u8.byteOffset, u8.length).toArray
+
+  /**
+    * View a JVM byte array as a Node-compatible `Uint8Array` (Node rejects `Int8Array` payloads).
+    * The two share the same underlying bytes; only the signed/unsigned interpretation differs,
+    * which Node ignores when writing raw bytes.
+    */
+  def toUint8Array(bytes: Array[Byte]): Uint8Array =
+    val i8 = bytes.toTypedArray
+    Uint8Array(i8.buffer, i8.byteOffset, i8.length)
+
+end NodeBytes

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeHttpServer.scala
@@ -19,7 +19,6 @@ import wvlet.uni.rx.{Cancelable, OnCompletion, OnError, OnNext, Rx, RxRunner}
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters.*
-import scala.scalajs.js.typedarray.*
 
 /**
   * Node.js-based HTTP server implementation, backed by the built-in `http` module. It implements
@@ -84,6 +83,20 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
         readyPromise.success(this)
 
     server.applyDynamic("on")("error", onError)
+
+    // Node's http server has no built-in WebSocket; handle the raw `upgrade` event ourselves.
+    if config.webSocketRoutes.nonEmpty then
+      val onUpgrade: js.Function3[js.Dynamic, js.Dynamic, js.Dynamic, Unit] =
+        (req: js.Dynamic, socket: js.Dynamic, head: js.Dynamic) =>
+          NodeWebSocket.handleUpgrade(
+            req,
+            socket,
+            head,
+            config.webSocketRoutes,
+            config.webSocketMaxFrameSize
+          )
+      server.applyDynamic("on")("upgrade", onUpgrade)
+
     server.applyDynamic("listen")(config.port, config.host, onListening)
 
   end start
@@ -122,7 +135,7 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
 
       val onData: js.Function1[js.Dynamic, Unit] =
         (chunk: js.Dynamic) =>
-          bodyChunks ++= toBytes(chunk)
+          bodyChunks ++= NodeBytes.toBytes(chunk)
           ()
 
       val onEnd: js.Function0[Unit] =
@@ -179,7 +192,7 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
         else
           // Node sets Content-Length automatically for a buffered body. The body must be a
           // Uint8Array/Buffer (Node rejects Int8Array), so view the bytes as unsigned.
-          res.applyDynamic("end")(toUint8Array(bytes))
+          res.applyDynamic("end")(NodeBytes.toUint8Array(bytes))
     catch
       case e: Throwable =>
         warn(s"Failed to write response: ${e.getMessage}", e)
@@ -257,23 +270,6 @@ class NodeHttpServer(config: NodeServerConfig) extends HttpServer with LogSuppor
       else
         res.applyDynamic("setHeader")(name, values.toJSArray)
     }
-
-  /**
-    * Copy a Node `Buffer`/`Uint8Array` chunk into a JVM byte array. The chunk may be a view into a
-    * larger pooled buffer, so honor its `byteOffset`/`length`.
-    */
-  private def toBytes(chunk: js.Dynamic): Array[Byte] =
-    val u8 = chunk.asInstanceOf[Uint8Array]
-    Int8Array(u8.buffer, u8.byteOffset, u8.length).toArray
-
-  /**
-    * View a JVM byte array as a Node-compatible `Uint8Array` (Node rejects `Int8Array` response
-    * bodies). The two share the same underlying bytes; only the signed/unsigned interpretation
-    * differs, which Node ignores when writing raw bytes.
-    */
-  private def toUint8Array(bytes: Array[Byte]): Uint8Array =
-    val i8 = bytes.toTypedArray
-    Uint8Array(i8.buffer, i8.byteOffset, i8.length)
 
   override def stop(): Unit =
     // Check `started`, not `running`: stop() may race a pending bind (started but not yet

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeServer.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeServer.scala
@@ -46,7 +46,11 @@ case class NodeServerConfig(
     host: String = "0.0.0.0",
     port: Int = 8080,
     handler: RxHttpHandler = RxHttpHandler.notFound,
-    filters: Seq[RxHttpFilter] = Seq.empty
+    filters: Seq[RxHttpFilter] = Seq.empty,
+    // WebSocket routes, matched by path during the HTTP upgrade handshake
+    override val webSocketRoutes: Seq[WebSocketRoute] = Nil,
+    // Maximum size (bytes) of an inbound WebSocket message
+    webSocketMaxFrameSize: Int = 1024 * 1024
 ) extends HttpServerConfig:
 
   def withName(name: String): NodeServerConfig = copy(name = name)
@@ -70,6 +74,22 @@ case class NodeServerConfig(
   def withFilters(filters: Seq[RxHttpFilter]): NodeServerConfig = copy(filters =
     this.filters ++ filters
   )
+
+  /** Register a WebSocket route; the factory creates a fresh handler per accepted connection. */
+  def withWebSocketRoute(path: String)(
+      handlerFactory: Request => WebSocketHandler
+  ): NodeServerConfig = withWebSocketRoute(path, RxHttpFilter.identity)(handlerFactory)
+
+  /** Register a WebSocket route with a filter that gates the upgrade handshake (e.g. for auth). */
+  def withWebSocketRoute(path: String, filter: RxHttpFilter)(
+      handlerFactory: Request => WebSocketHandler
+  ): NodeServerConfig = copy(webSocketRoutes =
+    webSocketRoutes :+ WebSocketRoute(path, handlerFactory, filter)
+  )
+
+  def withWebSocketMaxFrameSize(sizeInBytes: Int): NodeServerConfig =
+    require(sizeInBytes > 0, "webSocketMaxFrameSize must be positive")
+    copy(webSocketMaxFrameSize = sizeInBytes)
 
   /**
     * Start the server and return the running server instance. Note that on Node.js the socket bind

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeWebSocket.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeWebSocket.scala
@@ -1,0 +1,321 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.log.LogSupport
+import wvlet.uni.rx.{OnCompletion, OnError, OnNext, Rx, RxRunner}
+
+import java.nio.charset.StandardCharsets
+import scala.scalajs.js
+import scala.util.control.NonFatal
+
+/**
+  * Node.js WebSocket (RFC 6455) handling on a raw `net.Socket` from the http server's `'upgrade'`
+  * event. Node has no built-in WebSocket server, so the handshake + framing are done by hand,
+  * reusing the cross-platform [[WebSocketFrame]] / [[WebSocketFrameDecoder]] that the Native
+  * backend also uses. All socket I/O runs on the single-threaded event loop, so a plain `var`
+  * guards exactly-once `onClose`, and every write is wrapped (an uncaught throw on the loop crashes
+  * Node).
+  */
+private[http] object NodeWebSocket extends LogSupport:
+
+  /**
+    * Handle an HTTP `'upgrade'`: validate it's a registered WebSocket route, gate it through the
+    * route filter, write the `101` handshake, then bridge socket data to the [[WebSocketHandler]].
+    */
+  def handleUpgrade(
+      req: js.Dynamic,
+      socket: js.Dynamic,
+      head: js.Dynamic,
+      routes: Seq[WebSocketRoute],
+      maxFrameSize: Int
+  ): Unit =
+    try
+      val request = buildRequest(req)
+      routeFor(request, routes) match
+        case None =>
+          destroyQuietly(socket)
+        case Some(route) =>
+          request.header(HttpHeader.SecWebSocketKey).filter(_.nonEmpty) match
+            case None =>
+              // A WebSocket upgrade without a Sec-WebSocket-Key is malformed (RFC 6455 §4.2.1).
+              writeHttpClose(socket, Response.badRequest("Missing Sec-WebSocket-Key"))
+            case Some(key) =>
+              gateAndAccept(socket, head, key, route, request, maxFrameSize)
+    catch
+      case NonFatal(e) =>
+        warn(s"WebSocket upgrade error: ${e.getMessage}")
+        destroyQuietly(socket)
+
+  private def gateAndAccept(
+      socket: js.Dynamic,
+      head: js.Dynamic,
+      key: String,
+      route: WebSocketRoute,
+      request: Request,
+      maxFrameSize: Int
+  ): Unit =
+    // Capture the request as threaded through the filter, so attributes a filter adds during the
+    // handshake reach the WebSocketContext (matching the Netty/Native backends).
+    var upgradeRequest = request
+    val gate           = RxHttpHandler { r =>
+      upgradeRequest = r
+      Rx.single(Response.ok)
+    }
+    RxRunner.runOnce(route.filter.apply(request, gate)) {
+      case OnNext(response) =>
+        val resp = response.asInstanceOf[Response]
+        if resp.isSuccessful then
+          accept(socket, head, key, route, upgradeRequest, maxFrameSize)
+        else
+          writeHttpClose(socket, resp)
+      case OnError(e) =>
+        warn(s"WebSocket upgrade filter error: ${e.getMessage}", e)
+        writeHttpClose(socket, Response.internalServerError(e.getMessage))
+      case OnCompletion =>
+        // Filter completed without a verdict: close the connection rather than leave it hanging.
+        destroyQuietly(socket)
+    }
+
+  private def accept(
+      socket: js.Dynamic,
+      head: js.Dynamic,
+      key: String,
+      route: WebSocketRoute,
+      request: Request,
+      maxFrameSize: Int
+  ): Unit =
+    val handler = route.handlerFactory(request)
+    val ctx     = NodeWebSocketContext(socket, request)
+    val decoder = WebSocketFrameDecoder(maxFrameSize)
+    var closed  = false
+
+    def notifyClose(): Unit =
+      if !closed then
+        closed = true
+        try
+          handler.onClose(ctx)
+        catch
+          case NonFatal(e) =>
+            warn(s"onClose error: ${e.getMessage}")
+
+    def drive(bytes: Array[Byte]): Unit =
+      if !closed then
+        try
+          if !decoder.feed(bytes)(ev => dispatch(handler, ctx, () => notifyClose(), ev)) then
+            // A terminal event (peer close / protocol failure) was emitted; flush and close.
+            endQuietly(socket)
+        catch
+          case NonFatal(e) =>
+            warn(s"WebSocket read error: ${e.getMessage}")
+            notifyClose()
+            destroyQuietly(socket)
+
+    try
+      val handshake =
+        s"HTTP/1.1 101 Switching Protocols\r\n" + s"${HttpHeader.Upgrade}: websocket\r\n" +
+          s"${HttpHeader.Connection}: Upgrade\r\n" +
+          s"${HttpHeader.SecWebSocketAccept}: ${WebSocketFrame.acceptKey(key)}\r\n\r\n"
+      socket.applyDynamic("write")(
+        NodeBytes.toUint8Array(handshake.getBytes(StandardCharsets.ISO_8859_1))
+      )
+
+      try
+        handler.onOpen(ctx)
+      catch
+        case NonFatal(e) =>
+          safeOnError(handler, ctx, e)
+
+      // Wire teardown, then feed any bytes already read past the request headers before live data.
+      val onData: js.Function1[js.Dynamic, Unit] =
+        (chunk: js.Dynamic) => drive(NodeBytes.toBytes(chunk))
+      val onClose: js.Function1[js.Dynamic, Unit] = (_: js.Dynamic) => notifyClose()
+      socket.applyDynamic("on")("close", onClose)
+      socket.applyDynamic("on")("error", onClose)
+      socket.applyDynamic("on")("data", onData)
+      if !js.isUndefined(head) && head != null && head.length.asInstanceOf[Int] > 0 then
+        drive(NodeBytes.toBytes(head))
+    catch
+      case NonFatal(e) =>
+        warn(s"WebSocket accept error: ${e.getMessage}")
+        notifyClose()
+        destroyQuietly(socket)
+
+  end accept
+
+  private def dispatch(
+      handler: WebSocketHandler,
+      ctx: NodeWebSocketContext,
+      notifyClose: () => Unit,
+      event: WsEvent
+  ): Unit =
+    event match
+      case WsEvent.Message(WebSocketFrame.OpText, data) =>
+        deliverText(handler, ctx, data)
+      case WsEvent.Message(_, data) =>
+        deliverBinary(handler, ctx, data)
+      case WsEvent.Ping(data) =>
+        ctx.sendPong(data)
+      case WsEvent.Pong(_) =>
+      // ignore unsolicited pongs
+      case WsEvent.PeerClose(code, _) =>
+        notifyClose()
+        ctx.close(code, "") // echo the peer's close code (RFC 6455 §5.5.1)
+      case WsEvent.Fail(code, reason) =>
+        ctx.close(code, reason)
+
+  private def deliverText(
+      handler: WebSocketHandler,
+      ctx: NodeWebSocketContext,
+      data: Array[Byte]
+  ): Unit =
+    try
+      handler.onTextMessage(ctx, new String(data, StandardCharsets.UTF_8))
+    catch
+      case NonFatal(e) =>
+        safeOnError(handler, ctx, e)
+
+  private def deliverBinary(
+      handler: WebSocketHandler,
+      ctx: NodeWebSocketContext,
+      data: Array[Byte]
+  ): Unit =
+    try
+      handler.onBinaryMessage(ctx, data)
+    catch
+      case NonFatal(e) =>
+        safeOnError(handler, ctx, e)
+
+  private def safeOnError(handler: WebSocketHandler, ctx: WebSocketContext, e: Throwable): Unit =
+    try
+      handler.onError(ctx, e)
+    catch
+      case NonFatal(e2) =>
+        warn(s"onError error: ${e2.getMessage}")
+
+  private def buildRequest(req: js.Dynamic): Request =
+    val method     = HttpMethod.of(req.method.asInstanceOf[String]).getOrElse(HttpMethod.GET)
+    val uri        = req.url.asInstanceOf[String]
+    val builder    = HttpMultiMap.newBuilder
+    val rawHeaders =
+      if js.isUndefined(req.rawHeaders) || req.rawHeaders == null then
+        js.Array[String]()
+      else
+        req.rawHeaders.asInstanceOf[js.Array[String]]
+    var i = 0
+    while i + 1 < rawHeaders.length do
+      builder.add(rawHeaders(i), rawHeaders(i + 1))
+      i += 2
+    val headers = builder.result()
+    Request(
+      method = method,
+      uri = uri,
+      headers = headers,
+      content = HttpContent.fromBytes(Array.emptyByteArray, headers)
+    )
+
+  private def routeFor(request: Request, routes: Seq[WebSocketRoute]): Option[WebSocketRoute] =
+    if routes.isEmpty || !isWebSocketUpgrade(request) then
+      None
+    else
+      routes.find(_.path == request.path)
+
+  private def isWebSocketUpgrade(request: Request): Boolean =
+    request.header(HttpHeader.Connection).exists(_.toLowerCase.contains("upgrade")) &&
+      request.header(HttpHeader.Upgrade).exists(_.equalsIgnoreCase("websocket"))
+
+  /** Write a short HTTP response (rejecting the upgrade) and half-close the socket. */
+  private def writeHttpClose(socket: js.Dynamic, response: Response): Unit =
+    try
+      val body = response.content.toContentBytes
+      val sb   = StringBuilder()
+      sb.append("HTTP/1.1 ")
+        .append(response.status.code)
+        .append(" ")
+        .append(response.status.reason)
+        .append("\r\n")
+      sb.append(HttpHeader.Connection).append(": close\r\n")
+      sb.append(HttpHeader.ContentLength).append(": ").append(body.length).append("\r\n\r\n")
+      val head = sb.toString.getBytes(StandardCharsets.ISO_8859_1)
+      socket.applyDynamic("write")(NodeBytes.toUint8Array(head ++ body))
+      endQuietly(socket)
+    catch
+      case NonFatal(e) =>
+        destroyQuietly(socket)
+
+  private def endQuietly(socket: js.Dynamic): Unit =
+    try
+      socket.applyDynamic("end")()
+    catch
+      case NonFatal(e) =>
+        debug(s"socket end failed: ${e.getMessage}")
+
+  private def destroyQuietly(socket: js.Dynamic): Unit =
+    try
+      socket.applyDynamic("destroy")()
+    catch
+      case NonFatal(_) =>
+        ()
+
+end NodeWebSocket
+
+/**
+  * Node [[WebSocketContext]]. Single-threaded event loop, so a plain `var closed` guards writes;
+  * all socket writes are wrapped (an uncaught throw on the loop crashes the process).
+  */
+private[http] class NodeWebSocketContext(socket: js.Dynamic, override val request: Request)
+    extends WebSocketContext
+    with LogSupport:
+
+  private var closed = false
+
+  override def send(text: String): Unit = writeIfOpen(
+    WebSocketFrame.OpText,
+    text.getBytes(StandardCharsets.UTF_8)
+  )
+
+  override def send(data: Array[Byte]): Unit = writeIfOpen(WebSocketFrame.OpBinary, data)
+
+  override def close(): Unit = close(1000, "")
+
+  override def close(statusCode: Int, reason: String): Unit =
+    if !closed then
+      closed = true
+      writeFrame(WebSocketFrame.OpClose, WebSocketFrame.closePayload(statusCode, reason))
+      // Flush the close frame, then FIN — the socket 'close' event drives onClose. Not destroy(),
+      // which could drop the still-buffered close frame.
+      try
+        socket.applyDynamic("end")()
+      catch
+        case NonFatal(e) =>
+          debug(s"socket end failed: ${e.getMessage}")
+
+  private[http] def sendPong(payload: Array[Byte]): Unit =
+    if !closed then
+      writeFrame(WebSocketFrame.OpPong, payload)
+
+  private def writeIfOpen(opcode: Int, payload: Array[Byte]): Unit =
+    if !closed then
+      writeFrame(opcode, payload)
+
+  private def writeFrame(opcode: Int, payload: Array[Byte]): Unit =
+    try
+      socket.applyDynamic("write")(
+        NodeBytes.toUint8Array(WebSocketFrame.encodeFrame(opcode, payload))
+      )
+    catch
+      case NonFatal(e) =>
+        debug(s"WebSocket write failed: ${e.getMessage}")
+
+end NodeWebSocketContext

--- a/uni/.js/src/main/scala/wvlet/uni/http/NodeWebSocket.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/NodeWebSocket.scala
@@ -96,6 +96,11 @@ private[http] object NodeWebSocket extends LogSupport:
       request: Request,
       maxFrameSize: Int
   ): Unit =
+    // The route filter may be asynchronous; if the client disconnected while it ran, the socket is
+    // already gone — skip the upgrade entirely (no onOpen, so no dangling onClose).
+    if isDestroyed(socket) then
+      return
+
     val handler = route.handlerFactory(request)
     val ctx     = NodeWebSocketContext(socket, request)
     val decoder = WebSocketFrameDecoder(maxFrameSize)
@@ -113,8 +118,14 @@ private[http] object NodeWebSocket extends LogSupport:
     def drive(bytes: Array[Byte]): Unit =
       if !closed then
         try
-          if !decoder.feed(bytes)(ev => dispatch(handler, ctx, () => notifyClose(), ev)) then
-            // A terminal event (peer close / protocol failure) was emitted; flush and close.
+          if !decoder.feed(bytes)(ev =>
+              WebSocketDispatcher.dispatch(handler, ctx, ctx.sendPong, () => notifyClose(), ev)
+            )
+          then
+            // A terminal event (peer close / protocol failure) was emitted. Fire onClose now (the
+            // Native backend does this via its read-loop's `finally`; the socket 'close' event may
+            // not arrive for a half-open peer), then flush our close frame and FIN.
+            notifyClose()
             endQuietly(socket)
         catch
           case NonFatal(e) =>
@@ -131,18 +142,20 @@ private[http] object NodeWebSocket extends LogSupport:
         NodeBytes.toUint8Array(handshake.getBytes(StandardCharsets.ISO_8859_1))
       )
 
-      try
-        handler.onOpen(ctx)
-      catch
-        case NonFatal(e) =>
-          safeOnError(handler, ctx, e)
-
-      // Wire teardown, then feed any bytes already read past the request headers before live data.
+      // Wire teardown before onOpen so a disconnect during the handshake can't slip through; then
+      // call onOpen, attach data, and feed any bytes already read past the request headers.
       val onData: js.Function1[js.Dynamic, Unit] =
         (chunk: js.Dynamic) => drive(NodeBytes.toBytes(chunk))
       val onClose: js.Function1[js.Dynamic, Unit] = (_: js.Dynamic) => notifyClose()
       socket.applyDynamic("on")("close", onClose)
       socket.applyDynamic("on")("error", onClose)
+
+      try
+        handler.onOpen(ctx)
+      catch
+        case NonFatal(e) =>
+          WebSocketDispatcher.safeOnError(handler, ctx, e)
+
       socket.applyDynamic("on")("data", onData)
       if !js.isUndefined(head) && head != null && head.length.asInstanceOf[Int] > 0 then
         drive(NodeBytes.toBytes(head))
@@ -151,58 +164,13 @@ private[http] object NodeWebSocket extends LogSupport:
         warn(s"WebSocket accept error: ${e.getMessage}")
         notifyClose()
         destroyQuietly(socket)
+    end try
 
   end accept
 
-  private def dispatch(
-      handler: WebSocketHandler,
-      ctx: NodeWebSocketContext,
-      notifyClose: () => Unit,
-      event: WsEvent
-  ): Unit =
-    event match
-      case WsEvent.Message(WebSocketFrame.OpText, data) =>
-        deliverText(handler, ctx, data)
-      case WsEvent.Message(_, data) =>
-        deliverBinary(handler, ctx, data)
-      case WsEvent.Ping(data) =>
-        ctx.sendPong(data)
-      case WsEvent.Pong(_) =>
-      // ignore unsolicited pongs
-      case WsEvent.PeerClose(code, _) =>
-        notifyClose()
-        ctx.close(code, "") // echo the peer's close code (RFC 6455 §5.5.1)
-      case WsEvent.Fail(code, reason) =>
-        ctx.close(code, reason)
-
-  private def deliverText(
-      handler: WebSocketHandler,
-      ctx: NodeWebSocketContext,
-      data: Array[Byte]
-  ): Unit =
-    try
-      handler.onTextMessage(ctx, new String(data, StandardCharsets.UTF_8))
-    catch
-      case NonFatal(e) =>
-        safeOnError(handler, ctx, e)
-
-  private def deliverBinary(
-      handler: WebSocketHandler,
-      ctx: NodeWebSocketContext,
-      data: Array[Byte]
-  ): Unit =
-    try
-      handler.onBinaryMessage(ctx, data)
-    catch
-      case NonFatal(e) =>
-        safeOnError(handler, ctx, e)
-
-  private def safeOnError(handler: WebSocketHandler, ctx: WebSocketContext, e: Throwable): Unit =
-    try
-      handler.onError(ctx, e)
-    catch
-      case NonFatal(e2) =>
-        warn(s"onError error: ${e2.getMessage}")
+  private def isDestroyed(socket: js.Dynamic): Boolean =
+    val d = socket.destroyed
+    !js.isUndefined(d) && d != null && d.asInstanceOf[Boolean]
 
   private def buildRequest(req: js.Dynamic): Request =
     val method     = HttpMethod.of(req.method.asInstanceOf[String]).getOrElse(HttpMethod.GET)

--- a/uni/.js/src/test/scala/wvlet/uni/http/NodeWebSocketTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/NodeWebSocketTest.scala
@@ -1,0 +1,335 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.rx.Rx
+import wvlet.uni.test.UniTest
+
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.scalajs.js
+
+/**
+  * Verifies the Node.js WebSocket backend with a manual `net.Socket` client (no `ws` dependency).
+  * The client mirrors the Native `WsClient` but is async, so each test returns an `Rx`/`Future` the
+  * framework awaits, matching the Node SSE test idiom.
+  */
+class NodeWebSocketTest extends UniTest:
+
+  private given ExecutionContext = scala.scalajs.concurrent.JSExecutionContext.queue
+
+  private val key            = "dGhlIHNhbXBsZSBub25jZQ=="
+  private val expectedAccept = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+
+  /** Parsed WebSocket handshake response: status code + lower-cased headers. */
+  private case class Handshake(status: Int, headers: Map[String, String])
+
+  /** A minimal async WebSocket client over a raw Node `net.Socket`. */
+  private class NodeWsClient(port: Int):
+    private val socket = NodeModules
+      .builtin("net")
+      .applyDynamic("createConnection")(port, "127.0.0.1")
+      .asInstanceOf[js.Dynamic]
+
+    private val buf              = mutable.ArrayBuffer.empty[Byte]
+    private var handshook        = false
+    private val handshakePromise = Promise[Handshake]()
+    private val frameQueue       = mutable.Queue.empty[(Int, Array[Byte])]
+    private val waiters          = mutable.Queue.empty[Promise[(Int, Array[Byte])]]
+
+    private val onData: js.Function1[js.Dynamic, Unit] =
+      (chunk: js.Dynamic) =>
+        buf ++= NodeBytes.toBytes(chunk)
+        process()
+
+    private val onError: js.Function1[js.Dynamic, Unit] =
+      (e: js.Dynamic) =>
+        if !handshakePromise.isCompleted then
+          handshakePromise.failure(RuntimeException(s"socket error: ${e}"))
+
+    socket.applyDynamic("on")("data", onData)
+    socket.applyDynamic("on")("error", onError)
+
+    /** Send the upgrade request; resolves with the parsed handshake response. */
+    def connect(path: String): Future[Handshake] =
+      val onConnect: js.Function0[Unit] =
+        () =>
+          val req =
+            s"GET ${path} HTTP/1.1\r\nHost: localhost\r\n" +
+              s"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+              s"Sec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+          socket.applyDynamic("write")(
+            NodeBytes.toUint8Array(req.getBytes(StandardCharsets.ISO_8859_1))
+          )
+      socket.applyDynamic("on")("connect", onConnect)
+      handshakePromise.future
+
+    def sendText(text: String): Unit = send(
+      WebSocketFrame.OpText,
+      text.getBytes(StandardCharsets.UTF_8)
+    )
+
+    def sendBinary(data: Array[Byte]): Unit = send(WebSocketFrame.OpBinary, data)
+
+    /** Await the next server frame (opcode + payload). */
+    def nextFrame(): Future[(Int, Array[Byte])] =
+      if frameQueue.nonEmpty then
+        Future.successful(frameQueue.dequeue())
+      else
+        val p = Promise[(Int, Array[Byte])]()
+        waiters.enqueue(p)
+        p.future
+
+    def nextText(): Future[String] = nextFrame().map((_, data) =>
+      new String(data, StandardCharsets.UTF_8)
+    )
+
+    def close(): Unit =
+      try
+        socket.applyDynamic("destroy")()
+      catch
+        case _: Throwable =>
+          ()
+
+    /** Build a masked client frame. */
+    private def send(opcode: Int, payload: Array[Byte]): Unit =
+      val mask   = Array[Byte](0x12, 0x34, 0x56, 0x78)
+      val header = Array[Byte]((0x80 | opcode).toByte, (0x80 | payload.length).toByte)
+      val masked = new Array[Byte](payload.length)
+      var i      = 0
+      while i < payload.length do
+        masked(i) = (payload(i) ^ mask(i % 4)).toByte
+        i += 1
+      socket.applyDynamic("write")(NodeBytes.toUint8Array(header ++ mask ++ masked))
+
+    private def process(): Unit =
+      if !handshook then
+        val idx = headerEnd
+        if idx >= 0 then
+          val head = new String(buf.slice(0, idx).toArray, StandardCharsets.ISO_8859_1)
+          buf.remove(0, idx + 4)
+          val parsed = parseHead(head)
+          handshook = parsed.status == 101
+          handshakePromise.success(parsed)
+      if handshook then
+        parseFrames()
+
+    private def headerEnd: Int =
+      var i = 0
+      while i + 3 < buf.length do
+        if buf(i) == '\r' && buf(i + 1) == '\n' && buf(i + 2) == '\r' && buf(i + 3) == '\n' then
+          return i
+        i += 1
+      -1
+
+    private def parseHead(head: String): Handshake =
+      val lines   = head.split("\r\n")
+      val status  = lines(0).split(" ")(1).toInt
+      val headers =
+        lines
+          .drop(1)
+          .flatMap { line =>
+            val c = line.indexOf(':')
+            if c > 0 then
+              Some(line.substring(0, c).trim.toLowerCase -> line.substring(c + 1).trim)
+            else
+              None
+          }
+          .toMap
+      Handshake(status, headers)
+
+    /** Parse unmasked server frames buffered so far (tests stay under the 16-bit length). */
+    private def parseFrames(): Unit =
+      var go = true
+      while go do
+        if buf.length < 2 then
+          go = false
+        else
+          val opcode    = buf(0) & 0x0f
+          val base      = buf(1) & 0x7f
+          var headerLen = 2
+          var len       = base
+          if base == 126 then
+            if buf.length < 4 then
+              go = false
+            else
+              len = ((buf(2) & 0xff) << 8) | (buf(3) & 0xff)
+              headerLen = 4
+          if go && buf.length >= headerLen + len then
+            val payload = buf.slice(headerLen, headerLen + len).toArray
+            buf.remove(0, headerLen + len)
+            if waiters.nonEmpty then
+              waiters.dequeue().success((opcode, payload))
+            else
+              frameQueue.enqueue((opcode, payload))
+          else
+            go = false
+
+  end NodeWsClient
+
+  test("WebSocket handshake accept key and text echo") {
+    NodeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/echo") { _ =>
+        new WebSocketHandler:
+          override def onTextMessage(ctx: WebSocketContext, message: String): Unit = ctx.send(
+            s"echo:${message}"
+          )
+      }
+      .startAndAwait { server =>
+        val client = NodeWsClient(server.localPort)
+        val result =
+          for
+            hs <- client.connect("/ws/echo")
+            _ =
+              hs.status shouldBe 101
+              hs.headers.get("sec-websocket-accept") shouldBe Some(expectedAccept)
+              client.sendText("hello")
+            text <- client.nextText()
+          yield
+            client.close()
+            text shouldBe "echo:hello"
+        Rx.future(result)
+      }
+  }
+
+  test("WebSocket echoes binary messages") {
+    NodeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/bin") { _ =>
+        new WebSocketHandler:
+          override def onBinaryMessage(ctx: WebSocketContext, message: Array[Byte]): Unit = ctx
+            .send(message)
+      }
+      .startAndAwait { server =>
+        val client  = NodeWsClient(server.localPort)
+        val payload = Array[Byte](1, 2, 3, 4, 5)
+        val result  =
+          for
+            _ <- client.connect("/ws/bin")
+            _ = client.sendBinary(payload)
+            frame <- client.nextFrame()
+          yield
+            client.close()
+            frame._1 shouldBe WebSocketFrame.OpBinary
+            frame._2.toSeq shouldBe payload.toSeq
+        Rx.future(result)
+      }
+  }
+
+  test("WebSocket can push a message on open") {
+    NodeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/push") { _ =>
+        new WebSocketHandler:
+          override def onOpen(ctx: WebSocketContext): Unit = ctx.send("welcome")
+      }
+      .startAndAwait { server =>
+        val client = NodeWsClient(server.localPort)
+        val result =
+          for
+            _    <- client.connect("/ws/push")
+            text <- client.nextText()
+          yield
+            client.close()
+            text shouldBe "welcome"
+        Rx.future(result)
+      }
+  }
+
+  test("WebSocket fires onOpen and onClose") {
+    val opened = Promise[Boolean]()
+    val closed = Promise[Boolean]()
+    NodeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/life") { _ =>
+        new WebSocketHandler:
+          override def onOpen(ctx: WebSocketContext): Unit  = opened.success(true)
+          override def onClose(ctx: WebSocketContext): Unit = closed.success(true)
+      }
+      .startAndAwait { server =>
+        val client = NodeWsClient(server.localPort)
+        val result =
+          for
+            _ <- client.connect("/ws/life")
+            _ <- opened.future
+            _ = client.close()
+            c <- closed.future
+          yield c shouldBe true
+        Rx.future(result)
+      }
+  }
+
+  test("WebSocket upgrade without a key is rejected with 400") {
+    NodeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws") { _ =>
+        new WebSocketHandler {}
+      }
+      .startAndAwait { server =>
+        // Send an upgrade with no Sec-WebSocket-Key via a raw socket.
+        val socket = NodeModules
+          .builtin("net")
+          .applyDynamic("createConnection")(server.localPort, "127.0.0.1")
+          .asInstanceOf[js.Dynamic]
+        val received                               = Promise[Int]()
+        val buffer                                 = mutable.ArrayBuffer.empty[Byte]
+        val onData: js.Function1[js.Dynamic, Unit] =
+          (chunk: js.Dynamic) =>
+            buffer ++= NodeBytes.toBytes(chunk)
+            val text = new String(buffer.toArray, StandardCharsets.ISO_8859_1)
+            if text.contains("\r\n") && !received.isCompleted then
+              received.success(text.split(" ")(1).toInt)
+        val onConnect: js.Function0[Unit] =
+          () =>
+            val req =
+              "GET /ws HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
+            socket.applyDynamic("write")(
+              NodeBytes.toUint8Array(req.getBytes(StandardCharsets.ISO_8859_1))
+            )
+        socket.applyDynamic("on")("data", onData)
+        socket.applyDynamic("on")("connect", onConnect)
+        Rx.future(received.future)
+          .map { status =>
+            try
+              socket.applyDynamic("destroy")()
+            catch
+              case _: Throwable =>
+                ()
+            status shouldBe 400
+          }
+      }
+  }
+
+  test("WebSocket upgrade can be rejected by a filter") {
+    val deny = RxHttpFilter { (_, _) =>
+      Rx.single(Response.forbidden)
+    }
+    NodeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/secure", deny) { _ =>
+        new WebSocketHandler {}
+      }
+      .startAndAwait { server =>
+        val client = NodeWsClient(server.localPort)
+        Rx.future(client.connect("/ws/secure"))
+          .map { hs =>
+            client.close()
+            hs.status shouldBe 403
+          }
+      }
+  }
+
+end NodeWebSocketTest

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
@@ -298,7 +298,7 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
           val handshake =
             s"HTTP/1.1 101 Switching Protocols\r\n" + s"${HttpHeader.Upgrade}: websocket\r\n" +
               s"${HttpHeader.Connection}: Upgrade\r\n" +
-              s"${HttpHeader.SecWebSocketAccept}: ${NativeWebSocket.acceptKey(key)}\r\n\r\n"
+              s"${HttpHeader.SecWebSocketAccept}: ${WebSocketFrame.acceptKey(key)}\r\n\r\n"
           if NativeSocket.sendAll(clientFd, handshake.getBytes(StandardCharsets.ISO_8859_1)) then
             val accepted = upgradeRequest.get()
             NativeWebSocket.serve(

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
@@ -16,51 +16,15 @@ package wvlet.uni.http
 import wvlet.uni.log.LogSupport
 
 import java.nio.charset.StandardCharsets
-import java.util.Base64
 import java.util.concurrent.atomic.AtomicBoolean
-import scala.collection.mutable
 import scala.util.control.NonFatal
 
 /**
-  * Native WebSocket (RFC 6455) over a raw POSIX socket: handshake accept-key, frame encode/decode,
-  * and the per-connection read loop bridging frames to a [[WebSocketHandler]].
+  * Native WebSocket (RFC 6455) over a raw POSIX socket: the per-connection read loop driving the
+  * shared [[WebSocketFrameDecoder]] and bridging events to a [[WebSocketHandler]]. Framing and the
+  * handshake accept key live in the cross-platform [[WebSocketFrame]].
   */
 private[http] object NativeWebSocket extends LogSupport:
-
-  final val OpContinuation = 0x0
-  final val OpText         = 0x1
-  final val OpBinary       = 0x2
-  final val OpClose        = 0x8
-  final val OpPing         = 0x9
-  final val OpPong         = 0xa
-
-  private final val MagicGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-
-  /** `Sec-WebSocket-Accept` = base64(SHA1(key + GUID)). */
-  def acceptKey(key: String): String = Base64
-    .getEncoder
-    .encodeToString(Sha1.digest((key + MagicGuid).getBytes(StandardCharsets.US_ASCII)))
-
-  /** Encode an unmasked server frame (FIN set). */
-  def encodeFrame(opcode: Int, payload: Array[Byte]): Array[Byte] =
-    val len    = payload.length
-    val b0     = (0x80 | opcode).toByte
-    val header =
-      if len < 126 then
-        Array[Byte](b0, len.toByte)
-      else if len < 65536 then
-        Array[Byte](b0, 126.toByte, ((len >>> 8) & 0xff).toByte, (len & 0xff).toByte)
-      else
-        val h = new Array[Byte](10)
-        h(0) = b0
-        h(1) = 127.toByte
-        val l = len.toLong
-        var i = 0
-        while i < 8 do
-          h(2 + i) = ((l >>> ((7 - i) * 8)) & 0xff).toByte
-          i += 1
-        h
-    header ++ payload
 
   /**
     * Run a WebSocket connection: deliver `onOpen`, then read/dispatch frames until the peer closes
@@ -77,24 +41,6 @@ private[http] object NativeWebSocket extends LogSupport:
           case NonFatal(e) =>
             warn(s"onClose error: ${e.getMessage}")
 
-    val buf             = mutable.ArrayBuffer.empty[Byte]
-    def fill(): Boolean =
-      val c = NativeSocket.recvChunk(clientFd)
-      if c.isEmpty then
-        false
-      else
-        buf ++= c
-        true
-    def ensure(n: Int): Boolean =
-      while buf.length < n do
-        if !fill() then
-          return false
-      true
-    def take(n: Int): Array[Byte] =
-      val a = buf.slice(0, n).toArray
-      buf.remove(0, n)
-      a
-
     try
       try
         handler.onOpen(ctx)
@@ -102,130 +48,62 @@ private[http] object NativeWebSocket extends LogSupport:
         case NonFatal(e) =>
           safeOnError(handler, ctx, e)
 
-      val fragments      = mutable.ArrayBuffer.empty[Byte]
-      var fragmentOpcode = -1
-      var open           = true
+      val decoder = WebSocketFrameDecoder(maxFrameSize)
+      var open    = true
       while open do
-        if !ensure(2) then
-          open = false
+        val chunk = NativeSocket.recvChunk(clientFd)
+        if chunk.isEmpty then
+          open = false // clean EOF
         else
-          val b0        = buf(0) & 0xff
-          val b1        = buf(1) & 0xff
-          val fin       = (b0 & 0x80) != 0
-          val rsv       = b0 & 0x70
-          val opcode    = b0 & 0x0f
-          val masked    = (b1 & 0x80) != 0
-          val isControl = (opcode & 0x8) != 0
-          var len       = b1 & 0x7f
-          var header    = 2
-          if len == 126 then
-            if !ensure(4) then
-              open = false
-            else
-              len = ((buf(2) & 0xff) << 8) | (buf(3) & 0xff)
-              header = 4
-          else if len == 127 then
-            if !ensure(10) then
-              open = false
-            else
-              var l = 0L
-              var i = 0
-              while i < 8 do
-                l = (l << 8) | (buf(2 + i) & 0xff).toLong
-                i += 1
-              if l > maxFrameSize then
-                len = -1 // signal too-big below
-              else
-                len = l.toInt
-              header = 10
-
-          if open && (len < 0 || len > maxFrameSize) then
-            ctx.close(1009, "message too big")
-            open = false
-          else if open && (rsv != 0 || !masked) then
-            // RSV must be 0 (no extension negotiated); client frames MUST be masked (RFC 6455 §5).
-            ctx.close(1002, "protocol error")
-            open = false
-          else if open && isControl && (!fin || len > 125) then
-            // Control frames must be final and at most 125 bytes (RFC 6455 §5.5).
-            ctx.close(1002, "invalid control frame")
-            open = false
-          else if open then
-            if !ensure(header + 4 + len) then
-              open = false
-            else
-              buf.remove(0, header)
-              val mask    = take(4) // client frames are masked (validated above)
-              val payload = take(len)
-              var i       = 0
-              while i < payload.length do
-                payload(i) = (payload(i) ^ mask(i % 4)).toByte
-                i += 1
-              opcode match
-                case OpText | OpBinary =>
-                  if fragmentOpcode != -1 then
-                    ctx.close(1002, "data frame during a fragmented message")
-                    open = false
-                  else if fin then
-                    deliver(handler, ctx, opcode, payload)
-                  else
-                    fragmentOpcode = opcode
-                    fragments.clear()
-                    fragments ++= payload
-                case OpContinuation =>
-                  if fragmentOpcode == -1 then
-                    ctx.close(1002, "continuation without a start frame")
-                    open = false
-                  else
-                    fragments ++= payload
-                    if fragments.length > maxFrameSize then
-                      ctx.close(1009, "message too big")
-                      open = false
-                    else if fin then
-                      deliver(handler, ctx, fragmentOpcode, fragments.toArray)
-                      fragments.clear()
-                      fragmentOpcode = -1
-                case OpClose =>
-                  notifyClose()
-                  // Echo the peer's close code (RFC 6455 §5.5.1).
-                  val code =
-                    if payload.length >= 2 then
-                      ((payload(0) & 0xff) << 8) | (payload(1) & 0xff)
-                    else
-                      1000
-                  ctx.close(code, "")
-                  open = false
-                case OpPing =>
-                  ctx.sendPong(payload)
-                case OpPong =>
-                // ignore unsolicited pongs
-                case _ =>
-                  ctx.close(1002, s"unsupported opcode ${opcode}")
-                  open = false
-              end match
-            end if
-          end if
-      end while
+          open = decoder.feed(chunk)(ev => dispatch(handler, ctx, notifyClose, ev))
     catch
       case NonFatal(e) =>
         safeOnError(handler, ctx, e)
     finally
       notifyClose()
-    end try
 
   end serve
 
-  private def deliver(
+  private def dispatch(
       handler: WebSocketHandler,
       ctx: NativeWebSocketContext,
-      opcode: Int,
-      payload: Array[Byte]
+      notifyClose: () => Unit,
+      event: WsEvent
+  ): Unit =
+    event match
+      case WsEvent.Message(WebSocketFrame.OpText, data) =>
+        deliverText(handler, ctx, data)
+      case WsEvent.Message(_, data) =>
+        deliverBinary(handler, ctx, data)
+      case WsEvent.Ping(data) =>
+        ctx.sendPong(data)
+      case WsEvent.Pong(_) =>
+      // ignore unsolicited pongs
+      case WsEvent.PeerClose(code, _) =>
+        notifyClose()
+        // Echo the peer's close code (RFC 6455 §5.5.1).
+        ctx.close(code, "")
+      case WsEvent.Fail(code, reason) =>
+        ctx.close(code, reason)
+
+  private def deliverText(
+      handler: WebSocketHandler,
+      ctx: NativeWebSocketContext,
+      data: Array[Byte]
   ): Unit =
     try
-      if opcode == OpText then
-        handler.onTextMessage(ctx, new String(payload, StandardCharsets.UTF_8))
-      else
-        handler.onBinaryMessage(ctx, payload)
+      handler.onTextMessage(ctx, new String(data, StandardCharsets.UTF_8))
+    catch
+      case NonFatal(e) =>
+        safeOnError(handler, ctx, e)
+
+  private def deliverBinary(
+      handler: WebSocketHandler,
+      ctx: NativeWebSocketContext,
+      data: Array[Byte]
+  ): Unit =
+    try
+      handler.onBinaryMessage(ctx, data)
     catch
       case NonFatal(e) =>
         safeOnError(handler, ctx, e)
@@ -250,33 +128,28 @@ private[http] class NativeWebSocketContext(clientFd: Int, override val request: 
   private val closed    = AtomicBoolean(false)
 
   override def send(text: String): Unit = sendFrameIfOpen(
-    NativeWebSocket.OpText,
+    WebSocketFrame.OpText,
     text.getBytes(StandardCharsets.UTF_8)
   )
 
-  override def send(data: Array[Byte]): Unit = sendFrameIfOpen(NativeWebSocket.OpBinary, data)
+  override def send(data: Array[Byte]): Unit = sendFrameIfOpen(WebSocketFrame.OpBinary, data)
 
   override def close(): Unit = close(1000, "")
 
   override def close(statusCode: Int, reason: String): Unit =
     if closed.compareAndSet(false, true) then
-      val reasonBytes = reason.getBytes(StandardCharsets.UTF_8)
-      val payload     = new Array[Byte](2 + reasonBytes.length)
-      payload(0) = ((statusCode >>> 8) & 0xff).toByte
-      payload(1) = (statusCode & 0xff).toByte
-      System.arraycopy(reasonBytes, 0, payload, 2, reasonBytes.length)
-      writeFrame(NativeWebSocket.OpClose, payload)
+      writeFrame(WebSocketFrame.OpClose, WebSocketFrame.closePayload(statusCode, reason))
 
   private[http] def sendPong(payload: Array[Byte]): Unit =
     if !closed.get() then
-      writeFrame(NativeWebSocket.OpPong, payload)
+      writeFrame(WebSocketFrame.OpPong, payload)
 
   private def sendFrameIfOpen(opcode: Int, payload: Array[Byte]): Unit =
     if !closed.get() then
       writeFrame(opcode, payload)
 
   private def writeFrame(opcode: Int, payload: Array[Byte]): Unit = writeLock.synchronized {
-    NativeSocket.sendAll(clientFd, NativeWebSocket.encodeFrame(opcode, payload))
+    NativeSocket.sendAll(clientFd, WebSocketFrame.encodeFrame(opcode, payload))
   }
 
 end NativeWebSocketContext

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
@@ -46,7 +46,7 @@ private[http] object NativeWebSocket extends LogSupport:
         handler.onOpen(ctx)
       catch
         case NonFatal(e) =>
-          safeOnError(handler, ctx, e)
+          WebSocketDispatcher.safeOnError(handler, ctx, e)
 
       val decoder = WebSocketFrameDecoder(maxFrameSize)
       var open    = true
@@ -55,65 +55,17 @@ private[http] object NativeWebSocket extends LogSupport:
         if chunk.isEmpty then
           open = false // clean EOF
         else
-          open = decoder.feed(chunk)(ev => dispatch(handler, ctx, notifyClose, ev))
+          open =
+            decoder.feed(chunk)(ev =>
+              WebSocketDispatcher.dispatch(handler, ctx, ctx.sendPong, () => notifyClose(), ev)
+            )
     catch
       case NonFatal(e) =>
-        safeOnError(handler, ctx, e)
+        WebSocketDispatcher.safeOnError(handler, ctx, e)
     finally
       notifyClose()
 
   end serve
-
-  private def dispatch(
-      handler: WebSocketHandler,
-      ctx: NativeWebSocketContext,
-      notifyClose: () => Unit,
-      event: WsEvent
-  ): Unit =
-    event match
-      case WsEvent.Message(WebSocketFrame.OpText, data) =>
-        deliverText(handler, ctx, data)
-      case WsEvent.Message(_, data) =>
-        deliverBinary(handler, ctx, data)
-      case WsEvent.Ping(data) =>
-        ctx.sendPong(data)
-      case WsEvent.Pong(_) =>
-      // ignore unsolicited pongs
-      case WsEvent.PeerClose(code, _) =>
-        notifyClose()
-        // Echo the peer's close code (RFC 6455 §5.5.1).
-        ctx.close(code, "")
-      case WsEvent.Fail(code, reason) =>
-        ctx.close(code, reason)
-
-  private def deliverText(
-      handler: WebSocketHandler,
-      ctx: NativeWebSocketContext,
-      data: Array[Byte]
-  ): Unit =
-    try
-      handler.onTextMessage(ctx, new String(data, StandardCharsets.UTF_8))
-    catch
-      case NonFatal(e) =>
-        safeOnError(handler, ctx, e)
-
-  private def deliverBinary(
-      handler: WebSocketHandler,
-      ctx: NativeWebSocketContext,
-      data: Array[Byte]
-  ): Unit =
-    try
-      handler.onBinaryMessage(ctx, data)
-    catch
-      case NonFatal(e) =>
-        safeOnError(handler, ctx, e)
-
-  private def safeOnError(handler: WebSocketHandler, ctx: WebSocketContext, e: Throwable): Unit =
-    try
-      handler.onError(ctx, e)
-    catch
-      case NonFatal(e2) =>
-        warn(s"onError error: ${e2.getMessage}")
 
 end NativeWebSocket
 

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeServerTest.scala
@@ -367,7 +367,7 @@ class NativeServerTest extends UniTest:
   end WsClient
 
   test("acceptKey matches the RFC 6455 example") {
-    NativeWebSocket.acceptKey("dGhlIHNhbXBsZSBub25jZQ==") shouldBe "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+    WebSocketFrame.acceptKey("dGhlIHNhbXBsZSBub25jZQ==") shouldBe "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
   }
 
   test("WebSocket echoes text messages") {

--- a/uni/src/main/scala/wvlet/uni/http/Sha1.scala
+++ b/uni/src/main/scala/wvlet/uni/http/Sha1.scala
@@ -17,8 +17,9 @@ import scala.collection.mutable
 
 /**
   * A small, dependency-free SHA-1 (RFC 3174) used for the WebSocket handshake accept key.
-  * `java.security.MessageDigest` is not available on Scala Native, so this provides the digest; the
-  * result is base64-encoded with `java.util.Base64` (which is available on Native).
+  * `java.security.MessageDigest` is not available on Scala Native, so this provides the digest on
+  * all platforms (the result is base64-encoded with `java.util.Base64`, which is available on JVM,
+  * Scala.js, and Native).
   */
 private[http] object Sha1:
 

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketDispatcher.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketDispatcher.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.log.LogSupport
+
+import java.nio.charset.StandardCharsets
+import scala.util.control.NonFatal
+
+/**
+  * Maps decoded [[WsEvent]]s to [[WebSocketHandler]] callbacks and outbound control frames, shared
+  * by the Native and Node.js backends. The platform-specific `sendPong` and `notifyClose` (the
+  * exactly-once onClose latch) are passed in; everything else is identical across backends.
+  */
+private[http] object WebSocketDispatcher extends LogSupport:
+
+  def dispatch(
+      handler: WebSocketHandler,
+      ctx: WebSocketContext,
+      sendPong: Array[Byte] => Unit,
+      notifyClose: () => Unit,
+      event: WsEvent
+  ): Unit =
+    event match
+      case WsEvent.Message(WebSocketFrame.OpText, data) =>
+        deliver(
+          handler,
+          ctx,
+          () => handler.onTextMessage(ctx, new String(data, StandardCharsets.UTF_8))
+        )
+      case WsEvent.Message(_, data) =>
+        deliver(handler, ctx, () => handler.onBinaryMessage(ctx, data))
+      case WsEvent.Ping(data) =>
+        sendPong(data)
+      case WsEvent.Pong(_) =>
+      // ignore unsolicited pongs
+      case WsEvent.PeerClose(code, _) =>
+        // onClose before the echo, matching the original Native ordering (RFC 6455 §5.5.1).
+        notifyClose()
+        ctx.close(code, "")
+      case WsEvent.Fail(code, reason) =>
+        // onClose is driven by the connection teardown after this terminal event.
+        ctx.close(code, reason)
+
+  private def deliver(handler: WebSocketHandler, ctx: WebSocketContext, action: () => Unit): Unit =
+    try
+      action()
+    catch
+      case NonFatal(e) =>
+        safeOnError(handler, ctx, e)
+
+  def safeOnError(handler: WebSocketHandler, ctx: WebSocketContext, e: Throwable): Unit =
+    try
+      handler.onError(ctx, e)
+    catch
+      case NonFatal(e2) =>
+        warn(s"onError error: ${e2.getMessage}")
+
+end WebSocketDispatcher

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketFrame.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketFrame.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+/**
+  * Cross-platform RFC 6455 frame helpers: opcodes, the handshake accept key, and the (unmasked)
+  * server-frame encoder. Shared by the Native and Node.js WebSocket backends so there is a single
+  * framing implementation. Decoding of inbound (masked) client frames lives in
+  * [[WebSocketFrameDecoder]].
+  */
+private[http] object WebSocketFrame:
+
+  final val OpContinuation = 0x0
+  final val OpText         = 0x1
+  final val OpBinary       = 0x2
+  final val OpClose        = 0x8
+  final val OpPing         = 0x9
+  final val OpPong         = 0xa
+
+  private final val MagicGuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+  /** `Sec-WebSocket-Accept` = base64(SHA1(key + GUID)). */
+  def acceptKey(key: String): String = Base64
+    .getEncoder
+    .encodeToString(Sha1.digest((key + MagicGuid).getBytes(StandardCharsets.US_ASCII)))
+
+  /** Encode an unmasked server frame (FIN set). */
+  def encodeFrame(opcode: Int, payload: Array[Byte]): Array[Byte] =
+    val len    = payload.length
+    val b0     = (0x80 | opcode).toByte
+    val header =
+      if len < 126 then
+        Array[Byte](b0, len.toByte)
+      else if len < 65536 then
+        Array[Byte](b0, 126.toByte, ((len >>> 8) & 0xff).toByte, (len & 0xff).toByte)
+      else
+        val h = new Array[Byte](10)
+        h(0) = b0
+        h(1) = 127.toByte
+        val l = len.toLong
+        var i = 0
+        while i < 8 do
+          h(2 + i) = ((l >>> ((7 - i) * 8)) & 0xff).toByte
+          i += 1
+        h
+    header ++ payload
+
+  /** A Close-frame payload: a 2-byte big-endian status code followed by the UTF-8 reason. */
+  def closePayload(statusCode: Int, reason: String): Array[Byte] =
+    val reasonBytes = reason.getBytes(StandardCharsets.UTF_8)
+    val payload     = new Array[Byte](2 + reasonBytes.length)
+    payload(0) = ((statusCode >>> 8) & 0xff).toByte
+    payload(1) = (statusCode & 0xff).toByte
+    System.arraycopy(reasonBytes, 0, payload, 2, reasonBytes.length)
+    payload
+
+end WebSocketFrame

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketFrameDecoder.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketFrameDecoder.scala
@@ -92,8 +92,10 @@ private[http] class WebSocketFrameDecoder(maxFrameSize: Int):
       while i < 8 do
         l = (l << 8) | (buf(2 + i) & 0xff).toLong
         i += 1
+      // `l < 0` guards an 8-byte length with the high bit set (a signed Long), which would
+      // otherwise slip past `l > maxFrameSize` and truncate to a small Int → framing desync.
       len =
-        if l > maxFrameSize then
+        if l < 0 || l > maxFrameSize then
           -1
         else
           l.toInt

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketFrameDecoder.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketFrameDecoder.scala
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import scala.collection.mutable
+
+/**
+  * A decoded inbound WebSocket event. Text/binary messages are delivered fully reassembled;
+  * [[PeerClose]] and [[Fail]] are terminal (the decoder ignores further input after either).
+  */
+private[http] enum WsEvent:
+  case Message(opcode: Int, data: Array[Byte])
+  case Ping(data: Array[Byte])
+  case Pong(data: Array[Byte])
+  case PeerClose(code: Int, reason: String)
+  case Fail(code: Int, reason: String)
+
+/**
+  * Incremental RFC 6455 frame decoder for inbound (masked, client->server) frames. Bytes are fed in
+  * as they arrive — possibly splitting a frame across calls or batching several — and each complete
+  * frame emits a [[WsEvent]]. A partial frame is buffered until the rest arrives; an incomplete
+  * frame is never an error. Shared by the Native (blocking recv loop) and Node.js (socket `data`
+  * events) backends.
+  *
+  * `maxFrameSize` bounds both a single frame and a reassembled fragmented message (close 1009).
+  */
+private[http] class WebSocketFrameDecoder(maxFrameSize: Int):
+  import WebSocketFrame.*
+
+  private val buf            = mutable.ArrayBuffer.empty[Byte]
+  private val fragments      = mutable.ArrayBuffer.empty[Byte]
+  private var fragmentOpcode = -1
+  private var terminated     = false
+
+  /**
+    * Feed received bytes, invoking `emit` once per decoded event (in order). Returns false once a
+    * terminal event ([[WsEvent.PeerClose]] or [[WsEvent.Fail]]) has been emitted — after which the
+    * decoder ignores further input and the caller should stop reading.
+    */
+  def feed(bytes: Array[Byte])(emit: WsEvent => Unit): Boolean =
+    if terminated then
+      return false
+    buf ++= bytes
+    var progressed = true
+    while progressed && !terminated do
+      progressed = decodeOne(emit)
+    !terminated
+
+  /**
+    * Decode one frame if fully buffered. Returns true if a frame was consumed (loop again), false
+    * if more bytes are needed.
+    */
+  private def decodeOne(emit: WsEvent => Unit): Boolean =
+    if buf.length < 2 then
+      return false
+    val b0        = buf(0) & 0xff
+    val b1        = buf(1) & 0xff
+    val fin       = (b0 & 0x80) != 0
+    val rsv       = b0 & 0x70
+    val opcode    = b0 & 0x0f
+    val masked    = (b1 & 0x80) != 0
+    val isControl = (opcode & 0x8) != 0
+    val base      = b1 & 0x7f
+    val headerLen =
+      base match
+        case 126 =>
+          4
+        case 127 =>
+          10
+        case _ =>
+          2
+    if buf.length < headerLen then
+      return false
+
+    var len = base
+    if base == 126 then
+      len = ((buf(2) & 0xff) << 8) | (buf(3) & 0xff)
+    else if base == 127 then
+      var l = 0L
+      var i = 0
+      while i < 8 do
+        l = (l << 8) | (buf(2 + i) & 0xff).toLong
+        i += 1
+      len =
+        if l > maxFrameSize then
+          -1
+        else
+          l.toInt
+
+    // Validation order matches the wire behavior: size, then RSV/mask, then control-frame rules.
+    if len < 0 || len > maxFrameSize then
+      return fail(emit, 1009, "message too big")
+    if rsv != 0 || !masked then
+      // RSV must be 0 (no extension negotiated); client frames MUST be masked (RFC 6455 §5).
+      return fail(emit, 1002, "protocol error")
+    if isControl && (!fin || len > 125) then
+      // Control frames must be final and at most 125 bytes (RFC 6455 §5.5).
+      return fail(emit, 1002, "invalid control frame")
+
+    val total = headerLen + 4 + len // + 4-byte mask key
+    if buf.length < total then
+      return false
+
+    val payload = new Array[Byte](len)
+    val maskOff = headerLen
+    val dataOff = headerLen + 4
+    var i       = 0
+    while i < len do
+      payload(i) = (buf(dataOff + i) ^ buf(maskOff + (i % 4))).toByte
+      i += 1
+    buf.remove(0, total)
+
+    dispatch(emit, fin, opcode, payload)
+    true
+
+  end decodeOne
+
+  private def dispatch(
+      emit: WsEvent => Unit,
+      fin: Boolean,
+      opcode: Int,
+      payload: Array[Byte]
+  ): Unit =
+    opcode match
+      case OpText | OpBinary =>
+        if fragmentOpcode != -1 then
+          fail(emit, 1002, "data frame during a fragmented message")
+        else if fin then
+          emit(WsEvent.Message(opcode, payload))
+        else
+          fragmentOpcode = opcode
+          fragments.clear()
+          fragments ++= payload
+      case OpContinuation =>
+        if fragmentOpcode == -1 then
+          fail(emit, 1002, "continuation without a start frame")
+        else
+          fragments ++= payload
+          if fragments.length > maxFrameSize then
+            fail(emit, 1009, "message too big")
+          else if fin then
+            emit(WsEvent.Message(fragmentOpcode, fragments.toArray))
+            fragments.clear()
+            fragmentOpcode = -1
+      case OpClose =>
+        val code =
+          if payload.length >= 2 then
+            ((payload(0) & 0xff) << 8) | (payload(1) & 0xff)
+          else
+            1000
+        emit(WsEvent.PeerClose(code, ""))
+        terminated = true
+      case OpPing =>
+        emit(WsEvent.Ping(payload))
+      case OpPong =>
+        emit(WsEvent.Pong(payload))
+      case _ =>
+        fail(emit, 1002, s"unsupported opcode ${opcode}")
+
+  /**
+    * Emit a terminal failure and mark the decoder done. Always returns false (no further decoding).
+    */
+  private def fail(emit: WsEvent => Unit, code: Int, reason: String): Boolean =
+    emit(WsEvent.Fail(code, reason))
+    terminated = true
+    false
+
+end WebSocketFrameDecoder

--- a/uni/src/test/scala/wvlet/uni/http/WebSocketFrameDecoderTest.scala
+++ b/uni/src/test/scala/wvlet/uni/http/WebSocketFrameDecoderTest.scala
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.test.UniTest
+
+import java.nio.charset.StandardCharsets
+import scala.collection.mutable
+
+/**
+  * Cross-platform unit tests for the RFC 6455 frame decoder. These lock the framing contract that
+  * the Native and Node.js WebSocket backends both depend on.
+  */
+class WebSocketFrameDecoderTest extends UniTest:
+
+  private val mask = Array[Byte](0x12, 0x34, 0x56, 0x78)
+
+  /** Build a masked client frame (FIN configurable) for `opcode` + `payload`. */
+  private def frame(opcode: Int, payload: Array[Byte], fin: Boolean = true): Array[Byte] =
+    val b0 = (
+      (
+        if fin then
+          0x80
+        else
+          0x00
+      ) | opcode
+    ).toByte
+    val len    = payload.length
+    val header =
+      if len < 126 then
+        Array[Byte](b0, (0x80 | len).toByte)
+      else if len < 65536 then
+        Array[Byte](b0, (0x80 | 126).toByte, ((len >>> 8) & 0xff).toByte, (len & 0xff).toByte)
+      else
+        val h = new Array[Byte](10)
+        h(0) = b0
+        h(1) = (0x80 | 127).toByte
+        val l = len.toLong
+        var i = 0
+        while i < 8 do
+          h(2 + i) = ((l >>> ((7 - i) * 8)) & 0xff).toByte
+          i += 1
+        h
+    val masked = new Array[Byte](len)
+    var i      = 0
+    while i < len do
+      masked(i) = (payload(i) ^ mask(i % 4)).toByte
+      i += 1
+    header ++ mask ++ masked
+
+  end frame
+
+  private def textFrame(s: String, fin: Boolean = true): Array[Byte] = frame(
+    WebSocketFrame.OpText,
+    s.getBytes(StandardCharsets.UTF_8),
+    fin
+  )
+
+  /** Feed all bytes at once and collect emitted events. */
+  private def decode(bytes: Array[Byte], maxFrameSize: Int = 1024 * 1024): Seq[WsEvent] =
+    val events  = mutable.ArrayBuffer.empty[WsEvent]
+    val decoder = WebSocketFrameDecoder(maxFrameSize)
+    decoder.feed(bytes)(events += _)
+    events.toSeq
+
+  test("decode a single masked text frame") {
+    decode(textFrame("hello")) shouldMatch {
+      case Seq(WsEvent.Message(WebSocketFrame.OpText, data)) =>
+        new String(data, StandardCharsets.UTF_8) shouldBe "hello"
+    }
+  }
+
+  test("decode a binary frame") {
+    val payload = Array[Byte](1, 2, 3, 4, 5)
+    decode(frame(WebSocketFrame.OpBinary, payload)) shouldMatch {
+      case Seq(WsEvent.Message(WebSocketFrame.OpBinary, data)) =>
+        data.toSeq shouldBe payload.toSeq
+    }
+  }
+
+  test("decode multiple frames in one feed") {
+    decode(textFrame("a") ++ textFrame("b")) shouldMatch {
+      case Seq(WsEvent.Message(_, d1), WsEvent.Message(_, d2)) =>
+        new String(d1, StandardCharsets.UTF_8) shouldBe "a"
+        new String(d2, StandardCharsets.UTF_8) shouldBe "b"
+    }
+  }
+
+  test("reassemble a fragmented text message") {
+    val start = textFrame("Hel", fin = false)
+    val cont  = frame(
+      WebSocketFrame.OpContinuation,
+      "lo".getBytes(StandardCharsets.UTF_8),
+      fin = true
+    )
+    decode(start ++ cont) shouldMatch { case Seq(WsEvent.Message(WebSocketFrame.OpText, data)) =>
+      new String(data, StandardCharsets.UTF_8) shouldBe "Hello"
+    }
+  }
+
+  test("a new data frame during fragmentation fails with 1002") {
+    val start = textFrame("Hel", fin = false)
+    decode(start ++ textFrame("oops")) shouldMatch { case Seq(WsEvent.Fail(1002, _)) =>
+    }
+  }
+
+  test("a continuation without a start frame fails with 1002") {
+    val cont = frame(WebSocketFrame.OpContinuation, "x".getBytes(StandardCharsets.UTF_8))
+    decode(cont) shouldMatch { case Seq(WsEvent.Fail(1002, _)) =>
+    }
+  }
+
+  test("a ping emits Ping and a pong is emitted") {
+    decode(frame(WebSocketFrame.OpPing, "p".getBytes(StandardCharsets.UTF_8))) shouldMatch {
+      case Seq(WsEvent.Ping(data)) =>
+        new String(data, StandardCharsets.UTF_8) shouldBe "p"
+    }
+    decode(frame(WebSocketFrame.OpPong, Array.emptyByteArray)) shouldMatch {
+      case Seq(WsEvent.Pong(_)) =>
+    }
+  }
+
+  test("a close frame emits PeerClose with the peer's code") {
+    val payload = Array[Byte](((1001 >>> 8) & 0xff).toByte, (1001 & 0xff).toByte)
+    decode(frame(WebSocketFrame.OpClose, payload)) shouldMatch {
+      case Seq(WsEvent.PeerClose(1001, _)) =>
+    }
+  }
+
+  test("an unmasked frame fails with 1002") {
+    // Hand-build an unmasked text frame (mask bit clear, no mask key).
+    val payload  = "hi".getBytes(StandardCharsets.UTF_8)
+    val unmasked = Array[Byte](0x81.toByte, payload.length.toByte) ++ payload
+    decode(unmasked) shouldMatch { case Seq(WsEvent.Fail(1002, _)) =>
+    }
+  }
+
+  test("a set RSV bit fails with 1002") {
+    val f = textFrame("x")
+    f(0) = (f(0) | 0x40).toByte // set RSV1
+    decode(f) shouldMatch { case Seq(WsEvent.Fail(1002, _)) =>
+    }
+  }
+
+  test("an oversized frame fails with 1009") {
+    decode(textFrame("abcdef"), maxFrameSize = 3) shouldMatch { case Seq(WsEvent.Fail(1009, _)) =>
+    }
+  }
+
+  test("an oversized reassembled message fails with 1009") {
+    val start = textFrame("aa", fin = false)
+    val cont  = frame(
+      WebSocketFrame.OpContinuation,
+      "bb".getBytes(StandardCharsets.UTF_8),
+      fin = true
+    )
+    // Each frame (2 bytes) is within the cap, but the reassembled message (4) exceeds it.
+    decode(start ++ cont, maxFrameSize = 3) shouldMatch { case Seq(WsEvent.Fail(1009, _)) =>
+    }
+  }
+
+  test("a fragmented (non-final) control frame fails with 1002") {
+    val ping = frame(WebSocketFrame.OpPing, "x".getBytes(StandardCharsets.UTF_8), fin = false)
+    decode(ping) shouldMatch { case Seq(WsEvent.Fail(1002, _)) =>
+    }
+  }
+
+  test("an oversized control frame fails with 1002") {
+    val big = frame(WebSocketFrame.OpPing, new Array[Byte](126))
+    decode(big) shouldMatch { case Seq(WsEvent.Fail(1002, _)) =>
+    }
+  }
+
+  test("a stream split one byte per feed decodes identically") {
+    val stream  = textFrame("hello") ++ frame(WebSocketFrame.OpBinary, Array[Byte](9, 8, 7))
+    val events  = mutable.ArrayBuffer.empty[WsEvent]
+    val decoder = WebSocketFrameDecoder(1024 * 1024)
+    var i       = 0
+    while i < stream.length do
+      decoder.feed(Array(stream(i)))(events += _)
+      i += 1
+    events.toSeq shouldMatch {
+      case Seq(
+            WsEvent.Message(WebSocketFrame.OpText, d1),
+            WsEvent.Message(WebSocketFrame.OpBinary, d2)
+          ) =>
+        new String(d1, StandardCharsets.UTF_8) shouldBe "hello"
+        d2.toSeq shouldBe Seq[Byte](9, 8, 7)
+    }
+  }
+
+  test("input after a terminal event is ignored") {
+    val decoder = WebSocketFrameDecoder(1024 * 1024)
+    val events  = mutable.ArrayBuffer.empty[WsEvent]
+    decoder.feed(frame(WebSocketFrame.OpClose, Array.emptyByteArray))(events += _) shouldBe false
+    // Further frames are dropped.
+    decoder.feed(textFrame("ignored"))(events += _) shouldBe false
+    events.size shouldBe 1
+  }
+
+end WebSocketFrameDecoderTest

--- a/uni/src/test/scala/wvlet/uni/http/WebSocketFrameDecoderTest.scala
+++ b/uni/src/test/scala/wvlet/uni/http/WebSocketFrameDecoderTest.scala
@@ -182,6 +182,13 @@ class WebSocketFrameDecoderTest extends UniTest:
     }
   }
 
+  test("an 8-byte length with the high bit set fails with 1009") {
+    // FIN+text, masked, 127 extended length whose MSB is set (a negative signed Long).
+    val frame = Array[Byte](0x81.toByte, 0xff.toByte, 0xff.toByte, 0, 0, 0, 0, 0, 0, 1)
+    decode(frame) shouldMatch { case Seq(WsEvent.Fail(1009, _)) =>
+    }
+  }
+
   test("a stream split one byte per feed decodes identically") {
     val stream  = textFrame("hello") ++ frame(WebSocketFrame.OpBinary, Array[Byte](9, 8, 7))
     val events  = mutable.ArrayBuffer.empty[WsEvent]


### PR DESCRIPTION
## Why

Node's `http.Server` has no built-in WebSocket (it was deferred when the cross-platform server abstraction landed). This adds a WebSocket server to the Node.js backend by hand-rolling the handshake + RFC 6455 framing on the raw `'upgrade'` socket — **completing WebSocket support across all three backends**: JVM/Netty (#573), Native (#576), and now Node.

## Approach — a shared, tested frame codec

Rather than duplicate the intricate, security-sensitive RFC 6455 parser (the Native one accrued 7 review findings), this **extracts a shared codec** that both the Native and Node backends drive. Research confirmed `Sha1` (pure Scala) and `java.util.Base64` both run on Scala.js, so the handshake is fully shareable.

**Shared (`uni/src/main`, cross-compiled JVM/JS/Native):**
- `Sha1` — moved from Native (deleted the Native copy).
- `WebSocketFrame` — opcodes, `acceptKey`, `encodeFrame`, `closePayload`.
- `WebSocketFrameDecoder` — a stateful incremental decoder, `feed(bytes)(emit): Boolean`, emitting a `WsEvent` (`Message`/`Ping`/`Pong`/`PeerClose`/`Fail`). It carries the **exact** validation the Native loop had: masking required, RSV/control-frame rules, per-frame *and* per-message size caps (1009), fragmentation reassembly, and — the key subtlety — a **truncated frame is buffered as "need more bytes", never an error** (frames span chunks).

**Native:** `NativeWebSocket.serve` becomes a thin driver around the shared decoder (recv loop → `feed` → dispatch); behavior unchanged — the 18 Native tests still pass.

**Node:** `NodeWebSocket` handles the `'upgrade'` event — builds the `Request`, gates the upgrade through the route filter (async `RxRunner`; `OnCompletion` → close, matching Netty), writes the `101`, then bridges `socket.on("data")` → decoder. `NodeWebSocketContext` uses a plain `var` (single-threaded event loop — no atomics/locks) and wraps every write (an uncaught throw on the loop crashes Node); `close()` uses `socket.end()` to flush the close frame. `NodeServerConfig` gains `webSocketRoutes` + `withWebSocketRoute[/filter]` + `withWebSocketMaxFrameSize`. `toBytes`/`toUint8Array` extracted to `NodeBytes`.

```scala
NodeServer.withPort(0)
  .withWebSocketRoute("/ws"){ _ =>
    new WebSocketHandler:
      override def onTextMessage(ctx, m) = ctx.send(s"echo:${m}")
  }
  .startAndAwait { server => ... }
```

## Testing
- **Cross-platform decoder unit tests** (`uni/src/test`, run on JVM/JS/Native — the real regression guard): text/binary, fragmentation, interleaved-data & lone-continuation → `Fail(1002)`, ping/pong, close → `PeerClose(code)`, unmasked/RSV → `Fail(1002)`, oversized frame & oversized reassembly → `Fail(1009)`, oversized/non-final control → `Fail(1002)`, and **split-buffer** (one byte per `feed` → identical events).
- **Node integration test** via a manual `net.Socket` client (no `ws` npm dep): handshake accept-key + text echo, binary echo, push-on-open, `onOpen`/`onClose`, missing-key 400, filter-reject 403.
- **JVM 1634 / Native 1386 / JS 1385** tests pass (0 failures). No new dependency.

## Limitations / follow-ups
- **Backpressure (Node):** `socket.write` returning `false` buffers in memory unbounded (Native's `sendAll` is naturally backpressured) — optional follow-up: pause on `false`, resume on `drain`.
- `Sec-WebSocket-Version` not validated (matches Native; Netty replies 426).
- No permessage-deflate; no client-side WebSocket (the standing cross-platform-client follow-up).

Plan: `plans/2026-06-19-node-websocket.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)