### PR TITLE
feature: Add the Native WebSocket client (raw socket + shared client-mode codec)

### DIFF
--- a/plans/2026-06-19-websocket-client-native.md
+++ b/plans/2026-06-19-websocket-client-native.md
@@ -1,0 +1,35 @@
+# WebSocket client — Native backend (PR 3 of 3)
+
+## Context
+Final WebSocket-client PR (after JVM #581, JS #582). Native has no built-in WebSocket, so the client
+is hand-rolled over a raw POSIX socket, reusing the shared codec — which is generalized here to
+client mode.
+
+## Changes
+- **Shared codec client-mode** (used by the Native client; server unchanged):
+  - `WebSocketFrameDecoder(maxFrameSize, expectMasked = true)` — `expectMasked=false` accepts the
+    unmasked server->client frames a client receives and rejects a masked one (1002); the unmask
+    step is skipped when unmasked. Server callers keep the masked-required default.
+  - `WebSocketFrame`: `encodeMaskedFrame(opcode, payload, mask)` for client sends, `newMaskingKey()`
+    (4 bytes), `newClientKey()` (base64 of 16 random bytes for `Sec-WebSocket-Key`), and a shared
+    `frameHeader` helper. Cross-platform decoder tests cover client-mode decode + masked-frame reject.
+- **`NativeSocket.connect(host, port)`** — open a client TCP connection (IPv4/"localhost").
+- **`NativeWebSocketClient`** — connect, send the upgrade GET (random key), validate the 101 +
+  `Sec-WebSocket-Accept`, then drive `WebSocketFrameDecoder(expectMasked=false)` on a daemon reader
+  thread bridging to the handler (via the shared `WebSocketDispatcher`); `onOpen` before the reader
+  starts, `onClose` exactly once. `NativeWebSocketClientContext` masks every outbound frame and
+  serializes writes. `ws://` only (no TLS on the raw socket). Registered in
+  `NativeHttpChannelFactory.newWebSocketClient`.
+
+## Verification
+`NativeWebSocketClientTest` drives the Native client against the in-process `NativeServer` WS
+echo/push route (text echo, push-on-open, onClose). All platforms green: JVM 1637 / JS 1389 /
+Native 1398 / Netty 37. The server suites confirm the codec generalization didn't regress the
+masked (server) path.
+
+## Result
+WebSocket client now works on all three backends (JVM/Netty java.net.http, JS global WebSocket,
+Native raw socket + shared codec), on the same `WebSocketClient`/`WebSocketHandler`/`WebSocketContext`.
+
+## Remaining follow-ups
+WS ping/pong heartbeat (server + client); permessage-deflate.

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpChannelFactory.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpChannelFactory.scala
@@ -53,4 +53,6 @@ object NativeHttpChannelFactory extends HttpChannelFactory:
       )
     CurlAsyncChannel()
 
+  override def newWebSocketClient: WebSocketClient = NativeWebSocketClient()
+
 end NativeHttpChannelFactory

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
@@ -88,11 +88,16 @@ private[http] object NativeSocket:
     cstring.memset(addr.asInstanceOf[Ptr[Byte]], 0, sizeof[sockaddr_in])
     addr.sin_family = csocket.AF_INET.toUShort
     addr.sin_port = inet.htons(port.toUShort)
-    setBindAddress(addr, host)
-    if csocket.connect(fd, addr.asInstanceOf[Ptr[sockaddr]], sizeof[sockaddr_in].toUInt) < 0 then
-      unistd.close(fd)
-      throw HttpException.connectionFailed(s"Failed to connect to ${host}:${port}")
-    fd
+    // Close the fd on any failure (e.g. setBindAddress rejecting an invalid host) — don't leak it.
+    try
+      setBindAddress(addr, host)
+      if csocket.connect(fd, addr.asInstanceOf[Ptr[sockaddr]], sizeof[sockaddr_in].toUInt) < 0 then
+        throw HttpException.connectionFailed(s"Failed to connect to ${host}:${port}")
+      fd
+    catch
+      case e: Throwable =>
+        unistd.close(fd)
+        throw e
 
   private def setBindAddress(addr: Ptr[sockaddr_in], host: String): Unit =
     // INADDR_ANY (0) for wildcard; otherwise parse a dotted-quad. "localhost" maps to loopback.

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
@@ -225,4 +225,7 @@ private[http] object NativeSocket:
 
   def close(fd: Int): Unit = unistd.close(fd)
 
