### PR TITLE
feature: Add a cross-platform WebSocket client API + JVM backend

### DIFF
--- a/plans/2026-06-19-websocket-client.md
+++ b/plans/2026-06-19-websocket-client.md
@@ -1,0 +1,33 @@
+# Cross-platform WebSocket client (PR 1: shared API + JVM)
+
+## Context
+The server side has WebSocket on all three backends, but there was no WebSocket *client*. This is the
+first of three PRs (JVM, then JS, then Native), delivered JVM-first so the public API can be reviewed
+before the other backends are built.
+
+## Design
+Reuse the existing shared `WebSocketHandler`/`WebSocketContext` so client and server handler code is
+symmetric (a client connection IS-A WebSocketContext whose `request` is the connect request).
+
+- **`WebSocketClient` (shared)** — `connect(uri, handler): Rx[WebSocketContext]`. The Rx emits the
+  open connection (for send/close) once the handshake completes, or fails with the handshake error;
+  `handler.onOpen` fires for the same event.
+- **`HttpChannelFactory.newWebSocketClient: WebSocketClient`** — new factory method with a default
+  that throws `NotImplementedError` (JS/Native inherit it until implemented; no per-platform change
+  needed yet). Surfaced as `Http.webSocketClient`.
+- **JVM (`JavaWebSocketClient`)** — backed by `java.net.http.WebSocket` (handshake/masking/framing
+  handled by the JDK). A `WebSocket.Listener` reassembles text/binary fragments (on `last`),
+  delivers to the handler, and guarantees `onClose` exactly once; `onOpen` calls `request(MaxValue)`.
+  The open connection is bridged to `Rx` via a `Promise[WebSocketContext]` + `Rx.future` (RxRunner
+  runs `Rx.future`; it does *not* run an `RxDeferred.get` node — that was the initial mistake).
+  Registered in `JVMHttpChannelFactory.newWebSocketClient`.
+
+## Verification
+`uni-netty` test starts a `NettyServer` with a `withWebSocketRoute` echo/push route and drives the new
+client over `ws://localhost:port`: text echo, server push on open, and onClose on disconnect. JVM
+suite 1635 passed; JS/Native compile (inherit the throwing default).
+
+## Follow-ups (this feature)
+PR 2 — JS backend (global `WebSocket`). PR 3 — Native backend (raw socket + the shared codec extended
+to client mode: mask outbound frames, decode unmasked server frames). Also: WS ping/pong heartbeat,
+permessage-deflate.

