### PR TITLE
feature: WebSocket ping/pong heartbeat — shared core + Native server & client

### DIFF
--- a/plans/2026-06-19-websocket-heartbeat.md
+++ b/plans/2026-06-19-websocket-heartbeat.md
@@ -1,0 +1,34 @@
+# WebSocket ping/pong heartbeat (PR 1: shared core + Native server & client)
+
+## Context
+Incoming Ping→Pong auto-reply already works everywhere; this adds *initiating* pings to detect a
+half-open peer (one that neither sends data nor closes), closing it if pings go unanswered. Full
+scope is server (Native/Node/Netty) + client (JVM/Native); the JS client can't (the browser/Node
+global WebSocket exposes no send-ping to JS). Delivered as ~4 PRs; this is PR 1 (shared core + the
+Native backends, which share the poll-based read loop).
+
+## Changes
+- **`WebSocketHeartbeat` (shared)** — a small state machine: `onActivity()` (any inbound frame proves
+  liveness) and `onTick(): Decision` (`SendPing` on an idle interval; `Close` if a prior ping is
+  still unanswered after another idle interval; `Idle` when there was recent activity). Gives a dead
+  peer ~2 intervals. Deterministic unit test.
+- **`WebSocketDispatcher.dispatch`** gains an `onActivity: () => Unit = () => ()` hook, invoked once
+  per decoded frame, so every decoder-driven backend resets the heartbeat uniformly (default no-op
+  keeps Node/Netty unchanged for now).
+- **`NativeWebSocket.runReadLoop`** — extracted poll/read/dispatch loop shared by the Native server
+  (`serve`) and client (reader thread). With `pingIntervalMillis > 0` it uses `poll` as the heartbeat
+  clock (send ping on idle tick; close on unanswered); with 0 it blocks (poll timeout -1) exactly like
+  the old `recv`. `sendPing` added to both contexts (server unmasked, client masked).
+- **Config**: `NativeServerConfig.webSocketPingIntervalMillis` (0 = off) + `withWebSocketPingIntervalMillis`,
+  threaded into `serve`. **`WebSocketClient.connect` gains a `pingIntervalMillis` param** (a final
+  2-arg overload delegates with 0); the Native client uses it, JVM/JS impls accept-and-ignore it for
+  now (JVM wires it in PR 4; JS can't).
+
+## Verification
+`WebSocketHeartbeatTest` (state machine) + a Native integration test (server pings every 150ms, the
+client auto-pongs, the live-but-idle connection is NOT reaped over ~5 intervals). All suites green:
+JVM 1640 / JS 1395 / Native 1402 / Netty 37.
+
+## Follow-ups
+PR 2 — Node server (`setInterval`). PR 3 — Netty server (`IdleStateHandler`). PR 4 — JVM client
+(`ScheduledExecutorService` + `sendPing`/`onPong`). JS client: not possible (documented).

--- a/uni/.js/src/main/scala/wvlet/uni/http/JSWebSocketClient.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/http/JSWebSocketClient.scala
@@ -46,7 +46,12 @@ class JSWebSocketClient extends WebSocketClient:
 
   private given ExecutionContext = scala.scalajs.concurrent.JSExecutionContext.queue
 
-  override def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext] =
+  // pingIntervalMillis is ignored: the browser/Node global WebSocket can't send protocol pings.
+  override def connect(
+      uri: String,
+      handler: WebSocketHandler,
+      pingIntervalMillis: Int
+  ): Rx[WebSocketContext] =
     val opened = Promise[WebSocketContext]()
     val ws     = new JsWebSocket(uri)
     ws.binaryType = "arraybuffer"

--- a/uni/.jvm/src/main/scala/wvlet/uni/http/JavaWebSocketClient.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/http/JavaWebSocketClient.scala
@@ -31,7 +31,12 @@ class JavaWebSocketClient extends WebSocketClient:
 
   private given ExecutionContext = ExecutionContext.parasitic
 