+  /** Shut down both directions, unblocking any thread parked in `recv` on this fd. */
+  def shutdown(fd: Int): Unit = csocket.shutdown(fd, csocket.SHUT_RDWR)
+
 end NativeSocket

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeSocket.scala
@@ -75,6 +75,25 @@ private[http] object NativeSocket:
 
   end bindAndListen
 
+  /**
+    * Open a TCP connection to host:port (IPv4 dotted-quad or "localhost"). Returns the client fd.
+    */
+  def connect(host: String, port: Int): Int =
+    if port < 0 || port > 65535 then
+      throw HttpException.connectionFailed(s"Invalid port: ${port}")
+    val fd = csocket.socket(csocket.AF_INET, csocket.SOCK_STREAM, 0)
+    if fd < 0 then
+      throw HttpException.connectionFailed("Failed to create socket")
+    val addr = stackalloc[sockaddr_in]()
+    cstring.memset(addr.asInstanceOf[Ptr[Byte]], 0, sizeof[sockaddr_in])
+    addr.sin_family = csocket.AF_INET.toUShort
+    addr.sin_port = inet.htons(port.toUShort)
+    setBindAddress(addr, host)
+    if csocket.connect(fd, addr.asInstanceOf[Ptr[sockaddr]], sizeof[sockaddr_in].toUInt) < 0 then
+      unistd.close(fd)
+      throw HttpException.connectionFailed(s"Failed to connect to ${host}:${port}")
+    fd
+
   private def setBindAddress(addr: Ptr[sockaddr_in], host: String): Unit =
     // INADDR_ANY (0) for wildcard; otherwise parse a dotted-quad. "localhost" maps to loopback.
     val normalized =

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocketClient.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocketClient.scala
@@ -1,0 +1,227 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.log.LogSupport
+import wvlet.uni.rx.Rx
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.collection.mutable
+import scala.util.control.NonFatal
+
+/**
+  * Scala Native WebSocket client over a raw POSIX socket: connects, performs the handshake, then
+  * drives the shared [[WebSocketFrameDecoder]] (client mode — server frames are unmasked) on a
+  * daemon reader thread, bridging to a [[WebSocketHandler]]. Outbound frames are masked (RFC 6455
+  * §5.3). Only `ws://` is supported (no TLS on the raw socket).
+  */
+class NativeWebSocketClient extends WebSocketClient with LogSupport:
+
+  override def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext] =
+    try
+      val target = NativeWebSocketClient.parse(uri)
+      val fd     = NativeSocket.connect(target.host, target.port)
+      try
+        val key     = WebSocketFrame.newClientKey()
+        val request =
+          s"GET ${target.path} HTTP/1.1\r\nHost: ${target.host}:${target.port}\r\n" +
+            s"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+            s"Sec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n"
+        if !NativeSocket.sendAll(fd, request.getBytes(StandardCharsets.ISO_8859_1)) then
+          throw HttpException.connectionFailed("Failed to send the WebSocket upgrade request")
+
+        val handshake = NativeWebSocketClient.readHandshake(fd)
+        if handshake.status != 101 then
+          throw HttpException.connectionFailed(s"WebSocket upgrade rejected: ${handshake.status}")
+        if handshake.headers.getOrElse("sec-websocket-accept", "") != WebSocketFrame.acceptKey(key)
+        then
+          throw HttpException.connectionFailed("Invalid Sec-WebSocket-Accept in the handshake")
+
+        val ctx                 = NativeWebSocketClientContext(fd, Request.get(uri))
+        val closeNotified       = AtomicBoolean(false)
+        def notifyClose(): Unit =
+          if closeNotified.compareAndSet(false, true) then
+            try
+              handler.onClose(ctx)
+            catch
+              case NonFatal(e) =>
+                warn(s"onClose error: ${e.getMessage}")
+
+        // onOpen before the reader starts, so it precedes any delivered message.
+        try
+          handler.onOpen(ctx)
+        catch
+          case NonFatal(e) =>
+            WebSocketDispatcher.safeOnError(handler, ctx, e)
+
+        val reader = Thread(() =>
+          try
+            val decoder = WebSocketFrameDecoder(
+              NativeWebSocketClient.MaxFrameSize,
+              expectMasked = false
+            )
+            def feed(bytes: Array[Byte]): Boolean =
+              decoder.feed(bytes)(ev =>
+                WebSocketDispatcher.dispatch(handler, ctx, ctx.sendPong, () => notifyClose(), ev)
+              )
+            var open = handshake.leftover.isEmpty || feed(handshake.leftover)
+            while open do
+              val chunk = NativeSocket.recvChunk(fd)
+              if chunk.isEmpty then
+                open = false
+              else
+                open = feed(chunk)
+          catch
+            case NonFatal(e) =>
+              WebSocketDispatcher.safeOnError(handler, ctx, e)
+          finally
+            notifyClose()
+            NativeSocket.close(fd)
+        )
+        reader.setDaemon(true)
+        reader.setName("native-ws-client-reader")
+        reader.start()
+
+        Rx.single(ctx)
+      catch
+        case NonFatal(e) =>
+          NativeSocket.close(fd)
+          Rx.exception(e)
+      end try
+    catch
+      case NonFatal(e) =>
+        Rx.exception(e)
+
+end NativeWebSocketClient
+
+object NativeWebSocketClient:
+  private final val MaxFrameSize = 1024 * 1024
+
+  def apply(): NativeWebSocketClient = new NativeWebSocketClient()
+
+  private case class Target(host: String, port: Int, path: String)
+
+  /**
+    * The parsed handshake response: status code, lower-cased headers, and any buffered frame bytes.
+    */
+  private case class Handshake(status: Int, headers: Map[String, String], leftover: Array[Byte])
+
+  private def parse(uri: String): Target =
+    if uri.startsWith("wss://") then
+      throw HttpException.connectionFailed("wss:// (TLS) is not supported by the Native client")
+    val rest      = uri.stripPrefix("ws://")
+    val slash     = rest.indexOf('/')
+    val authority =
+      if slash >= 0 then
+        rest.substring(0, slash)
+      else
+        rest
+    val path =
+      if slash >= 0 then
+        rest.substring(slash)
+      else
+        "/"
+    val colon = authority.indexOf(':')
+    val host  =
+      if colon >= 0 then
+        authority.substring(0, colon)
+      else
+        authority
+    val port =
+      if colon >= 0 then
+        authority.substring(colon + 1).toInt
+      else
+        80
+    Target(host, port, path)
+
+  /**
+    * Read the HTTP upgrade response up to the header terminator; retain any frame bytes that
+    * follow.
+    */
+  private def readHandshake(fd: Int): Handshake =
+    val buf = mutable.ArrayBuffer.empty[Byte]
+    var end = -1
+    while end < 0 do
+      val chunk = NativeSocket.recvChunk(fd)
+      if chunk.isEmpty then
+        throw HttpException.connectionFailed("Connection closed during the WebSocket handshake")
+      buf ++= chunk
+      end = headerEnd(buf)
+    val head     = new String(buf.slice(0, end).toArray, StandardCharsets.ISO_8859_1)
+    val leftover = buf.slice(end + 4, buf.length).toArray
+    val lines    = head.split("\r\n")
+    val status   = lines(0).split(" ")(1).toInt
+    val headers  =
+      lines
+        .drop(1)
+        .flatMap { line =>
+          val c = line.indexOf(':')
+          if c > 0 then
+            Some(line.substring(0, c).trim.toLowerCase -> line.substring(c + 1).trim)
+          else
+            None
+        }
+        .toMap
+    Handshake(status, headers, leftover)
+
+  private def headerEnd(buf: mutable.ArrayBuffer[Byte]): Int =
+    var i = 0
+    while i + 3 < buf.length do
+      if buf(i) == '\r' && buf(i + 1) == '\n' && buf(i + 2) == '\r' && buf(i + 3) == '\n' then
+        return i
+      i += 1
+    -1
+
+end NativeWebSocketClient
+
+/**
+  * Native client [[WebSocketContext]]. Outbound frames are masked (client->server requirement);
+  * writes are serialized so `send`/`close` are safe from any thread.
+  */
+private class NativeWebSocketClientContext(clientFd: Int, override val request: Request)
+    extends WebSocketContext:
+
+  private val writeLock = Object()
+  private val closed    = AtomicBoolean(false)
+
+  override def send(text: String): Unit = sendFrameIfOpen(
+    WebSocketFrame.OpText,
+    text.getBytes(StandardCharsets.UTF_8)
+  )
+
+  override def send(data: Array[Byte]): Unit = sendFrameIfOpen(WebSocketFrame.OpBinary, data)
+
+  override def close(): Unit = close(1000, "")
+
+  override def close(statusCode: Int, reason: String): Unit =
+    if closed.compareAndSet(false, true) then
+      writeFrame(WebSocketFrame.OpClose, WebSocketFrame.closePayload(statusCode, reason))
+
+  private[http] def sendPong(payload: Array[Byte]): Unit =
+    if !closed.get() then
+      writeFrame(WebSocketFrame.OpPong, payload)
+
+  private def sendFrameIfOpen(opcode: Int, payload: Array[Byte]): Unit =
+    if !closed.get() then
+      writeFrame(opcode, payload)
+
+  private def writeFrame(opcode: Int, payload: Array[Byte]): Unit = writeLock.synchronized {
+    NativeSocket.sendAll(
+      clientFd,
+      WebSocketFrame.encodeMaskedFrame(opcode, payload, WebSocketFrame.newMaskingKey())
+    )
+  }
+
+end NativeWebSocketClientContext

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocketClient.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocketClient.scala
@@ -25,7 +25,11 @@ import scala.util.control.NonFatal
   * Scala Native WebSocket client over a raw POSIX socket: connects, performs the handshake, then
   * drives the shared [[WebSocketFrameDecoder]] (client mode — server frames are unmasked) on a
   * daemon reader thread, bridging to a [[WebSocketHandler]]. Outbound frames are masked (RFC 6455
-  * §5.3). Only `ws://` is supported (no TLS on the raw socket).
+  * §5.3).
+  *
+  * Limitations: `ws://` only (no TLS on the raw socket); the host must be a dotted-quad IP or
+  * `localhost` (no DNS); `connect` blocks the caller through the TCP connect + handshake (the
+  * handshake read is bounded/timed, but the TCP connect itself has no timeout).
   */
 class NativeWebSocketClient extends WebSocketClient with LogSupport:
 
