### PR TITLE
fix: Repair the Native libcurl client (CURLE_URL_MALFORMAT via C shim)

### DIFF
--- a/plans/2026-06-19-native-curl-client-fix.md
+++ b/plans/2026-06-19-native-curl-client-fix.md
@@ -1,0 +1,34 @@
+# Fix the Native libcurl client (CURLE_URL_MALFORMAT)
+
+## Context
+The Scala Native HTTP client (`CurlChannel`) failed on every request with `CURLE_URL_MALFORMAT`
+(code 3) on a valid loopback URL — so it was unusable (prior work fell back to a raw POSIX client to
+test the Native server).
+
+## Root cause
+`curl_easy_setopt` and `curl_easy_getinfo` are **C variadic** functions. The bindings called them via
+**fixed-arity** `@extern` declarations. On arm64-apple-darwin the variadic argument is passed on the
+stack while a fixed-arity call places it in a register, so curl read garbage for the value — a valid
+URL became "malformed". (`setopt` returns OK because it just stores the pointer; `perform` then fails.)
+A `CVarArg*` variadic extern did **not** fix it either — Scala Native's variadic codegen does not pass
+the argument through for this function on this toolchain (verified: even a global `c"..."` literal URL
+still produced code 3).
+
+## Fix
+Route `setopt`/`getinfo` through tiny **fixed-arity C shims** that forward to the real variadic
+functions, so the C compiler emits the correct variadic call and Scala Native sees ordinary
+fixed-arity symbols:
+- `uni/.native/src/main/resources/scala-native/uni_curl_shim.c` — `uni_curl_easy_setopt_ptr/_long`
+  and `uni_curl_easy_getinfo_ptr`, forwarding to `curl_easy_setopt`/`curl_easy_getinfo`. Declares the
+  curl prototypes locally so no libcurl headers are needed at build time (symbols resolve from -lcurl).
+- `CurlBindings`: the `Extern` object declares the three shim functions; the `curl_easy_setopt_*` /
+  `curl_easy_getinfo_long` wrappers call them (pointer options, the write/header callbacks via
+  `CFuncPtr.toPtr`, slist and the response-code out-pointer all go through the `_ptr` shim).
+
+## Verification
+New `NativeCurlClientTest` hits the in-process `NativeServer` over loopback: GET (URL + write callback
++ response code), POST (POSTFIELDS), and header round-trip (HTTPHEADER slist) — all 200. `uniNative/test`:
+1402 tests, 0 failed.
+
+## Follow-ups (remaining)
+Cross-platform WebSocket client; WS ping/pong heartbeat; permessage-deflate.

--- a/uni/.native/src/main/resources/scala-native/uni_curl_shim.c
+++ b/uni/.native/src/main/resources/scala-native/uni_curl_shim.c
@@ -37,6 +37,7 @@ int uni_curl_easy_setopt_long(void *handle, int option, long value) {
   return curl_easy_setopt(handle, option, value);
 }
 