--- a/uni-netty/src/test/scala/wvlet/uni/http/netty/WebSocketClientTest.scala
+++ b/uni-netty/src/test/scala/wvlet/uni/http/netty/WebSocketClientTest.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http.netty
+
+import wvlet.uni.http.{Http, WebSocketContext, WebSocketHandler}
+import wvlet.uni.rx.{OnError, OnNext, RxRunner}
+import wvlet.uni.test.UniTest
+
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{CountDownLatch, LinkedBlockingQueue, TimeUnit}
+
+/**
+  * Verifies the shared `WebSocketClient` (JVM `java.net.http` backend) against a Netty server with
+  * a WebSocket route — a real client/server round-trip on the same `WebSocketHandler` abstraction.
+  */
+class WebSocketClientTest extends UniTest:
+
+  /** Open the connection and return its [[WebSocketContext]] (waits for the handshake). */
+  private def connect(uri: String, handler: WebSocketHandler): WebSocketContext =
+    val ref   = AtomicReference[WebSocketContext]()
+    val error = AtomicReference[Throwable]()
+    val ready = CountDownLatch(1)
+    RxRunner.runOnce(Http.webSocketClient.connect(uri, handler)) {
+      case OnNext(ctx) =>
+        ref.set(ctx.asInstanceOf[WebSocketContext]);
+        ready.countDown()
+      case OnError(e) =>
+        error.set(e);
+        ready.countDown()
+      case _ =>
+    }
+    ready.await(10, TimeUnit.SECONDS) shouldBe true
+    if error.get() != null then
+      throw error.get()
+    ref.get()
+
+  test("WebSocketClient connects and exchanges text messages") {
+    NettyServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/echo") { _ =>
+        new WebSocketHandler:
+          override def onTextMessage(ctx: WebSocketContext, message: String): Unit = ctx.send(
+            s"echo:${message}"
+          )
+      }
+      .start { server =>
+        val messages = LinkedBlockingQueue[String]()
+        val handler  =
+          new WebSocketHandler:
+            override def onTextMessage(ctx: WebSocketContext, message: String): Unit = messages.put(
+              message
+            )
+        val ctx = connect(s"ws://localhost:${server.localPort}/ws/echo", handler)
+        try
+          ctx.send("hello")
+          messages.poll(10, TimeUnit.SECONDS) shouldBe "echo:hello"
+        finally
+          ctx.close()
+      }
+  }
+
+  test("WebSocketClient receives a server push on open") {
+    NettyServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/push") { _ =>
+        new WebSocketHandler:
+          override def onOpen(ctx: WebSocketContext): Unit = ctx.send("welcome")
+      }
+      .start { server =>
+        val messages = LinkedBlockingQueue[String]()
+        val handler  =
+          new WebSocketHandler:
+            override def onTextMessage(ctx: WebSocketContext, message: String): Unit = messages.put(
+              message
+            )
+        val ctx = connect(s"ws://localhost:${server.localPort}/ws/push", handler)
+        try messages.poll(10, TimeUnit.SECONDS) shouldBe "welcome"
+        finally ctx.close()
+      }
+  }
+
+  test("WebSocketClient fires onClose when the connection ends") {
+    NettyServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/life") { _ =>
+        new WebSocketHandler {}
+      }
+      .start { server =>
+        val closed  = CountDownLatch(1)
+        val handler =
+          new WebSocketHandler:
+            override def onClose(ctx: WebSocketContext): Unit = closed.countDown()
+        val ctx = connect(s"ws://localhost:${server.localPort}/ws/life", handler)
+        ctx.close()
+        closed.await(10, TimeUnit.SECONDS) shouldBe true
+      }
+  }
+
+end WebSocketClientTest

--- a/uni/.jvm/src/main/scala/wvlet/uni/http/JVMHttpChannelFactory.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/http/JVMHttpChannelFactory.scala
@@ -25,4 +25,6 @@ object JVMHttpChannelFactory extends HttpChannelFactory:
 
   override def newAsyncChannel: HttpAsyncChannel = JavaHttpAsyncChannel()
 
+  override def newWebSocketClient: WebSocketClient = JavaWebSocketClient()
+
 end JVMHttpChannelFactory