@@ -107,7 +111,9 @@ class NativeWebSocketClient extends WebSocketClient with LogSupport:
 end NativeWebSocketClient
 
 object NativeWebSocketClient:
-  private final val MaxFrameSize = 1024 * 1024
+  private final val MaxFrameSize           = 1024 * 1024
+  private final val MaxHandshakeBytes      = 64 * 1024
+  private final val HandshakeTimeoutMillis = 30000
 
   def apply(): NativeWebSocketClient = new NativeWebSocketClient()
 
@@ -154,6 +160,11 @@ object NativeWebSocketClient:
     val buf = mutable.ArrayBuffer.empty[Byte]
     var end = -1
     while end < 0 do
+      if buf.length > MaxHandshakeBytes then
+        throw HttpException.connectionFailed("WebSocket handshake response too large")
+      // Bound the wait so a connected-but-silent server can't hang the caller indefinitely.
+      if NativeSocket.waitReadable(fd, HandshakeTimeoutMillis) != 1 then
+        throw HttpException.connectionFailed("Timed out during the WebSocket handshake")
       val chunk = NativeSocket.recvChunk(fd)
       if chunk.isEmpty then
         throw HttpException.connectionFailed("Connection closed during the WebSocket handshake")
@@ -175,6 +186,8 @@ object NativeWebSocketClient:
         }
         .toMap
     Handshake(status, headers, leftover)
