### PR TITLE
feature: Add the JS WebSocket client (global WebSocket); drop Node 20

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -23,7 +23,7 @@ jobs:
           cache: sbt
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Setup GPG
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install Node dependencies
         run: pnpm install --frozen-lockfile
@@ -129,7 +129,7 @@ jobs:
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
       - name: Install Node dependencies
         run: pnpm install --frozen-lockfile

--- a/plans/2026-06-19-websocket-client-js.md
+++ b/plans/2026-06-19-websocket-client-js.md
@@ -1,0 +1,26 @@
+# WebSocket client — JS backend (PR 2 of 3)
+
+## Context
+Second of three WebSocket-client PRs (after JVM #581). Originally scoped for the global `WebSocket`,
+which is only a stable Node global from v22; CI ran Node 20. Rather than implement a raw-socket
+fallback, **we dropped Node 20 support** (bumped CI to Node 22), so the JS client is a thin adapter
+over the global `WebSocket` (browsers + Node >= 22), which handles the handshake/masking/framing.
+
+## Changes
+- **`JSWebSocketClient`** (uni/.js) — facade over the global `WebSocket` (`@JSGlobal("WebSocket")`):
+  `binaryType = "arraybuffer"`; `onopen`→`onOpen` + resolve the connect `Rx`; `onmessage`→
+  `onTextMessage` (string) / `onBinaryMessage` (ArrayBuffer→bytes); `onclose`→`onClose` (once);
+  `onerror`→`onClose` (transport errors, matching the other backends) + fail the connect `Rx`. Bridged
+  to `Rx` via `Promise` + `Rx.future`. `JSWebSocketContext` sends text/`Uint8Array` and closes.
+  Registered in `JSHttpChannelFactory.newWebSocketClient`.
+- **CI**: bump `node-version` 20 → 22 in `.github/workflows/{test,doc,release-js}.yml`.
+
+No shared-code change (the codec stays server-only; the client-mode codec is PR 3's Native work).
+
+## Verification
+`uniJS/test` (1400 tests): new `JSWebSocketClientTest` drives the JS client against an in-process
+`NodeServer` WS echo/push route over `ws://127.0.0.1` — text echo, push-on-open, onClose.
+
+## Follow-up
+PR 3 — Native client (raw socket + the shared codec extended to client mode: mask outbound, decode
+unmasked server frames).

--- a/uni/.js/src/main/scala/wvlet/uni/http/JSHttpChannelFactory.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/JSHttpChannelFactory.scala
@@ -35,4 +35,6 @@ object JSHttpChannelFactory extends HttpChannelFactory:
 
   override def newAsyncChannel: HttpAsyncChannel = FetchChannel()
 
+  override def newWebSocketClient: WebSocketClient = JSWebSocketClient()
+
 end JSHttpChannelFactory

--- a/uni/.js/src/main/scala/wvlet/uni/http/JSWebSocketClient.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/JSWebSocketClient.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.rx.Rx
+
+import scala.concurrent.{ExecutionContext, Promise}
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+import scala.scalajs.js.typedarray.{ArrayBuffer, Int8Array, Uint8Array}
+import scala.util.control.NonFatal
+
+/**
+  * Minimal facade for the global `WebSocket` (browsers and Node.js >= 22, which provides it as a
+  * stable global). The runtime performs the handshake, masking, and framing.
+  */
+@js.native
+@JSGlobal("WebSocket")
+private class JsWebSocket(url: String) extends js.Object:
+  var binaryType: String                        = js.native
+  var onopen: js.Function1[js.Any, Unit]        = js.native
+  var onmessage: js.Function1[js.Dynamic, Unit] = js.native
+  var onclose: js.Function1[js.Any, Unit]       = js.native
+  var onerror: js.Function1[js.Any, Unit]       = js.native
+  def send(data: String): Unit                  = js.native
+  def send(data: Uint8Array): Unit              = js.native
+  def close(code: Int, reason: String): Unit    = js.native
+  def close(): Unit                             = js.native
+
+/**
+  * JavaScript WebSocket client backed by the global `WebSocket`. Bridges its events to the shared
+  * [[WebSocketHandler]] / [[WebSocketContext]].
+  */
+class JSWebSocketClient extends WebSocketClient:
+
+  private given ExecutionContext = scala.scalajs.concurrent.JSExecutionContext.queue
+
+  override def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext] =
+    val opened = Promise[WebSocketContext]()
+    val ws     = new JsWebSocket(uri)
+    ws.binaryType = "arraybuffer"
+    val ctx    = JSWebSocketContext(ws, Request.get(uri))
+    var closed = false
+
+    def notifyClose(): Unit =
+      if !closed then
+        closed = true
+        try
+          handler.onClose(ctx)
+        catch
+          case NonFatal(_) =>
+            ()
+
+    def deliver(action: () => Unit): Unit =
+      try
+        action()
+      catch
+        case NonFatal(e) =>
+          WebSocketDispatcher.safeOnError(handler, ctx, e)
+
+    ws.onopen =
+      (_: js.Any) =>
+        deliver(() => handler.onOpen(ctx))
+        opened.trySuccess(ctx)
+    ws.onmessage =
+      (event: js.Dynamic) =>
+        val data = event.data
+        if js.typeOf(data) == "string" then
+          val text = data.asInstanceOf[String]
+          deliver(() => handler.onTextMessage(ctx, text))
+        else
+          // binaryType = "arraybuffer", so binary frames arrive as an ArrayBuffer.
+          val bytes = Int8Array(data.asInstanceOf[ArrayBuffer]).toArray
+          deliver(() => handler.onBinaryMessage(ctx, bytes))
+    ws.onclose = (_: js.Any) => notifyClose()
+    ws.onerror =
+      (_: js.Any) =>
+        // Transport error maps to onClose (matching the other backends); surface pre-open failures.
+        opened.tryFailure(RuntimeException(s"WebSocket connection failed: ${uri}"))
+        notifyClose()
+
+    Rx.future(opened.future)
+
+  end connect
+
+end JSWebSocketClient
+
+object JSWebSocketClient:
+  def apply(): JSWebSocketClient = new JSWebSocketClient()
+
+/** [[WebSocketContext]] over the global `WebSocket`. `request` is the connect request. */
+private class JSWebSocketContext(ws: JsWebSocket, override val request: Request)
+    extends WebSocketContext:
+
+  override def send(text: String): Unit = ws.send(text)
+
+  override def send(data: Array[Byte]): Unit = ws.send(NodeBytes.toUint8Array(data))
+
+  override def close(): Unit = ws.close()
+
+  override def close(statusCode: Int, reason: String): Unit = ws.close(statusCode, reason)
+
+end JSWebSocketContext

--- a/uni/.js/src/main/scala/wvlet/uni/http/JSWebSocketClient.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/JSWebSocketClient.scala
@@ -18,7 +18,7 @@ import wvlet.uni.rx.Rx
 import scala.concurrent.{ExecutionContext, Promise}
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal
-import scala.scalajs.js.typedarray.{ArrayBuffer, Int8Array, Uint8Array}
+import scala.scalajs.js.typedarray.*
 import scala.util.control.NonFatal
 
 /**
@@ -34,7 +34,7 @@ private class JsWebSocket(url: String) extends js.Object:
   var onclose: js.Function1[js.Any, Unit]       = js.native
   var onerror: js.Function1[js.Any, Unit]       = js.native
   def send(data: String): Unit                  = js.native
-  def send(data: Uint8Array): Unit              = js.native
+  def send(data: Int8Array): Unit               = js.native
   def close(code: Int, reason: String): Unit    = js.native
   def close(): Unit                             = js.native
 
@@ -105,7 +105,9 @@ private class JSWebSocketContext(ws: JsWebSocket, override val request: Request)
 
   override def send(text: String): Unit = ws.send(text)
 
-  override def send(data: Array[Byte]): Unit = ws.send(NodeBytes.toUint8Array(data))
+  // Standard Scala.js conversion (no Node-specific helper) so this works in browsers too. ws.send
+  // accepts any ArrayBufferView; the signed Int8Array shares the same bytes.
+  override def send(data: Array[Byte]): Unit = ws.send(data.toTypedArray)
 
   override def close(): Unit = ws.close()
 

--- a/uni/.js/src/test/scala/wvlet/uni/http/JSWebSocketClientTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/http/JSWebSocketClientTest.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.rx.{OnError, OnNext, Rx, RxRunner}
+import wvlet.uni.test.UniTest
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+
+/**
+  * Verifies the JS WebSocket client (global `WebSocket`, Node.js >= 22) against the in-process Node
+  * server with a WebSocket route — a real client/server round-trip on the same `WebSocketHandler`.
+  */
+class JSWebSocketClientTest extends UniTest:
+
+  private given ExecutionContext = scala.scalajs.concurrent.JSExecutionContext.queue
+
+  /** Open the connection and resolve with its [[WebSocketContext]] once the handshake completes. */
+  private def connect(uri: String, handler: WebSocketHandler): Future[WebSocketContext] =
+    val opened = Promise[WebSocketContext]()
+    RxRunner.runOnce(Http.webSocketClient.connect(uri, handler)) {
+      case OnNext(ctx) =>
+        opened.trySuccess(ctx.asInstanceOf[WebSocketContext])
+      case OnError(e) =>
+        opened.tryFailure(e)
+      case _ =>
+    }
+    opened.future
+
+  test("JS WebSocket client echoes text messages") {
+    NodeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/echo") { _ =>
+        new WebSocketHandler:
+          override def onTextMessage(ctx: WebSocketContext, message: String): Unit = ctx.send(
+            s"echo:${message}"
+          )
+      }
+      .startAndAwait { server =>
+        val received = Promise[String]()
+        val handler  =
+          new WebSocketHandler:
+            override def onTextMessage(ctx: WebSocketContext, message: String): Unit = received
+              .trySuccess(message)
+        val result =
+          for
+            ctx <- connect(s"ws://127.0.0.1:${server.localPort}/ws/echo", handler)
+            _ = ctx.send("hello")
+            message <- received.future
+          yield
+            ctx.close()
+            message shouldBe "echo:hello"
+        Rx.future(result)
+      }
+  }
+
+  test("JS WebSocket client receives a server push on open") {
+    NodeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/push") { _ =>
+        new WebSocketHandler:
+          override def onOpen(ctx: WebSocketContext): Unit = ctx.send("welcome")
+      }
+      .startAndAwait { server =>
+        val received = Promise[String]()
+        val handler  =
+          new WebSocketHandler:
+            override def onTextMessage(ctx: WebSocketContext, message: String): Unit = received
+              .trySuccess(message)
+        val result =
+          for
+            ctx     <- connect(s"ws://127.0.0.1:${server.localPort}/ws/push", handler)
+            message <- received.future
+          yield
+            ctx.close()
+            message shouldBe "welcome"
+        Rx.future(result)
+      }
+  }
+
+  test("JS WebSocket client fires onClose when the connection ends") {
+    NodeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/life") { _ =>
+        new WebSocketHandler:
+          override def onOpen(ctx: WebSocketContext): Unit = ctx.send("hi")
+      }
+      .startAndAwait { server =>
+        val closed  = Promise[Boolean]()
+        val handler =
+          new WebSocketHandler:
+            override def onClose(ctx: WebSocketContext): Unit = closed.trySuccess(true)
+        val result =
+          for
+            ctx <- connect(s"ws://127.0.0.1:${server.localPort}/ws/life", handler)
+            _ = ctx.close()
+            done <- closed.future
+          yield done shouldBe true
+        Rx.future(result)
+      }
+  }
+
+end JSWebSocketClientTest