--- a/uni/.jvm/src/main/scala/wvlet/uni/http/JavaWebSocketClient.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/http/JavaWebSocketClient.scala
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.rx.Rx
+
+import java.net.URI
+import java.net.http.{HttpClient, WebSocket}
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.{ExecutionContext, Promise}
+
+/**
+  * JVM WebSocket client backed by `java.net.http.WebSocket` (Java 11+), which performs the
+  * handshake, masking, and framing. This adapter bridges the JDK listener/socket to the shared
+  * [[WebSocketHandler]] / [[WebSocketContext]].
+  */
+class JavaWebSocketClient extends WebSocketClient:
+
+  private val httpClient         = HttpClient.newHttpClient()
+  private given ExecutionContext = ExecutionContext.parasitic
+
+  override def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext] =
+    val opened   = Promise[WebSocketContext]()
+    val listener = JavaWebSocketListener(handler, Request.get(uri), opened)
+    httpClient
+      .newWebSocketBuilder()
+      .buildAsync(URI.create(uri), listener)
+      .exceptionally { e =>
+        // buildAsync wraps the cause in a CompletionException.
+        opened.tryFailure(Option(e.getCause).getOrElse(e))
+        null
+      }
+    Rx.future(opened.future)
+
+end JavaWebSocketClient
+
+object JavaWebSocketClient:
+  def apply(): JavaWebSocketClient = new JavaWebSocketClient()
+
+/**
+  * JDK `WebSocket.Listener` that reassembles message fragments and delivers them to a
+  * [[WebSocketHandler]], guaranteeing `onClose` exactly once.
+  */
+private class JavaWebSocketListener(
+    handler: WebSocketHandler,
+    connectRequest: Request,
+    opened: Promise[WebSocketContext]
+) extends WebSocket.Listener:
+
+  private val textBuffer   = StringBuilder()
+  private val binaryBuffer = java.io.ByteArrayOutputStream()
+  private val closed       = AtomicBoolean(false)
+  @volatile
+  private var ctx: WebSocketContext = null
+
+  override def onOpen(webSocket: WebSocket): Unit =
+    // Request all messages up front so the JDK keeps delivering without per-message request() calls.
+    webSocket.request(Long.MaxValue)
+    val c = JavaWebSocketContext(webSocket, connectRequest)
+    ctx = c
+    try
+      handler.onOpen(c)
+    catch
+      case scala.util.control.NonFatal(e) =>
+        WebSocketDispatcher.safeOnError(handler, c, e)
+    opened.trySuccess(c)
+
+  override def onText(webSocket: WebSocket, data: CharSequence, last: Boolean): CompletionStage[?] =
+    textBuffer.append(data)
+    if last then
+      val message = textBuffer.toString
+      textBuffer.setLength(0)
+      deliver(() => handler.onTextMessage(ctx, message))
+    null
+
+  override def onBinary(webSocket: WebSocket, data: ByteBuffer, last: Boolean): CompletionStage[?] =
+    val chunk = new Array[Byte](data.remaining)
+    data.get(chunk)
+    binaryBuffer.write(chunk)
+    if last then
+      val message = binaryBuffer.toByteArray
+      binaryBuffer.reset()
+      deliver(() => handler.onBinaryMessage(ctx, message))
+    null
+
+  override def onClose(webSocket: WebSocket, statusCode: Int, reason: String): CompletionStage[?] =
+    notifyClose()
+    null
+
+  override def onError(webSocket: WebSocket, error: Throwable): Unit =
+    val c = ctx
+    if c != null then
+      WebSocketDispatcher.safeOnError(handler, c, error)
+    // No-op if the handshake already completed successfully.
+    opened.tryFailure(error)
+    notifyClose()
+
+  private def deliver(action: () => Unit): Unit =
+    try
+      action()
+    catch
+      case scala.util.control.NonFatal(e) =>
+        WebSocketDispatcher.safeOnError(handler, ctx, e)
+
+  private def notifyClose(): Unit =
+    if closed.compareAndSet(false, true) && ctx != null then
+      try
+        handler.onClose(ctx)
+      catch
+        case scala.util.control.NonFatal(_) =>
+          ()
+
+end JavaWebSocketListener
+
+/**
+  * [[WebSocketContext]] over a JDK `java.net.http.WebSocket`. `request` is the connect request.
+  *
+  * Note: the JDK requires each send to complete before the next is issued; this fire-and-forget
+  * adapter is intended for typical request/response style use, not high-rate concurrent sends.
+  */
+private class JavaWebSocketContext(webSocket: WebSocket, override val request: Request)
+    extends WebSocketContext:
+
+  override def send(text: String): Unit = webSocket.sendText(text, true)
+
+  override def send(data: Array[Byte]): Unit = webSocket.sendBinary(ByteBuffer.wrap(data), true)
+
+  override def close(): Unit = close(WebSocket.NORMAL_CLOSURE, "")
+
+  override def close(statusCode: Int, reason: String): Unit = webSocket.sendClose(
+    statusCode,
+    reason
+  )
+
+end JavaWebSocketContext

--- a/uni/.jvm/src/main/scala/wvlet/uni/http/JavaWebSocketClient.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/http/JavaWebSocketClient.scala
@@ -18,7 +18,7 @@ import wvlet.uni.rx.Rx
 import java.net.URI
 import java.net.http.{HttpClient, WebSocket}
 import java.nio.ByteBuffer
-import java.util.concurrent.CompletionStage
+import java.util.concurrent.{CompletableFuture, CompletionStage}
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.{ExecutionContext, Promise}
 