+
+  end readHandshake
 
   private def headerEnd(buf: mutable.ArrayBuffer[Byte]): Int =
     var i = 0
@@ -208,6 +221,9 @@ private class NativeWebSocketClientContext(clientFd: Int, override val request: 
   override def close(statusCode: Int, reason: String): Unit =
     if closed.compareAndSet(false, true) then
       writeFrame(WebSocketFrame.OpClose, WebSocketFrame.closePayload(statusCode, reason))
+      // Unblock the reader thread (parked in recv) so it exits and fires onClose promptly, rather
+      // than waiting for an unresponsive server to echo the close or drop the connection.
+      NativeSocket.shutdown(clientFd)
 
   private[http] def sendPong(payload: Array[Byte]): Unit =
     if !closed.get() then

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocketClient.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocketClient.scala
@@ -89,7 +89,9 @@ class NativeWebSocketClient extends WebSocketClient with LogSupport:
                 open = feed(chunk)
           catch
             case NonFatal(e) =>
-              WebSocketDispatcher.safeOnError(handler, ctx, e)
+              // Transport/read errors surface as onClose (via the finally), not onError — onError is
+              // reserved for handler-callback exceptions (those are wrapped in WebSocketDispatcher).
+              warn(s"WebSocket client read error: ${e.getMessage}")
           finally
             notifyClose()
             NativeSocket.close(fd)
@@ -125,8 +127,13 @@ object NativeWebSocketClient:
   private case class Handshake(status: Int, headers: Map[String, String], leftover: Array[Byte])
 
   private def parse(uri: String): Target =
-    if uri.startsWith("wss://") then
-      throw HttpException.connectionFailed("wss:// (TLS) is not supported by the Native client")
+    // Reject CR/LF so a crafted URI can't inject extra request lines/headers (HTTP request splitting).
+    if uri.indexOf('\r') >= 0 || uri.indexOf('\n') >= 0 then
+      throw HttpException.connectionFailed("Invalid characters in WebSocket URI")
+    if !uri.startsWith("ws://") then
+      throw HttpException.connectionFailed(
+        s"Only ws:// URLs are supported by the Native client: ${uri}"
+      )
     val rest      = uri.stripPrefix("ws://")
     val slash     = rest.indexOf('/')
     val authority =
@@ -152,6 +159,8 @@ object NativeWebSocketClient:
         80
     Target(host, port, path)
 
+  end parse
+
   /**
     * Read the HTTP upgrade response up to the header terminator; retain any frame bytes that
     * follow.
@@ -173,8 +182,14 @@ object NativeWebSocketClient:
     val head     = new String(buf.slice(0, end).toArray, StandardCharsets.ISO_8859_1)
     val leftover = buf.slice(end + 4, buf.length).toArray
     val lines    = head.split("\r\n")
-    val status   = lines(0).split(" ")(1).toInt
-    val headers  =
+    // Robust against a malformed status line ("HTTP/1.1 101 ..."); a bad line yields -1 -> rejected.
+    val status = lines
+      .headOption
+      .map(_.split(" "))
+      .filter(_.length >= 2)
+      .flatMap(_(1).toIntOption)
+      .getOrElse(-1)
+    val headers =
       lines
         .drop(1)
         .flatMap { line =>

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeWebSocketClientTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeWebSocketClientTest.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.rx.{OnError, OnNext, RxRunner}
+import wvlet.uni.test.UniTest
+
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{CountDownLatch, LinkedBlockingQueue, TimeUnit}
+
+/**
+  * Verifies the Native WebSocket client (raw socket + the shared codec in client mode) against the
+  * in-process Native server — a real client/server round-trip on the same `WebSocketHandler`.
+  */
+class NativeWebSocketClientTest extends UniTest:
+
+  /** Open the connection and return its [[WebSocketContext]] (waits for the handshake). */
+  private def connect(uri: String, handler: WebSocketHandler): WebSocketContext =
+    val ref   = AtomicReference[WebSocketContext]()
+    val error = AtomicReference[Throwable]()
+    val ready = CountDownLatch(1)
+    RxRunner.runOnce(Http.webSocketClient.connect(uri, handler)) {
+      case OnNext(ctx) =>
+        ref.set(ctx.asInstanceOf[WebSocketContext]);
+        ready.countDown()
+      case OnError(e) =>
+        error.set(e);
+        ready.countDown()
+      case _ =>
+    }
+    ready.await(10, TimeUnit.SECONDS) shouldBe true
+    if error.get() != null then
+      throw error.get()
+    ref.get()
+
+  test("Native WebSocket client echoes text messages") {
+    NativeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/echo") { _ =>
+        new WebSocketHandler:
+          override def onTextMessage(ctx: WebSocketContext, message: String): Unit = ctx.send(
+            s"echo:${message}"
+          )
+      }
+      .start { server =>
+        val messages = LinkedBlockingQueue[String]()
+        val handler  =
+          new WebSocketHandler:
+            override def onTextMessage(ctx: WebSocketContext, message: String): Unit = messages.put(
+              message
+            )
+        val ctx = connect(s"ws://127.0.0.1:${server.localPort}/ws/echo", handler)
+        try
+          ctx.send("hello")
+          messages.poll(10, TimeUnit.SECONDS) shouldBe "echo:hello"
+        finally
+          ctx.close()
+      }
+  }
+
+  test("Native WebSocket client receives a server push on open") {
+    NativeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/push") { _ =>
+        new WebSocketHandler:
+          override def onOpen(ctx: WebSocketContext): Unit = ctx.send("welcome")
+      }
+      .start { server =>
+        val messages = LinkedBlockingQueue[String]()
+        val handler  =
+          new WebSocketHandler:
+            override def onTextMessage(ctx: WebSocketContext, message: String): Unit = messages.put(
+              message
+            )
+        val ctx = connect(s"ws://127.0.0.1:${server.localPort}/ws/push", handler)
+        try messages.poll(10, TimeUnit.SECONDS) shouldBe "welcome"
+        finally ctx.close()
+      }
+  }
+
+  test("Native WebSocket client fires onClose when the connection ends") {
+    NativeServer
+      .withPort(0)
+      .withWebSocketRoute("/ws/life") { _ =>
+        new WebSocketHandler {}
+      }
+      .start { server =>
+        val closed  = CountDownLatch(1)
+        val handler =
+          new WebSocketHandler:
+            override def onClose(ctx: WebSocketContext): Unit = closed.countDown()
+        val ctx = connect(s"ws://127.0.0.1:${server.localPort}/ws/life", handler)
+        ctx.close()
+        closed.await(10, TimeUnit.SECONDS) shouldBe true
+      }
+  }
+
+end NativeWebSocketClientTest

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketFrame.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketFrame.scala
@@ -38,26 +38,55 @@ private[http] object WebSocketFrame:
     .getEncoder
     .encodeToString(Sha1.digest((key + MagicGuid).getBytes(StandardCharsets.US_ASCII)))
 