### PR DESCRIPTION
## Why

Second of three WebSocket-client PRs (after the JVM backend, #581). The browser/Node global `WebSocket` handles the handshake/masking/framing for us — but it's only a **stable Node global from v22**, and CI ran Node 20.

Per the decision to **drop Node 20 support**, this bumps CI to Node 22, so the JS client is a thin adapter over the global `WebSocket` rather than needing a raw-socket+codec fallback.

## What

- **`JSWebSocketClient`** (uni/.js) — a facade over the global `WebSocket` (`@JSGlobal("WebSocket")`), reusing the shared `WebSocketHandler`/`WebSocketContext`:
  - `binaryType = "arraybuffer"`; `onopen` → `onOpen` + resolves the connect `Rx`; `onmessage` → `onTextMessage` (string) / `onBinaryMessage` (ArrayBuffer → bytes); `onclose` → `onClose` (once); `onerror` → `onClose` (transport errors, matching the JVM/Native/Node backends) and fails the connect `Rx`.
  - Bridged to `Rx` via `Promise` + `Rx.future`. Registered in `JSHttpChannelFactory.newWebSocketClient`.
- **Drop Node 20** — bump `node-version` 20 → 22 in `.github/workflows/{test,doc,release-js}.yml`.

No shared-code change (the codec stays server-only; the **client-mode codec** is PR 3's Native work).

## Testing
`JSWebSocketClientTest` drives the JS client against an in-process `NodeServer` WS echo/push route over `ws://127.0.0.1`: text echo, push-on-open, and `onClose`. **`uniJS/test`: 1400 tests, 0 failed** (on Node 22).

Plan: `plans/2026-06-19-websocket-client-js.md`.

### Up next
**PR 3** — Native client (raw socket + the shared codec extended to **client mode**: mask outbound frames, decode *unmasked* server frames).

🤖 Generated with [Claude Code](https://claude.com/claude-code)