-int uni_curl_easy_getinfo_ptr(void *handle, int info, void *value) {
+/* Typed long* out-parameter for CURLINFO_*_RESPONSE_CODE and other `long` infos. */
+int uni_curl_easy_getinfo_long(void *handle, int info, long *value) {
   return curl_easy_getinfo(handle, info, value);
 }

--- a/uni/.native/src/main/resources/scala-native/uni_curl_shim.c
+++ b/uni/.native/src/main/resources/scala-native/uni_curl_shim.c
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Fixed-arity shims over libcurl's variadic curl_easy_setopt / curl_easy_getinfo.
+ *
+ * Scala Native cannot reliably call these C variadic functions: a fixed-arity @extern uses the wrong
+ * calling convention for the variadic argument (it lands in a register instead of on the stack on
+ * arm64-apple-darwin), and a CVarArg* extern does not pass the argument through at all on this
+ * toolchain. Both make curl read garbage for the value (e.g. a valid URL reported as
+ * CURLE_URL_MALFORMAT). Routing through these real, fixed-arity C functions lets the C compiler emit
+ * the correct variadic call, while Scala Native sees ordinary fixed-arity symbols.
+ *
+ * The curl prototypes are declared locally so the shim needs no libcurl headers at build time; the
+ * symbols are resolved from the linked libcurl (-lcurl). CURLoption/CURLINFO are C enums (int).
+ */
+
+extern int curl_easy_setopt(void *handle, int option, ...);
+extern int curl_easy_getinfo(void *handle, int info, ...);
+
+int uni_curl_easy_setopt_ptr(void *handle, int option, void *value) {
+  return curl_easy_setopt(handle, option, value);
+}
+
+int uni_curl_easy_setopt_long(void *handle, int option, long value) {
+  return curl_easy_setopt(handle, option, value);
+}
+
+int uni_curl_easy_getinfo_ptr(void *handle, int info, void *value) {
+  return curl_easy_getinfo(handle, info, value);
+}

--- a/uni/.native/src/main/scala/wvlet/uni/http/CurlBindings.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/CurlBindings.scala
@@ -104,7 +104,7 @@ object CurlBindings:
     // src/main/resources/scala-native/uni_curl_shim.c, which forward to the real variadic functions.
     def uni_curl_easy_setopt_ptr(curl: CURL, option: CInt, value: Ptr[Byte]): CInt = extern
     def uni_curl_easy_setopt_long(curl: CURL, option: CInt, value: Long): CInt     = extern
-    def uni_curl_easy_getinfo_ptr(curl: CURL, info: CInt, value: Ptr[Byte]): CInt  = extern
+    def uni_curl_easy_getinfo_long(curl: CURL, info: CInt, value: Ptr[Long]): CInt = extern
 
     @name("curl_easy_strerror")
     def easyStrerror(code: CInt): CString = extern
@@ -134,7 +134,7 @@ object CurlBindings:
     .uni_curl_easy_setopt_ptr(curl, option, parameter)
 
   def curl_easy_setopt_str(curl: CURL, option: CInt, parameter: CString): CInt = Extern
-    .uni_curl_easy_setopt_ptr(curl, option, parameter)
+    .uni_curl_easy_setopt_ptr(curl, option, parameter.asInstanceOf[Ptr[Byte]])
 
   def curl_easy_setopt_callback(
       curl: CURL,
@@ -150,7 +150,7 @@ object CurlBindings:
     .uni_curl_easy_setopt_ptr(curl, option, parameter.asInstanceOf[Ptr[Byte]])
 
   def curl_easy_getinfo_long(curl: CURL, info: CInt, result: Ptr[Long]): CInt = Extern
-    .uni_curl_easy_getinfo_ptr(curl, info, result.asInstanceOf[Ptr[Byte]])
+    .uni_curl_easy_getinfo_long(curl, info, result)
 
   def curl_easy_strerror(code: CInt): CString = Extern.easyStrerror(code)
   def curl_slist_append(list: Ptr[CurlSlist], str: CString): Ptr[CurlSlist] = Extern.slistAppend(

--- a/uni/.native/src/main/scala/wvlet/uni/http/CurlBindings.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/CurlBindings.scala
@@ -97,24 +97,14 @@ object CurlBindings:
     @name("curl_easy_perform")
     def easyPerform(curl: CURL): CInt = extern
 
-    @name("curl_easy_setopt")
-    def easySetoptLong(curl: CURL, option: CInt, parameter: Long): CInt = extern
-
-    @name("curl_easy_setopt")
-    def easySetoptPtr(curl: CURL, option: CInt, parameter: Ptr[Byte]): CInt = extern
-
-    @name("curl_easy_setopt")
-    def easySetoptCallback(
-        curl: CURL,
-        option: CInt,
-        parameter: CFuncPtr4[Ptr[Byte], CSize, CSize, Ptr[Byte], CSize]
-    ): CInt = extern
-
-    @name("curl_easy_setopt")
-    def easySetoptSlist(curl: CURL, option: CInt, parameter: Ptr[CurlSlist]): CInt = extern
-
-    @name("curl_easy_getinfo")
-    def easyGetinfoLong(curl: CURL, info: CInt, result: Ptr[Long]): CInt = extern
+    // curl_easy_setopt / curl_easy_getinfo are C variadic functions that Scala Native cannot call
+    // correctly (a fixed-arity extern uses the wrong calling convention for the variadic arg, and a
+    // CVarArg* extern doesn't pass it through on this toolchain) — curl then reads garbage for the
+    // value (a valid URL becomes CURLE_URL_MALFORMAT). These resolve to fixed-arity C shims in
+    // src/main/resources/scala-native/uni_curl_shim.c, which forward to the real variadic functions.
+    def uni_curl_easy_setopt_ptr(curl: CURL, option: CInt, value: Ptr[Byte]): CInt = extern
+    def uni_curl_easy_setopt_long(curl: CURL, option: CInt, value: Long): CInt     = extern
+    def uni_curl_easy_getinfo_ptr(curl: CURL, info: CInt, value: Ptr[Byte]): CInt  = extern
 
     @name("curl_easy_strerror")
     def easyStrerror(code: CInt): CString = extern
@@ -138,25 +128,29 @@ object CurlBindings:
   def curl_easy_perform(curl: CURL): CInt = Extern.easyPerform(curl)
 
   def curl_easy_setopt_long(curl: CURL, option: CInt, parameter: Long): CInt = Extern
-    .easySetoptLong(curl, option, parameter)
+    .uni_curl_easy_setopt_long(curl, option, parameter)
 
   def curl_easy_setopt_ptr(curl: CURL, option: CInt, parameter: Ptr[Byte]): CInt = Extern
-    .easySetoptPtr(curl, option, parameter)
+    .uni_curl_easy_setopt_ptr(curl, option, parameter)
 
   def curl_easy_setopt_str(curl: CURL, option: CInt, parameter: CString): CInt = Extern
-    .easySetoptPtr(curl, option, parameter.asInstanceOf[Ptr[Byte]])
+    .uni_curl_easy_setopt_ptr(curl, option, parameter)
 
   def curl_easy_setopt_callback(
       curl: CURL,
       option: CInt,
       parameter: CFuncPtr4[Ptr[Byte], CSize, CSize, Ptr[Byte], CSize]
-  ): CInt = Extern.easySetoptCallback(curl, option, parameter)
+  ): CInt = Extern.uni_curl_easy_setopt_ptr(
+    curl,
+    option,
+    CFuncPtr.toPtr(parameter).asInstanceOf[Ptr[Byte]]
+  )
 
   def curl_easy_setopt_slist(curl: CURL, option: CInt, parameter: Ptr[CurlSlist]): CInt = Extern
-    .easySetoptSlist(curl, option, parameter)
+    .uni_curl_easy_setopt_ptr(curl, option, parameter.asInstanceOf[Ptr[Byte]])
 
   def curl_easy_getinfo_long(curl: CURL, info: CInt, result: Ptr[Long]): CInt = Extern
-    .easyGetinfoLong(curl, info, result)
+    .uni_curl_easy_getinfo_ptr(curl, info, result.asInstanceOf[Ptr[Byte]])
 
   def curl_easy_strerror(code: CInt): CString = Extern.easyStrerror(code)
   def curl_slist_append(list: Ptr[CurlSlist], str: CString): Ptr[CurlSlist] = Extern.slistAppend(

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeCurlClientTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeCurlClientTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.test.UniTest
+
+/**
+  * Verifies the Scala Native libcurl client ([[CurlChannel]]) against the in-process Native server
+  * over loopback. Exercises the variadic `curl_easy_setopt`/`curl_easy_getinfo` paths (URL, write
+  * callback, response code, POST fields, header list) — all previously broken on arm64 because the
+  * variadic curl functions were declared as fixed-arity externs.
+  */
+class NativeCurlClientTest extends UniTest:
+
+  private def client(server: HttpServer) =
+    Http.client.withBaseUri(s"http://127.0.0.1:${server.localPort}").newSyncClient
+
+  test("curl client performs a loopback GET") {
+    NativeServer
+      .withHandler(req => Response.ok(s"Hello from ${req.path}"))
+      .withPort(0)
+      .start { server =>
+        val response = client(server).send(Request.get("/test"))
+        response.statusCode shouldBe 200
+        response.contentAsString shouldBe Some("Hello from /test")
+      }
+  }
+
+  test("curl client sends a POST body") {
+    NativeServer
+      .withHandler(req => Response.ok(s"Received: ${req.content.toContentString}"))
+      .withPort(0)
+      .start { server =>
+        val response = client(server).send(
+          Request.post("/data").withContent(HttpContent.text("payload"))
+        )
+        response.statusCode shouldBe 200
+        response.contentAsString shouldBe Some("Received: payload")
+      }
+  }
+
+  test("curl client round-trips request and response headers") {
+    NativeServer
+      .withHandler(req =>
+        Response.ok("ok").addHeader("X-Echoed", req.header("X-Echo").getOrElse("none"))
+      )
+      .withPort(0)
+      .start { server =>
+        val response = client(server).send(Request.get("/headers").addHeader("X-Echo", "ping"))
+        response.statusCode shouldBe 200
+        response.header("X-Echoed") shouldBe Some("ping")
+      }
+  }
+
+end NativeCurlClientTest


### PR DESCRIPTION
## Why

The Scala Native HTTP client (`CurlChannel`) failed on **every** request with `CURLE_URL_MALFORMAT` (code 3) on a valid loopback URL — so it was effectively unusable (prior work fell back to a raw POSIX-socket client to test the Native server).

## Root cause

`curl_easy_setopt` and `curl_easy_getinfo` are **C variadic** functions, but the bindings called them through **fixed-arity** `@extern` declarations. On arm64-apple-darwin the variadic argument is passed on the **stack** while a fixed-arity call places it in a **register**, so curl read garbage for the value — a valid URL became "malformed". (`setopt` returns OK because it only *stores* the pointer; `perform` then fails when it dereferences garbage.)

A `CVarArg*` variadic extern did **not** fix it either: Scala Native's variadic codegen does not pass the argument through for this function on this toolchain (verified — even a global `c"http://..."` literal URL still produced code 3).

## Fix

Route `setopt`/`getinfo` through tiny **fixed-arity C shims** that forward to the real variadic functions, so the C compiler emits the correct variadic call and Scala Native sees ordinary fixed-arity symbols:

- **`uni/.native/src/main/resources/scala-native/uni_curl_shim.c`** — `uni_curl_easy_setopt_ptr/_long` + `uni_curl_easy_getinfo_ptr`, forwarding to `curl_easy_setopt`/`curl_easy_getinfo`. It declares the curl prototypes locally, so **no libcurl headers are needed at build time** (the symbols resolve from the already-linked `-lcurl`).
- **`CurlBindings`** — the `Extern` object now declares the three shim functions; the `curl_easy_setopt_*` / `curl_easy_getinfo_long` wrappers call them (pointer options, the write/header callbacks via `CFuncPtr.toPtr`, the header slist, and the response-code out-pointer all go through the `_ptr` shim).

## Testing

New **`NativeCurlClientTest`** drives the real client against the in-process `NativeServer` over loopback: **GET** (exercises `CURLOPT_URL` + write callback + `getinfo` response code), **POST** (`POSTFIELDS`), and a **header round-trip** (`HTTPHEADER` slist) — all 200. `uniNative/test`: **1402 tests, 0 failed.** Native-only; no new dependency (the shim links against the existing libcurl).

Plan: `plans/2026-06-19-native-curl-client-fix.md`. Remaining follow-up: a cross-platform WebSocket client (+ WS ping/pong heartbeat, permessage-deflate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)