+  /**
+    * A fresh `Sec-WebSocket-Key` for a client handshake: base64 of 16 random bytes (RFC 6455 §4.1).
+    */
+  def newClientKey(): String =
+    val nonce = new Array[Byte](16)
+    scala.util.Random.nextBytes(nonce)
+    Base64.getEncoder.encodeToString(nonce)
+
   /** Encode an unmasked server frame (FIN set). */
   def encodeFrame(opcode: Int, payload: Array[Byte]): Array[Byte] =
-    val len    = payload.length
-    val b0     = (0x80 | opcode).toByte
-    val header =
-      if len < 126 then
-        Array[Byte](b0, len.toByte)
-      else if len < 65536 then
-        Array[Byte](b0, 126.toByte, ((len >>> 8) & 0xff).toByte, (len & 0xff).toByte)
+    frameHeader(opcode, payload.length, masked = false) ++ payload
+
+  /** Encode a masked client frame (FIN set) with a 4-byte masking key (RFC 6455 §5.3). */
+  def encodeMaskedFrame(opcode: Int, payload: Array[Byte], mask: Array[Byte]): Array[Byte] =
+    val masked = new Array[Byte](payload.length)
+    var i      = 0
+    while i < payload.length do
+      masked(i) = (payload(i) ^ mask(i % 4)).toByte
+      i += 1
+    frameHeader(opcode, payload.length, masked = true) ++ mask ++ masked
+
+  /** A fresh 4-byte masking key for client frames. */
+  def newMaskingKey(): Array[Byte] =
+    val mask = new Array[Byte](4)
+    scala.util.Random.nextBytes(mask)
+    mask
+
+  /** Frame header bytes (b0 + length, with the mask bit when `masked`); excludes the mask key. */
+  private def frameHeader(opcode: Int, len: Int, masked: Boolean): Array[Byte] =
+    val b0      = (0x80 | opcode).toByte
+    val maskBit =
+      if masked then
+        0x80
       else