-  override def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext] =
+  // pingIntervalMillis (client heartbeat) is wired in a follow-up PR; ignored for now.
+  override def connect(
+      uri: String,
+      handler: WebSocketHandler,
+      pingIntervalMillis: Int
+  ): Rx[WebSocketContext] =
     val opened   = Promise[WebSocketContext]()
     val listener = JavaWebSocketListener(handler, Request.get(uri), opened)
     JavaWebSocketClient

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeHttpServer.scala
@@ -340,7 +340,8 @@ class NativeHttpServer(config: NativeServerConfig) extends HttpServer with LogSu
               clientFd,
               accepted,
               route.handlerFactory(accepted),
-              config.webSocketMaxFrameSize
+              config.webSocketMaxFrameSize,
+              config.webSocketPingIntervalMillis
             )
 
   private def daemonThreadFactory(name: String): ThreadFactory =

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeServer.scala
@@ -65,7 +65,10 @@ case class NativeServerConfig(
     // WebSocket routes, matched by path during the HTTP upgrade handshake
     override val webSocketRoutes: Seq[WebSocketRoute] = Nil,
     // Maximum size (bytes) of an inbound WebSocket message
-    webSocketMaxFrameSize: Int = 1024 * 1024
+    webSocketMaxFrameSize: Int = 1024 * 1024,
+    // Ping/pong heartbeat interval for WebSocket connections (0 disables it): the server pings an
+    // idle connection and closes it if the peer stops responding to pings.
+    webSocketPingIntervalMillis: Int = 0
 ) extends HttpServerConfig:
 
   def withName(name: String): NativeServerConfig = copy(name = name)