@@ -29,13 +29,13 @@ import scala.concurrent.{ExecutionContext, Promise}
   */
 class JavaWebSocketClient extends WebSocketClient:
 
-  private val httpClient         = HttpClient.newHttpClient()
   private given ExecutionContext = ExecutionContext.parasitic
 
   override def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext] =
     val opened   = Promise[WebSocketContext]()
     val listener = JavaWebSocketListener(handler, Request.get(uri), opened)
-    httpClient
+    JavaWebSocketClient
+      .sharedHttpClient
       .newWebSocketBuilder()
       .buildAsync(URI.create(uri), listener)
       .exceptionally { e =>
@@ -48,6 +48,10 @@ class JavaWebSocketClient extends WebSocketClient:
 end JavaWebSocketClient
 
 object JavaWebSocketClient:
+  // One HttpClient (and its thread pools) shared across all client instances — Http.webSocketClient
+  // builds a new JavaWebSocketClient per call, so a per-instance HttpClient would leak threads.
+  private lazy val sharedHttpClient: HttpClient = HttpClient.newHttpClient()
+
   def apply(): JavaWebSocketClient = new JavaWebSocketClient()
 
 /**
@@ -101,10 +105,9 @@ private class JavaWebSocketListener(
     null
 
   override def onError(webSocket: WebSocket, error: Throwable): Unit =
-    val c = ctx
-    if c != null then
-      WebSocketDispatcher.safeOnError(handler, c, error)
-    // No-op if the handshake already completed successfully.
+    // Transport/protocol errors map to onClose (not onError), matching the server backends — onError
+    // is reserved for exceptions thrown by handler callbacks (see WebSocketDispatcher). A pre-open
+    // failure still surfaces on the connect Rx via the promise.
     opened.tryFailure(error)
     notifyClose()
 
@@ -127,22 +130,30 @@ end JavaWebSocketListener
 
 /**
   * [[WebSocketContext]] over a JDK `java.net.http.WebSocket`. `request` is the connect request.
-  *
-  * Note: the JDK requires each send to complete before the next is issued; this fire-and-forget
-  * adapter is intended for typical request/response style use, not high-rate concurrent sends.
+  * Sends are serialized through a future chain (the JDK forbids overlapping sends).
   */
 private class JavaWebSocketContext(webSocket: WebSocket, override val request: Request)
     extends WebSocketContext:
 
-  override def send(text: String): Unit = webSocket.sendText(text, true)
+  // The JDK WebSocket requires each send to complete before the next is issued (else it throws
+  // IllegalStateException), so serialize sends through a single CompletableFuture chain. The
+  // `exceptionally` keeps the chain alive after a failed send rather than wedging all later sends.
+  private val sendLock                                = Object()
+  private var sendChain: CompletableFuture[WebSocket] = CompletableFuture.completedFuture(webSocket)
 
-  override def send(data: Array[Byte]): Unit = webSocket.sendBinary(ByteBuffer.wrap(data), true)
+  private def enqueue(send: WebSocket => CompletableFuture[WebSocket]): Unit = sendLock
+    .synchronized {
+      sendChain = sendChain.thenCompose(ws => send(ws)).exceptionally(_ => webSocket)
+    }
+
+  override def send(text: String): Unit = enqueue(_.sendText(text, true))
+
+  override def send(data: Array[Byte]): Unit = enqueue(_.sendBinary(ByteBuffer.wrap(data), true))
 
   override def close(): Unit = close(WebSocket.NORMAL_CLOSURE, "")
 
-  override def close(statusCode: Int, reason: String): Unit = webSocket.sendClose(
-    statusCode,
-    reason
+  override def close(statusCode: Int, reason: String): Unit = enqueue(
+    _.sendClose(statusCode, reason)
   )
 
 end JavaWebSocketContext

--- a/uni/src/main/scala/wvlet/uni/http/Http.scala
+++ b/uni/src/main/scala/wvlet/uni/http/Http.scala
@@ -39,6 +39,12 @@ object Http:
   def client: HttpClientConfig = HttpClientConfig.default.withChannelFactory(defaultChannelFactory)
 
   /**
+    * Entry point for opening WebSocket client connections, using the default platform-specific
+    * channel factory. Currently implemented on the JVM.
+    */
+  def webSocketClient: WebSocketClient = defaultChannelFactory.newWebSocketClient
+
+  /**
     * Default HTTP channel factory. Initialized from the platform-specific
     * `HttpCompat.defaultHttpChannelFactory` so cross-platform callers can use
     * `Http.client.newSyncClient` without per-platform setup. Callers that need a non-default

--- a/uni/src/main/scala/wvlet/uni/http/HttpChannel.scala
+++ b/uni/src/main/scala/wvlet/uni/http/HttpChannel.scala
@@ -103,3 +103,9 @@ trait HttpChannelFactory:
     * Create a new asynchronous HTTP channel
     */
   def newAsyncChannel: HttpAsyncChannel
+
+  /**
+    * Create a WebSocket client. Platforms that don't yet implement one throw.
+    */
+  def newWebSocketClient: WebSocketClient =
+    throw NotImplementedError("WebSocket client is not supported on this platform")

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketClient.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketClient.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.rx.Rx
+
+/**
+  * A client for opening WebSocket connections. Reuses the same [[WebSocketHandler]] /
+  * [[WebSocketContext]] abstraction as the server side, so handler code is symmetric.
+  */
+trait WebSocketClient:
+
+  /**
+    * Connect to a `ws://` or `wss://` URL. The `handler` receives the connection's lifecycle
+    * callbacks (`onOpen`/`onTextMessage`/`onBinaryMessage`/`onClose`/`onError`). The returned `Rx`
+    * emits the open [[WebSocketContext]] — used to `send`/`close` — once the handshake completes,
+    * or fails with the handshake error. (`handler.onOpen` fires for the same event.)
+    */
+  def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext]
+
+end WebSocketClient


### PR DESCRIPTION
## Why

The server side has WebSocket on all three backends (JVM/Netty, Node, Native), but there was no WebSocket **client**. This is the **first of three PRs** (JVM → JS → Native), delivered **JVM-first so the public API can be reviewed** before the other backends are built.

## API (shared)

Reuses the existing `WebSocketHandler`/`WebSocketContext`, so client and server handler code is symmetric (a client connection IS-A `WebSocketContext` whose `request` is the connect request):

```scala
val handler = new WebSocketHandler:
  override def onTextMessage(ctx: WebSocketContext, msg: String): Unit = println(msg)

Http.webSocketClient
  .connect("ws://localhost:8080/ws", handler)   // : Rx[WebSocketContext]
  .map { conn => conn.send("hello") }
```

- **`WebSocketClient.connect(uri, handler): Rx[WebSocketContext]`** — the `Rx` emits the open connection (for `send`/`close`) once the handshake completes, or fails with the handshake error; `handler.onOpen` fires for the same event.
- **`HttpChannelFactory.newWebSocketClient`** — new factory method with a default that throws `NotImplementedError`, so **JS/Native compile unchanged** until they're implemented. Surfaced as `Http.webSocketClient`.

## JVM backend

`JavaWebSocketClient` is backed by **`java.net.http.WebSocket`** (handshake/masking/framing handled by the JDK). A `WebSocket.Listener` reassembles text/binary fragments (on `last`), delivers to the handler, and guarantees `onClose` exactly once (`onOpen` requests `Long.MaxValue`). The open connection is bridged to `Rx` via a `Promise[WebSocketContext]` + `Rx.future`. Registered in `JVMHttpChannelFactory`.

## Testing
A `uni-netty` test starts a `NettyServer` with `withWebSocketRoute` echo/push routes and drives the **new client** over `ws://localhost:port`: text echo, server push on open, and `onClose` on disconnect. **JVM suite: 1635 passed**; JS/Native compile (they inherit the throwing default). No new dependency.

Plan: `plans/2026-06-19-websocket-client.md`.

### Up next (after your review of this API)
- **PR 2** — JS backend (global `WebSocket`).
- **PR 3** — Native backend (raw socket + the shared codec extended to **client mode**: mask outbound frames, decode *unmasked* server frames).

🤖 Generated with [Claude Code](https://claude.com/claude-code)