-        val h = new Array[Byte](10)
-        h(0) = b0
-        h(1) = 127.toByte
-        val l = len.toLong
-        var i = 0
-        while i < 8 do
-          h(2 + i) = ((l >>> ((7 - i) * 8)) & 0xff).toByte
-          i += 1
-        h
-    header ++ payload
+        0x00
+    if len < 126 then
+      Array[Byte](b0, (maskBit | len).toByte)
+    else if len < 65536 then
+      Array[Byte](b0, (maskBit | 126).toByte, ((len >>> 8) & 0xff).toByte, (len & 0xff).toByte)
+    else
+      val h = new Array[Byte](10)
+      h(0) = b0
+      h(1) = (maskBit | 127).toByte
+      val l = len.toLong
+      var i = 0
+      while i < 8 do
+        h(2 + i) = ((l >>> ((7 - i) * 8)) & 0xff).toByte
+        i += 1
+      h
 
   /** A Close-frame payload: a 2-byte big-endian status code followed by the UTF-8 reason. */
   def closePayload(statusCode: Int, reason: String): Array[Byte] =

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketFrame.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketFrame.scala
@@ -13,6 +13,8 @@
  */
 package wvlet.uni.http
 
+import wvlet.uni.util.SecureRandom
+
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
@@ -43,7 +45,7 @@ private[http] object WebSocketFrame:
     */
   def newClientKey(): String =
     val nonce = new Array[Byte](16)