@@ -131,6 +134,10 @@ case class NativeServerConfig(
   def withWebSocketMaxFrameSize(sizeInBytes: Int): NativeServerConfig =
     require(sizeInBytes > 0, "webSocketMaxFrameSize must be positive")
     copy(webSocketMaxFrameSize = sizeInBytes)
+
+  def withWebSocketPingIntervalMillis(millis: Int): NativeServerConfig =
+    require(millis >= 0, "webSocketPingIntervalMillis must be >= 0")
+    copy(webSocketPingIntervalMillis = millis)
 
   /**
     * Start the server and return the running instance. Binding is synchronous, so the inherited

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocket.scala
@@ -30,7 +30,13 @@ private[http] object NativeWebSocket extends LogSupport:
     * Run a WebSocket connection: deliver `onOpen`, then read/dispatch frames until the peer closes
     * or the socket ends, guaranteeing `onClose` exactly once. Runs on the calling worker thread.
     */
-  def serve(clientFd: Int, request: Request, handler: WebSocketHandler, maxFrameSize: Int): Unit =
+  def serve(
+      clientFd: Int,
+      request: Request,
+      handler: WebSocketHandler,
+      maxFrameSize: Int,
+      pingIntervalMillis: Int
+  ): Unit =
     val ctx                 = NativeWebSocketContext(clientFd, request)
     val closeNotified       = AtomicBoolean(false)
     def notifyClose(): Unit =
@@ -48,17 +54,18 @@ private[http] object NativeWebSocket extends LogSupport:
         case NonFatal(e) =>
           WebSocketDispatcher.safeOnError(handler, ctx, e)
 
-      val decoder = WebSocketFrameDecoder(maxFrameSize)
-      var open    = true
-      while open do
-        val chunk = NativeSocket.recvChunk(clientFd)
-        if chunk.isEmpty then
-          open = false // clean EOF
-        else
-          open =
-            decoder.feed(chunk)(ev =>
-              WebSocketDispatcher.dispatch(handler, ctx, ctx.sendPong, () => notifyClose(), ev)
-            )
+      runReadLoop(
+        clientFd,
+        maxFrameSize,
+        pingIntervalMillis,
+        expectMasked = true,
+        initial = Array.emptyByteArray,
+        handler,
+        ctx,
+        ctx.sendPong,
+        ctx.sendPing,
+        () => notifyClose()
+      )
     catch
       case NonFatal(e) =>
         WebSocketDispatcher.safeOnError(handler, ctx, e)
@@ -66,6 +73,74 @@ private[http] object NativeWebSocket extends LogSupport:
       notifyClose()
 
   end serve
+
+  /**
+    * Poll/read/dispatch loop shared by the Native server and client. Uses `poll` so a periodic
+    * heartbeat (when `pingIntervalMillis > 0`) can ping an idle peer and close it if a Ping goes
+    * unanswered; with the heartbeat off it blocks (poll timeout -1) like a plain `recv`. `initial`
+    * is any bytes already read past the handshake (client side). Exceptions propagate to the
+    * caller.
+    */
+  private[http] def runReadLoop(
+      fd: Int,
+      maxFrameSize: Int,
+      pingIntervalMillis: Int,
+      expectMasked: Boolean,
+      initial: Array[Byte],
+      handler: WebSocketHandler,
+      ctx: WebSocketContext,
+      sendPong: Array[Byte] => Unit,
+      sendPing: Array[Byte] => Unit,
+      notifyClose: () => Unit
+  ): Unit =
+    val decoder   = WebSocketFrameDecoder(maxFrameSize, expectMasked)
+    val heartbeat =
+      if pingIntervalMillis > 0 then
+        WebSocketHeartbeat()
+      else
+        null
+    val pollTimeout =
+      if pingIntervalMillis > 0 then
+        pingIntervalMillis
+      else
+        -1
+    def feed(bytes: Array[Byte]): Boolean =
+      decoder.feed(bytes)(ev =>
+        WebSocketDispatcher.dispatch(
+          handler,
+          ctx,
+          sendPong,
+          notifyClose,
+          ev,
+          () =>
+            if heartbeat != null then
+              heartbeat.onActivity()
+        )
+      )
+    var open = initial.isEmpty || feed(initial)
+    while open do
+      NativeSocket.waitReadable(fd, pollTimeout) match
+        case 1 =>
+          val chunk = NativeSocket.recvChunk(fd)
+          if chunk.isEmpty then
+            open = false
+          else
+            open = feed(chunk)
+        case 0 =>
+          // Heartbeat tick (only reached when pingIntervalMillis > 0).
+          if heartbeat != null then
+            heartbeat.onTick() match
+              case WebSocketHeartbeat.Decision.SendPing =>
+                sendPing(Array.emptyByteArray)
+              case WebSocketHeartbeat.Decision.Close =>
+                ctx.close(1011, "ping timeout")
+                open = false
+              case WebSocketHeartbeat.Decision.Idle =>
+                ()
+        case _ =>
+          open = false // hangup/error
+
+  end runReadLoop
 
 end NativeWebSocket
 
@@ -95,6 +170,10 @@ private[http] class NativeWebSocketContext(clientFd: Int, override val request: 
   private[http] def sendPong(payload: Array[Byte]): Unit =
     if !closed.get() then
       writeFrame(WebSocketFrame.OpPong, payload)
+
+  private[http] def sendPing(payload: Array[Byte]): Unit =
+    if !closed.get() then
+      writeFrame(WebSocketFrame.OpPing, payload)
 
   private def sendFrameIfOpen(opcode: Int, payload: Array[Byte]): Unit =
     if !closed.get() then

--- a/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocketClient.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/http/NativeWebSocketClient.scala
@@ -33,7 +33,11 @@ import scala.util.control.NonFatal
   */
 class NativeWebSocketClient extends WebSocketClient with LogSupport:
 
-  override def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext] =
+  override def connect(
+      uri: String,
+      handler: WebSocketHandler,
+      pingIntervalMillis: Int
+  ): Rx[WebSocketContext] =
     try
       val target = NativeWebSocketClient.parse(uri)
       val fd     = NativeSocket.connect(target.host, target.port)
@@ -72,21 +76,18 @@ class NativeWebSocketClient extends WebSocketClient with LogSupport:
 
         val reader = Thread(() =>
           try
-            val decoder = WebSocketFrameDecoder(
+            NativeWebSocket.runReadLoop(
+              fd,
               NativeWebSocketClient.MaxFrameSize,
-              expectMasked = false
+              pingIntervalMillis,
+              expectMasked = false,
+              initial = handshake.leftover,
+              handler,
+              ctx,
+              ctx.sendPong,
+              ctx.sendPing,
+              () => notifyClose()
             )
-            def feed(bytes: Array[Byte]): Boolean =
-              decoder.feed(bytes)(ev =>
-                WebSocketDispatcher.dispatch(handler, ctx, ctx.sendPong, () => notifyClose(), ev)
-              )
-            var open = handshake.leftover.isEmpty || feed(handshake.leftover)
-            while open do
-              val chunk = NativeSocket.recvChunk(fd)
-              if chunk.isEmpty then
-                open = false
-              else
-                open = feed(chunk)
           catch
             case NonFatal(e) =>
               // Transport/read errors surface as onClose (via the finally), not onError — onError is
@@ -243,6 +244,10 @@ private class NativeWebSocketClientContext(clientFd: Int, override val request: 
   private[http] def sendPong(payload: Array[Byte]): Unit =
     if !closed.get() then
       writeFrame(WebSocketFrame.OpPong, payload)
+
+  private[http] def sendPing(payload: Array[Byte]): Unit =
+    if !closed.get() then
+      writeFrame(WebSocketFrame.OpPing, payload)
 
   private def sendFrameIfOpen(opcode: Int, payload: Array[Byte]): Unit =
     if !closed.get() then

--- a/uni/.native/src/test/scala/wvlet/uni/http/NativeWebSocketClientTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/http/NativeWebSocketClientTest.scala
@@ -89,6 +89,27 @@ class NativeWebSocketClientTest extends UniTest:
       }
   }
 
+  test("server heartbeat keeps an idle connection alive via ping/pong") {
+    NativeServer
+      .withPort(0)
+      .withWebSocketPingIntervalMillis(150)
+      .withWebSocketRoute("/ws/idle") { _ =>
+        new WebSocketHandler {}
+      }
+      .start { server =>
+        val closed  = CountDownLatch(1)
+        val handler =
+          new WebSocketHandler:
+            override def onClose(ctx: WebSocketContext): Unit = closed.countDown()
+        val ctx = connect(s"ws://127.0.0.1:${server.localPort}/ws/idle", handler)
+        try
+          // The server pings every 150ms; the client auto-pongs, so the heartbeat must NOT reap this
+          // live-but-idle connection over several intervals.
+          closed.await(800, TimeUnit.MILLISECONDS) shouldBe false
+        finally ctx.close()
+      }
+  }
+
   test("Native WebSocket client fires onClose when the connection ends") {
     NativeServer
       .withPort(0)

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketClient.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketClient.scala
@@ -26,7 +26,18 @@ trait WebSocketClient:
     * callbacks (`onOpen`/`onTextMessage`/`onBinaryMessage`/`onClose`/`onError`). The returned `Rx`
     * emits the open [[WebSocketContext]] — used to `send`/`close` — once the handshake completes,
     * or fails with the handshake error. (`handler.onOpen` fires for the same event.)
+    *
+    * `pingIntervalMillis` enables a client-side ping/pong heartbeat (0 disables it): the client
+    * pings an idle connection and closes it if the peer stops responding. Not supported on the JS
+    * backend (the browser/Node `WebSocket` API cannot send protocol pings), where it is ignored.
     */
-  def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext]
+  def connect(uri: String, handler: WebSocketHandler, pingIntervalMillis: Int): Rx[WebSocketContext]
+
+  /** Connect with the client heartbeat disabled. */
+  final def connect(uri: String, handler: WebSocketHandler): Rx[WebSocketContext] = connect(
+    uri,
+    handler,
+    0
+  )
 
 end WebSocketClient

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketDispatcher.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketDispatcher.scala
@@ -30,8 +30,11 @@ private[http] object WebSocketDispatcher extends LogSupport:
       ctx: WebSocketContext,
       sendPong: Array[Byte] => Unit,
       notifyClose: () => Unit,
-      event: WsEvent
+      event: WsEvent,
+      onActivity: () => Unit = () => ()
   ): Unit =
+    // Any decoded frame proves the peer is alive — reset the heartbeat.
+    onActivity()
     event match
       case WsEvent.Message(WebSocketFrame.OpText, data) =>
         deliver(
@@ -52,6 +55,8 @@ private[http] object WebSocketDispatcher extends LogSupport:
       case WsEvent.Fail(code, reason) =>
         // onClose is driven by the connection teardown after this terminal event.
         ctx.close(code, reason)
+
+  end dispatch
 
   private def deliver(handler: WebSocketHandler, ctx: WebSocketContext, action: () => Unit): Unit =
     try

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketHeartbeat.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketHeartbeat.scala
@@ -13,8 +13,6 @@
  */
 package wvlet.uni.http
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 /**
   * Platform-neutral ping/pong heartbeat policy for detecting a half-open WebSocket peer.
   *
@@ -27,27 +25,31 @@ import java.util.concurrent.atomic.AtomicBoolean
 private[http] class WebSocketHeartbeat:
   import WebSocketHeartbeat.Decision
 
-  // Set by the reader on any inbound frame; consumed (and cleared) by each tick.
-  private val sawActivity  = AtomicBoolean(false)
-  private val awaitingPong = AtomicBoolean(false)
+  // onActivity (reader thread) and onTick (timer thread) can race on multi-threaded backends, so the
+  // compound state transition is guarded by the instance lock (uncontended: ~one tick per interval).
+  private var sawActivity  = false
+  private var awaitingPong = false
 
   /** Record inbound activity (any frame). Clears a pending ping. */
-  def onActivity(): Unit =
-    sawActivity.set(true)
-    awaitingPong.set(false)
+  def onActivity(): Unit = synchronized {
+    sawActivity = true
+    awaitingPong = false
+  }
 
   /** Decide what to do at a heartbeat interval. */
-  def onTick(): Decision =
-    if sawActivity.getAndSet(false) then
+  def onTick(): Decision = synchronized {
+    if sawActivity then
       // Recent traffic already proves liveness; no ping needed this interval.
-      awaitingPong.set(false)
+      sawActivity = false
+      awaitingPong = false
       Decision.Idle
-    else if awaitingPong.get() then
+    else if awaitingPong then
       // We pinged last interval and saw nothing since → the peer is gone.
       Decision.Close
     else
-      awaitingPong.set(true)
+      awaitingPong = true
       Decision.SendPing
+  }
 
 end WebSocketHeartbeat
 

--- a/uni/src/main/scala/wvlet/uni/http/WebSocketHeartbeat.scala
+++ b/uni/src/main/scala/wvlet/uni/http/WebSocketHeartbeat.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+  * Platform-neutral ping/pong heartbeat policy for detecting a half-open WebSocket peer.
+  *
+  * A backend drives this from a periodic clock (a poll timeout or a timer) by calling [[onTick]]
+  * every `pingIntervalMillis`, and calls [[onActivity]] whenever any inbound frame is observed (any
+  * frame proves the peer is alive, so there's no need to single out Pong). The state machine gives
+  * a disconnected peer up to ~2 intervals: an idle interval sends a Ping; a second idle interval
+  * with the Ping still unanswered reports [[Decision.Close]].
+  */
+private[http] class WebSocketHeartbeat:
+  import WebSocketHeartbeat.Decision
+
+  // Set by the reader on any inbound frame; consumed (and cleared) by each tick.
+  private val sawActivity  = AtomicBoolean(false)
+  private val awaitingPong = AtomicBoolean(false)
+
+  /** Record inbound activity (any frame). Clears a pending ping. */
+  def onActivity(): Unit =
+    sawActivity.set(true)
+    awaitingPong.set(false)
+
+  /** Decide what to do at a heartbeat interval. */
+  def onTick(): Decision =
+    if sawActivity.getAndSet(false) then
+      // Recent traffic already proves liveness; no ping needed this interval.
+      awaitingPong.set(false)
+      Decision.Idle
+    else if awaitingPong.get() then
+      // We pinged last interval and saw nothing since → the peer is gone.
+      Decision.Close
+    else
+      awaitingPong.set(true)
+      Decision.SendPing
+
+end WebSocketHeartbeat
+
+private[http] object WebSocketHeartbeat:
+  enum Decision:
+    case SendPing,
+      Close,
+      Idle

--- a/uni/src/test/scala/wvlet/uni/http/WebSocketHeartbeatTest.scala
+++ b/uni/src/test/scala/wvlet/uni/http/WebSocketHeartbeatTest.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.http
+
+import wvlet.uni.http.WebSocketHeartbeat.Decision
+import wvlet.uni.test.UniTest
+
+/** Deterministic tests for the cross-platform ping/pong heartbeat state machine. */
+class WebSocketHeartbeatTest extends UniTest:
+
+  test("an idle interval sends a ping, then closes if unanswered") {
+    val hb = WebSocketHeartbeat()
+    hb.onTick() shouldBe Decision.SendPing // idle → ping
+    hb.onTick() shouldBe Decision.Close    // still idle, ping unanswered → close
+  }
+
+  test("activity (e.g. a pong) clears the pending ping") {
+    val hb = WebSocketHeartbeat()
+    hb.onTick() shouldBe Decision.SendPing
+    hb.onActivity()                        // a frame arrived
+    hb.onTick() shouldBe Decision.Idle     // liveness proven → no ping, no close
+    hb.onTick() shouldBe Decision.SendPing // idle again → ping
+  }
+
+  test("continuous activity keeps it idle (never closes)") {
+    val hb = WebSocketHeartbeat()
+    hb.onActivity()
+    hb.onTick() shouldBe Decision.Idle
+    hb.onActivity()
+    hb.onTick() shouldBe Decision.Idle
+  }
+
+end WebSocketHeartbeatTest


### PR DESCRIPTION
## Why

Incoming Ping→Pong auto-reply already works on every backend; what's missing is **initiating** pings to detect a *half-open* peer — one that neither sends data nor closes (a silent network drop). This adds a heartbeat that pings idle connections and closes them when pings go unanswered.

Full scope is server (Native/Node/Netty) + client (JVM/Native); the **JS client can't** (the browser/Node global `WebSocket` exposes no send-ping to JS). Delivered as ~4 PRs — **this is PR 1: the shared core + the Native backends** (which share the poll-based read loop).

## What

- **`WebSocketHeartbeat`** (shared) — a small state machine: `onActivity()` (any inbound frame proves liveness) + `onTick(): Decision` → `SendPing` on an idle interval, `Close` if a prior ping is still unanswered after another idle interval, `Idle` after recent activity. A dead peer gets ~2 intervals. Deterministic unit test.
- **`WebSocketDispatcher.dispatch`** gains an `onActivity: () => Unit = () => ()` hook (invoked once per decoded frame), so every decoder-driven backend resets the heartbeat uniformly — default no-op keeps Node/Netty unchanged until their PRs.
- **`NativeWebSocket.runReadLoop`** — extracted poll/read/dispatch loop shared by the Native **server** (`serve`) and **client** reader. With `pingIntervalMillis > 0` it uses `poll` as the heartbeat clock (ping on idle tick; close on unanswered); with `0` it blocks (poll timeout `-1`) exactly like the old `recv`. `sendPing` added to both contexts (server unmasked, client masked).
- **Config** — `NativeServerConfig.webSocketPingIntervalMillis` (0 = off) + `withWebSocketPingIntervalMillis`. **`WebSocketClient.connect` gains a `pingIntervalMillis` param** (a `final` 2-arg overload delegates with `0`, so existing callers are unchanged); the Native client uses it, the JVM/JS impls accept-and-ignore it for now (JVM wires it in PR 4; JS can't).

## Testing
`WebSocketHeartbeatTest` (the state machine) + a Native integration test: the server pings every 150 ms, the client auto-pongs, and the live-but-idle connection is **not** reaped over ~5 intervals. All suites green: **JVM 1640 / JS 1395 / Native 1402 / Netty 37**.

Plan: `plans/2026-06-19-websocket-heartbeat.md`.

### Up next
PR 2 — Node server (`setInterval`). PR 3 — Netty server (`IdleStateHandler`). PR 4 — JVM client (`ScheduledExecutorService` + `sendPing`/`onPong`). JS client: not possible (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)