-    scala.util.Random.nextBytes(nonce)
+    SecureRandom.getInstance.nextBytes(nonce)
     Base64.getEncoder.encodeToString(nonce)
 
   /** Encode an unmasked server frame (FIN set). */
@@ -62,7 +64,7 @@ private[http] object WebSocketFrame:
   /** A fresh 4-byte masking key for client frames. */
   def newMaskingKey(): Array[Byte] =
     val mask = new Array[Byte](4)
-    scala.util.Random.nextBytes(mask)
+    SecureRandom.getInstance.nextBytes(mask)
     mask
 
   /** Frame header bytes (b0 + length, with the mask bit when `masked`); excludes the mask key. */

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketFrameDecoder.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketFrameDecoder.scala
@@ -35,7 +35,7 @@ private[http] enum WsEvent:
   *
   * `maxFrameSize` bounds both a single frame and a reassembled fragmented message (close 1009).
   */
-private[http] class WebSocketFrameDecoder(maxFrameSize: Int):
+private[http] class WebSocketFrameDecoder(maxFrameSize: Int, expectMasked: Boolean = true):
   import WebSocketFrame.*
 
   private val buf            = mutable.ArrayBuffer.empty[Byte]
@@ -103,23 +103,33 @@ private[http] class WebSocketFrameDecoder(maxFrameSize: Int):
     // Validation order matches the wire behavior: size, then RSV/mask, then control-frame rules.
     if len < 0 || len > maxFrameSize then
       return fail(emit, 1009, "message too big")
-    if rsv != 0 || !masked then
-      // RSV must be 0 (no extension negotiated); client frames MUST be masked (RFC 6455 §5).
+    if rsv != 0 || masked != expectMasked then
+      // RSV must be 0 (no extension negotiated). Client->server frames MUST be masked and
+      // server->client frames MUST NOT be (RFC 6455 §5); `expectMasked` selects the side.
       return fail(emit, 1002, "protocol error")
     if isControl && (!fin || len > 125) then
       // Control frames must be final and at most 125 bytes (RFC 6455 §5.5).
       return fail(emit, 1002, "invalid control frame")
 
-    val total = headerLen + 4 + len // + 4-byte mask key
+    val maskLen =
+      if masked then
+        4
+      else
+        0
+    val total = headerLen + maskLen + len
     if buf.length < total then
       return false
 
     val payload = new Array[Byte](len)
-    val maskOff = headerLen
-    val dataOff = headerLen + 4
+    val dataOff = headerLen + maskLen
     var i       = 0
     while i < len do
-      payload(i) = (buf(dataOff + i) ^ buf(maskOff + (i % 4))).toByte
+      // Unmask only when masked; server->client frames carry no masking key.
+      payload(i) =
+        if masked then
+          (buf(dataOff + i) ^ buf(headerLen + (i % 4))).toByte
+        else
+          buf(dataOff + i)
       i += 1
     buf.remove(0, total)
 

--- a/uni/src/test/scala/wvlet/uni/http/WebSocketFrameDecoderTest.scala
+++ b/uni/src/test/scala/wvlet/uni/http/WebSocketFrameDecoderTest.scala
@@ -207,6 +207,41 @@ class WebSocketFrameDecoderTest extends UniTest:
     }
   }
 
+  /** Build an unmasked server frame (for client-mode decoding). */
+  private def serverFrame(opcode: Int, payload: Array[Byte]): Array[Byte] =
+    val len    = payload.length
+    val header =
+      if len < 126 then
+        Array[Byte]((0x80 | opcode).toByte, len.toByte)
+      else
+        Array[Byte](
+          (0x80 | opcode).toByte,
+          126.toByte,
+          ((len >>> 8) & 0xff).toByte,
+          (len & 0xff).toByte
+        )
+    header ++ payload
+
+  test("client mode decodes an unmasked server text frame") {
+    val events  = mutable.ArrayBuffer.empty[WsEvent]
+    val decoder = WebSocketFrameDecoder(1024 * 1024, expectMasked = false)
+    decoder.feed(serverFrame(WebSocketFrame.OpText, "hi".getBytes(StandardCharsets.UTF_8)))(
+      events += _
+    )
+    events.toSeq shouldMatch { case Seq(WsEvent.Message(WebSocketFrame.OpText, data)) =>
+      new String(data, StandardCharsets.UTF_8) shouldBe "hi"
+    }
+  }
+
+  test("client mode rejects a masked frame with 1002") {
+    val events  = mutable.ArrayBuffer.empty[WsEvent]
+    val decoder = WebSocketFrameDecoder(1024 * 1024, expectMasked = false)
+    // A masked text frame (what a server must never send) — the client must reject it.
+    decoder.feed(textFrame("nope"))(events += _)
+    events.toSeq shouldMatch { case Seq(WsEvent.Fail(1002, _)) =>
+    }
+  }
+
   test("input after a terminal event is ignored") {
     val decoder = WebSocketFrameDecoder(1024 * 1024)
     val events  = mutable.ArrayBuffer.empty[WsEvent]


### PR DESCRIPTION
## Why

Final of three WebSocket-client PRs (after JVM #581, JS #582). Native has no built-in WebSocket, so the client is hand-rolled over a raw POSIX socket — reusing the shared codec, **generalized here to client mode**.

## What

- **Shared codec → client mode** (server path unchanged):
  - `WebSocketFrameDecoder(maxFrameSize, expectMasked = true)` — `expectMasked=false` accepts the *unmasked* server→client frames a client receives and rejects a masked one (1002), skipping the unmask step. Server callers keep the masked-required default.
  - `WebSocketFrame`: `encodeMaskedFrame(opcode, payload, mask)` (client sends MUST be masked), `newMaskingKey()`, `newClientKey()` (base64 of 16 random bytes for `Sec-WebSocket-Key`), and a shared `frameHeader` helper. New cross-platform decoder tests cover client-mode decode + masked-frame reject.
- **`NativeSocket.connect(host, port)`** — open a client TCP connection.
- **`NativeWebSocketClient`** — connect → send upgrade GET (random key) → validate `101` + `Sec-WebSocket-Accept` → drive `WebSocketFrameDecoder(expectMasked=false)` on a daemon reader thread, bridging to the handler via the shared `WebSocketDispatcher`. `onOpen` before the reader starts; `onClose` exactly once. `NativeWebSocketClientContext` masks every outbound frame and serializes writes. `ws://` only (no TLS on the raw socket). Registered in `NativeHttpChannelFactory`.

## Testing
`NativeWebSocketClientTest` drives the client against the in-process `NativeServer` WS echo/push route (text echo, push-on-open, onClose). **All platforms green: JVM 1637 / JS 1389 / Native 1398 / Netty 37** — the server suites confirm the codec generalization didn't regress the masked (server) path. No new dependency.

## Result
The WebSocket **client** now works on all three backends — JVM (`java.net.http`), JS (global `WebSocket`), Native (raw socket + shared codec) — on the same `WebSocketClient`/`WebSocketHandler`/`WebSocketContext` as the server.

Plan: `plans/2026-06-19-websocket-client-native.md`. Remaining follow-ups: WS ping/pong heartbeat; permessage-deflate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)