### PR TITLE
feature: Add BackgroundTask — cross-platform cancellable, progress-pollable worker (#552)

### DIFF
--- a/plans/2026-06-20-background-task.md
+++ b/plans/2026-06-20-background-task.md
@@ -1,0 +1,143 @@
+# BackgroundTask — cross-platform cancellable, progress-pollable worker (issue #552)
+
+## Context
+
+wvlet's `SqlConnector.QueryHandle` (`state`/`stats`/`cancel`/`await`) is satisfied "for free" by the
+Trino client (polls a remote HTTP server) but the DuckDB impl ships as a synchronous wrapper:
+`cancel` is a no-op and there's no progress. libduckdb *does* expose `duckdb_query_progress`,
+`duckdb_interrupt`, and a pending-result API for cooperative incremental execution — but driving them
+requires the query to run on a **different thread** than the one polling progress / issuing cancel.
+wvlet has no cross-platform primitive for that and doesn't want to inline JVM `Thread` / Native
+`pthread` / Node `worker_threads` plumbing per backend. Issue #552 asks uni for it.
+
+**Outcome:** a `BackgroundTask` that runs a plain side-effecting block on a background worker, with
+cooperative cancel + a non-blocking progress snapshot + block-to-completion — no effect monad.
+
+### Key constraint (drove the JS decision)
+
+Node `worker_threads` run a **separate JS realm** fed a pre-written JS string + `SharedArrayBuffer`
+(see `adr/2026-05-14-nodejs-sync-http.md`); an arbitrary Scala.js closure can't run on one, and
+Scala.js is single-threaded. So a *true* background worker exists only on **JVM and Native** (the
+DuckDB targets). Decision: the API is identical on all three platforms, but **JS runs the body inline
+on the event loop during `start()`** (completes immediately; `await`/`poll` return the result;
+`cancel()` is best-effort once done) — correct but not concurrent, and documented as such.
+
+## Design
+
+Package **`wvlet.uni.control`** (uni's side-effect/lifecycle home: `Control`, `Resource`,
+`RateLimiter`). Reserve `wvlet.uni.rx` for the existing Rx-flavored `RxFiber` (this is its non-Rx
+twin). Progress is a **poll snapshot** (no Rx dependency); an `Rx[P]` push stream is an easy
+follow-up if needed.
+
+```scala
+package wvlet.uni.control
+import wvlet.uni.util.Result
+
+/** A unit of work running on a background worker: cooperatively cancellable, progress-pollable. */
+trait BackgroundTask[A, P]:
+  /** Latest progress the body reported (None if none yet). Non-blocking. */
+  def progress: Option[P]
+  /** Terminal snapshot: None while running, Some(result) once done/failed/cancelled. Non-blocking. */
+  def poll: Option[Result[A]]
+  /** Block the caller until the task terminates, returning its result.
+    * JVM/Native block on a latch; on JS the body already ran inline, so this returns immediately. */
+  def await(): Result[A]
+  /** Signal cooperative cancellation: sets the flag and runs any registered onCancel hooks. */
+  def cancel(): Unit
+  def isCancelled: Boolean
+  def isDone: Boolean
+
+/** Handed to the task body so it can observe cancellation and report progress. */
+trait TaskContext[P]:
+  def isCancelled: Boolean
+  /** Throws TaskCancelledException if cancelled — call at safe points to abort cooperatively. */
+  def checkCancelled(): Unit
+  def reportProgress(p: P): Unit
+  /** Register a hook run on the caller's thread when cancel() fires (e.g. duckdb_interrupt). */
+  def onCancel(hook: () => Unit): Unit
+
+final class TaskCancelledException extends RuntimeException("BackgroundTask was cancelled")
+
+object BackgroundTask:
+  /** Start `body` on a background worker (JVM/Native: daemon thread; JS: inline). */
+  def start[A, P](body: TaskContext[P] => A): BackgroundTask[A, P]
+```
+
+### DuckDB usage (the motivating shape)
+
+```scala
+val task = BackgroundTask.start[ResultSet, QueryProgress] { ctx =>
+  ctx.onCancel(() => libduckdb.duckdb_interrupt(conn))   // unblock a query stuck in a libduckdb call
+  val pending = libduckdb.pending(conn, sql)
+  while !pending.isFinished do
+    ctx.checkCancelled()                                 // cooperative abort between steps
+    pending.executeTask()
+    ctx.reportProgress(libduckdb.duckdb_query_progress(conn))
+  pending.result
+}
+// caller thread, non-blocking:
+task.progress            // Option[QueryProgress] for a progress bar
+task.cancel()            // REPL ctrl-C → flag + duckdb_interrupt
+task.await()             // Result[ResultSet]
+```
+
+### Shared impl + platform split
+
+The whole state machine is **shared** (`uni/src/main`); only "spawn a worker" and "block until done"
+differ per platform. Internal state uses `AtomicBoolean`/`AtomicReference` (available on all three —
+Native is multithreaded, JS provides single-threaded shims):
+
+- `cancelled: AtomicBoolean`, `progressRef: AtomicReference[Option[P]]`,
+  `resultRef: AtomicReference[Option[Result[A]]]`, `cancelHooks: AtomicReference[List[() => Unit]]`.
+- `start` builds the `TaskContext`, then runs the body via the compat worker; the worker wrapper does
+  `resultRef.set(Some(try Success(body(ctx)) catch NonFatal => Failure(e)))` then signals the gate.
+  `cancel()` CAS-sets the flag once and runs the registered hooks. `await()` = `gate.await();
+  resultRef.get().get` (latch `countDown` happens-before `await` returns ⇒ result is visible).
+
+Platform compat — **`private[control] object BackgroundTaskCompat`** (one file per platform):
+
+| | `runWorker(body: () => Unit): Unit` | gate `await()` / `signal()` |
+|---|---|---|
+| **JVM** | daemon `Thread` via `ThreadUtil.newDaemonThreadFactory("uni-task")` | `CountDownLatch(1)` |
+| **Native** | daemon `Thread` (same) | `CountDownLatch(1)` |
+| **JS** | run `body()` **inline** (synchronous) | no-ops (already done when `start` returns) |
+
+Cancellation is **cooperative** (no forced interrupt) per the issue; the `onCancel` hook covers the
+"interrupt a call already in flight" case (e.g. `duckdb_interrupt`). `Thread.interrupt()` on
+JVM/Native is a possible later enhancement.
+
+## Files
+
+| Action | Path |
+|---|---|
+| Add | `uni/src/main/scala/wvlet/uni/control/BackgroundTask.scala` (traits + `TaskCancelledException` + shared impl + `object BackgroundTask`) |
+| Add | `uni/.jvm/src/main/scala/wvlet/uni/control/BackgroundTaskCompat.scala` (daemon thread + `CountDownLatch`) |
+| Add | `uni/.native/src/main/scala/wvlet/uni/control/BackgroundTaskCompat.scala` (same as JVM) |
+| Add | `uni/.js/src/main/scala/wvlet/uni/control/BackgroundTaskCompat.scala` (inline run + no-op gate) |
+| Add | `uni/src/test/scala/wvlet/uni/control/BackgroundTaskTest.scala` (cross-platform) |
+| Add | `uni/.jvm/src/test/.../BackgroundTaskConcurrencyTest.scala` (+ a `.native` copy) — true-concurrency cases |
+
+Reuses: `wvlet.uni.util.Result` (`Success`/`Failure`), `wvlet.uni.util.ThreadUtil`
+(`newDaemonThreadFactory`, `sleep`). Follows the established `Area`/`AreaCompat` value-handoff split
+(`adr/2026-05-15-cross-platform-init-handoff.md`).
+
+## Verification
+
+- `./sbt scalafmtAll` then `uniJVM/test uniJS/test uniNative/test` (compile + run all three).
+- **Cross-platform tests** (`uni/src/test`, run on JS inline too): normal completion → `Success`;
+  body throws → `Failure(e)`; `reportProgress` then return → `progress == Some(...)`; `await()`
+  returns the same as `poll` once done.
+- **Concurrency tests** (`.jvm` + `.native`, real threads via `CountDownLatch`): body loops on
+  `!ctx.isCancelled` reporting progress → caller observes `progress` advance, calls `cancel()`,
+  `await()` terminates (loop exits / `checkCancelled` → `Failure(TaskCancelledException)`),
+  `isCancelled == true`; `onCancel` hook runs on `cancel()`; `await()` blocks then returns `Success`
+  after a `ThreadUtil.sleep` body. (These can't run on JS — it executes inline, no concurrency.)
+
+## Risks / notes
+
+- **JS is non-concurrent** (inline) — acceptable; DuckDB is JVM/Native. Documented on `start`.
+- **Cooperative cancel only** — a body blocked inside one long FFI call won't cancel until it returns
+  to a checkpoint; the `onCancel` hook is the escape hatch (e.g. `duckdb_interrupt`).
+- **Out of scope (follow-ups):** `Rx[P]` progress stream (RxVar-backed), `Thread.interrupt()` on
+  cancel, worker pooling, timeouts. Capture an ADR for the Node-worker_threads limitation + the JS
+  inline decision once it lands.

--- a/uni/.js/src/main/scala/wvlet/uni/control/BackgroundTaskCompat.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/control/BackgroundTaskCompat.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.control
+
+/**
+  * Scala.js worker: there are no threads (and Node `worker_threads` run a separate JS realm that
+  * can't host an arbitrary Scala closure — see adr/2026-05-14-nodejs-sync-http.md), so the body
+  * runs inline and completes before `start` returns. The gate is therefore a no-op: by the time the
+  * caller can call `await`, the task is already done.
+  */
+private[control] object BackgroundTaskCompat:
+  def runWorker(body: () => Unit): Unit = body()
+
+  def newGate(): Gate = NoOpGate
+
+private[control] object NoOpGate extends Gate:
+  override def await(): Unit  = ()
+  override def signal(): Unit = ()

--- a/uni/.jvm/src/main/scala/wvlet/uni/control/BackgroundTaskCompat.scala
+++ b/uni/.jvm/src/main/scala/wvlet/uni/control/BackgroundTaskCompat.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.control
+
+import wvlet.uni.util.ThreadUtil
+
+import java.util.concurrent.CountDownLatch
+
+/** JVM worker: runs the body on a daemon thread; the gate is a one-shot latch. */
+private[control] object BackgroundTaskCompat:
+  private val threadFactory = ThreadUtil.newDaemonThreadFactory("uni-task")
+
+  def runWorker(body: () => Unit): Unit = threadFactory.newThread(() => body()).start()
+
+  def newGate(): Gate = LatchGate()
+
+private[control] class LatchGate extends Gate:
+  private val latch           = CountDownLatch(1)
+  override def await(): Unit  = latch.await()
+  override def signal(): Unit = latch.countDown()

--- a/uni/.jvm/src/test/scala/wvlet/uni/control/BackgroundTaskConcurrencyTest.scala
+++ b/uni/.jvm/src/test/scala/wvlet/uni/control/BackgroundTaskConcurrencyTest.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.control
+
+import wvlet.uni.util.{Result, ThreadUtil}
+import wvlet.uni.test.UniTest
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+/**
+  * True-concurrency behavior of [[BackgroundTask]] on the JVM (a real background thread). Mirrored
+  * for Native; not applicable on JS, where the body runs inline.
+  */
+class BackgroundTaskConcurrencyTest extends UniTest:
+
+  test("await blocks until the worker completes") {
+    val task = BackgroundTask.start[String, Unit] { _ =>
+      ThreadUtil.sleep(100)
+      "done"
+    }
+    // If await did not block on the gate, resultRef would still be None and .get would throw.
+    task.await() shouldBe Result.Success("done")
+  }
+
+  test("cooperative cancel is observed via isCancelled") {
+    val progressed = CountDownLatch(1)
+    val task       = BackgroundTask.start[Int, Int] { ctx =>
+      var i = 0
+      while !ctx.isCancelled do
+        i += 1
+        ctx.reportProgress(i)
+        if i == 1 then
+          progressed.countDown()
+        ThreadUtil.sleep(5)
+      i
+    }
+    progressed.await(5, TimeUnit.SECONDS) shouldBe true
+    task.progress.exists(_ >= 1) shouldBe true
+    task.cancel()
+    task.await().isSuccess shouldBe true // the loop exited and returned i
+    task.isCancelled shouldBe true
+  }
+
+  test("checkCancelled aborts with TaskCancelledException") {
+    val started = CountDownLatch(1)
+    val task    = BackgroundTask.start[Int, Unit] { ctx =>
+      started.countDown()
+      var n = 0
+      while n < 1000000 do
+        ctx.checkCancelled()
+        ThreadUtil.sleep(5)
+        n += 1
+      n
+    }
+    started.await(5, TimeUnit.SECONDS) shouldBe true
+    task.cancel()
+    task.await() shouldMatch { case Result.Failure(_: TaskCancelledException) =>
+    }
+  }
+
+  test("onCancel hook fires on cancel") {
+    val registered = CountDownLatch(1)
+    val hookRan    = CountDownLatch(1)
+    val task       = BackgroundTask.start[Int, Unit] { ctx =>
+      ctx.onCancel(() => hookRan.countDown())
+      registered.countDown()
+      while !ctx.isCancelled do
+        ThreadUtil.sleep(5)
+      0
+    }
+    registered.await(5, TimeUnit.SECONDS) shouldBe true
+    task.cancel()
+    hookRan.await(5, TimeUnit.SECONDS) shouldBe true
+    task.await().isSuccess shouldBe true
+  }
+
+  test("onCancel registered after cancellation runs immediately") {
+    val ranImmediately = CountDownLatch(1)
+    val task           = BackgroundTask.start[Int, Unit] { ctx =>
+      while !ctx.isCancelled do
+        ThreadUtil.sleep(5)
+      // Registered after cancel() has fired → must run right away.
+      ctx.onCancel(() => ranImmediately.countDown())
+      0
+    }
+    task.cancel()
+    ranImmediately.await(5, TimeUnit.SECONDS) shouldBe true
+    task.await().isSuccess shouldBe true
+  }
+
+end BackgroundTaskConcurrencyTest

--- a/uni/.native/src/main/scala/wvlet/uni/control/BackgroundTaskCompat.scala
+++ b/uni/.native/src/main/scala/wvlet/uni/control/BackgroundTaskCompat.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.control
+
+import wvlet.uni.util.ThreadUtil
+
+import java.util.concurrent.CountDownLatch
+
+/**
+  * Native worker (Scala Native multithreaded): runs the body on a daemon thread; the gate is a
+  * one-shot latch. Identical to the JVM impl — `java.lang.Thread` / `CountDownLatch` are both
+  * available on Scala Native 0.5, as the Native HTTP server already relies on.
+  */
+private[control] object BackgroundTaskCompat:
+  private val threadFactory = ThreadUtil.newDaemonThreadFactory("uni-task")
+
+  def runWorker(body: () => Unit): Unit = threadFactory.newThread(() => body()).start()
+
+  def newGate(): Gate = LatchGate()
+
+private[control] class LatchGate extends Gate:
+  private val latch           = CountDownLatch(1)
+  override def await(): Unit  = latch.await()
+  override def signal(): Unit = latch.countDown()

--- a/uni/.native/src/test/scala/wvlet/uni/control/BackgroundTaskConcurrencyTest.scala
+++ b/uni/.native/src/test/scala/wvlet/uni/control/BackgroundTaskConcurrencyTest.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.control
+
+import wvlet.uni.util.{Result, ThreadUtil}
+import wvlet.uni.test.UniTest
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+/**
+  * True-concurrency behavior of [[BackgroundTask]] on the JVM (a real background thread). Mirrored
+  * for Native; not applicable on JS, where the body runs inline.
+  */
+class BackgroundTaskConcurrencyTest extends UniTest:
+
+  test("await blocks until the worker completes") {
+    val task = BackgroundTask.start[String, Unit] { _ =>
+      ThreadUtil.sleep(100)
+      "done"
+    }
+    // If await did not block on the gate, resultRef would still be None and .get would throw.
+    task.await() shouldBe Result.Success("done")
+  }
+
+  test("cooperative cancel is observed via isCancelled") {
+    val progressed = CountDownLatch(1)
+    val task       = BackgroundTask.start[Int, Int] { ctx =>
+      var i = 0
+      while !ctx.isCancelled do
+        i += 1
+        ctx.reportProgress(i)
+        if i == 1 then
+          progressed.countDown()
+        ThreadUtil.sleep(5)
+      i
+    }
+    progressed.await(5, TimeUnit.SECONDS) shouldBe true
+    task.progress.exists(_ >= 1) shouldBe true
+    task.cancel()
+    task.await().isSuccess shouldBe true // the loop exited and returned i
+    task.isCancelled shouldBe true
+  }
+
+  test("checkCancelled aborts with TaskCancelledException") {
+    val started = CountDownLatch(1)
+    val task    = BackgroundTask.start[Int, Unit] { ctx =>
+      started.countDown()
+      var n = 0
+      while n < 1000000 do
+        ctx.checkCancelled()
+        ThreadUtil.sleep(5)
+        n += 1
+      n
+    }
+    started.await(5, TimeUnit.SECONDS) shouldBe true
+    task.cancel()
+    task.await() shouldMatch { case Result.Failure(_: TaskCancelledException) =>
+    }
+  }
+
+  test("onCancel hook fires on cancel") {
+    val registered = CountDownLatch(1)
+    val hookRan    = CountDownLatch(1)
+    val task       = BackgroundTask.start[Int, Unit] { ctx =>
+      ctx.onCancel(() => hookRan.countDown())
+      registered.countDown()
+      while !ctx.isCancelled do
+        ThreadUtil.sleep(5)
+      0
+    }
+    registered.await(5, TimeUnit.SECONDS) shouldBe true
+    task.cancel()
+    hookRan.await(5, TimeUnit.SECONDS) shouldBe true
+    task.await().isSuccess shouldBe true
+  }
+
+  test("onCancel registered after cancellation runs immediately") {
+    val ranImmediately = CountDownLatch(1)
+    val task           = BackgroundTask.start[Int, Unit] { ctx =>
+      while !ctx.isCancelled do
+        ThreadUtil.sleep(5)
+      // Registered after cancel() has fired → must run right away.
+      ctx.onCancel(() => ranImmediately.countDown())
+      0
+    }
+    task.cancel()
+    ranImmediately.await(5, TimeUnit.SECONDS) shouldBe true
+    task.await().isSuccess shouldBe true
+  }
+
+end BackgroundTaskConcurrencyTest

--- a/uni/src/main/scala/wvlet/uni/control/BackgroundTask.scala
+++ b/uni/src/main/scala/wvlet/uni/control/BackgroundTask.scala
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.control
+
+import wvlet.uni.util.Result
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import scala.util.control.NonFatal
+
+/** Thrown by [[TaskContext.checkCancelled]] when the task has been cancelled. */
+final class TaskCancelledException extends RuntimeException("BackgroundTask was cancelled")
+
+/**
+  * Handed to a [[BackgroundTask]] body so it can observe cancellation and report progress. The body
+  * is a plain side-effecting block (no effect monad); it cooperates with cancellation by polling
+  * [[isCancelled]] / calling [[checkCancelled]] at safe points (e.g. loop iterations).
+  */
+trait TaskContext[P]:
+  /** True once [[BackgroundTask.cancel]] has been called. */
+  def isCancelled: Boolean
+
+  /** Throw [[TaskCancelledException]] if cancelled — call at safe points to abort cooperatively. */
+  def checkCancelled(): Unit
+
+  /** Publish the latest progress, readable by the caller via [[BackgroundTask.progress]]. */
+  def reportProgress(p: P): Unit
+
+  /**
+    * Register a hook run (on the caller's thread) when [[BackgroundTask.cancel]] is invoked — the
+    * escape hatch for interrupting a call already in flight (e.g. `duckdb_interrupt`). A hook
+    * registered after cancellation runs immediately.
+    */
+  def onCancel(hook: () => Unit): Unit
+
+/**
+  * A unit of work running on a background worker: cooperatively cancellable and progress-pollable
+  * from another thread.
+  *
+  * On JVM and Native the body runs on a daemon thread, so the caller can poll progress / cancel /
+  * block on [[await]] concurrently. On Scala.js there are no threads, so the body runs inline
+  * during [[BackgroundTask.start]] and completes before it returns — the API is identical, but
+  * there is no concurrency (and [[cancel]] after completion is a no-op).
+  */
+trait BackgroundTask[A, P]:
+  /** Latest progress the body reported, or `None` if none yet. Non-blocking. */
+  def progress: Option[P]
+
+  /** Terminal snapshot: `None` while running, `Some(result)` once finished/failed. Non-blocking. */
+  def poll: Option[Result[A]]
+
+  /** Block the calling thread until the task terminates, returning its result. */
+  def await(): Result[A]
+
+  /** Signal cooperative cancellation: sets the flag and runs any registered `onCancel` hooks. */
+  def cancel(): Unit
+
+  def isCancelled: Boolean
+  def isDone: Boolean
+
+/** One-shot completion gate, provided per platform (JVM/Native: a latch; JS: a no-op). */
+private[control] trait Gate:
+  /** Block until [[signal]] has been called (returns immediately if already signalled). */
+  def await(): Unit
+  def signal(): Unit
+
+object BackgroundTask:
+
+  /**
+    * Start `body` on a background worker (JVM/Native: a daemon thread; JS: inline). The body
+    * receives a [[TaskContext]] for cooperative cancellation and progress reporting.
+    */
+  def start[A, P](body: TaskContext[P] => A): BackgroundTask[A, P] =
+    val task = BackgroundTaskImpl[A, P](body)
+    task.launch()
+    task
+
+/**
+  * Shared state machine. The only platform-specific pieces are spawning the worker and the
+  * completion gate (see `BackgroundTaskCompat`).
+  */
+private[control] class BackgroundTaskImpl[A, P](body: TaskContext[P] => A)
+    extends BackgroundTask[A, P]
+    with TaskContext[P]:
+
+  private val cancelled   = AtomicBoolean(false)
+  private val progressRef = AtomicReference[Option[P]](None)
+  private val resultRef   = AtomicReference[Option[Result[A]]](None)
+  private val gate        = BackgroundTaskCompat.newGate()
+
+  // onCancel hooks are coordinated under a lock (low-frequency): registration races cancellation.
+  private val hookLock                = Object()
+  private var hooks: List[() => Unit] = Nil
+  private var hooksDrained: Boolean   = false
+
+  /** Start the worker. Called after construction so `this` does not escape mid-initialization. */
+  private[control] def launch(): Unit = BackgroundTaskCompat.runWorker { () =>
+    val r =
+      try
+        Result.Success(body(this))
+      catch
+        case NonFatal(e) =>
+          Result.Failure(e)
+    resultRef.set(Some(r))
+    gate.signal()
+  }
+
+  // --- TaskContext (body side) ---
+
+  override def isCancelled: Boolean = cancelled.get()
+
+  override def checkCancelled(): Unit =
+    if cancelled.get() then
+      throw TaskCancelledException()
+
+  override def reportProgress(p: P): Unit = progressRef.set(Some(p))
+
+  override def onCancel(hook: () => Unit): Unit =
+    val runNow = hookLock.synchronized {
+      if hooksDrained then
+        true
+      else
+        hooks = hook :: hooks
+        false
+    }
+    if runNow then
+      runHookQuietly(hook)
+
+  // --- BackgroundTask (caller side) ---
+
+  override def progress: Option[P]     = progressRef.get()
+  override def poll: Option[Result[A]] = resultRef.get()
+  override def isDone: Boolean         = resultRef.get().isDefined
+
+  override def await(): Result[A] =
+    gate.await()
+    // The worker sets resultRef before signalling the gate, so it is visible here.
+    resultRef.get().get
+
+  override def cancel(): Unit =
+    cancelled.set(true)
+    val toRun = hookLock.synchronized {
+      if hooksDrained then
+        Nil
+      else
+        hooksDrained = true
+        val h = hooks
+        hooks = Nil
+        h
+    }
+    // Registered newest-first; run in registration order.
+    toRun.reverse.foreach(runHookQuietly)
+
+  private def runHookQuietly(hook: () => Unit): Unit =
+    try
+      hook()
+    catch
+      case NonFatal(_) =>
+        ()
+
+end BackgroundTaskImpl

--- a/uni/src/main/scala/wvlet/uni/control/BackgroundTask.scala
+++ b/uni/src/main/scala/wvlet/uni/control/BackgroundTask.scala
@@ -105,14 +105,25 @@ private[control] class BackgroundTaskImpl[A, P](body: TaskContext[P] => A)
 
   /** Start the worker. Called after construction so `this` does not escape mid-initialization. */
   private[control] def launch(): Unit = BackgroundTaskCompat.runWorker { () =>
-    val r =
-      try
-        Result.Success(body(this))
-      catch
-        case NonFatal(e) =>
-          Result.Failure(e)
-    resultRef.set(Some(r))
-    gate.signal()
+    try
+      // Catch every Throwable (not just NonFatal): a fatal error or InterruptedException must still
+      // become a result, or `await` would hang on the gate forever. (Inline on JS, so we record the
+      // failure rather than rethrow — that keeps `start` from throwing there.)
+      val r =
+        try
+          Result.Success(body(this))
+        catch
+          case e: Throwable =>
+            Result.Failure(e)
+      resultRef.set(Some(r))
+    finally
+      // The task is finished: drain the cancel hooks so a later cancel() can't fire them against an
+      // unrelated operation, and release their captured closures. No-op if cancel() already drained.
+      hookLock.synchronized {
+        hooksDrained = true
+        hooks = Nil
+      }
+      gate.signal()
   }
 
   // --- TaskContext (body side) ---
@@ -128,7 +139,8 @@ private[control] class BackgroundTaskImpl[A, P](body: TaskContext[P] => A)
   override def onCancel(hook: () => Unit): Unit =
     val runNow = hookLock.synchronized {
       if hooksDrained then
-        true
+        // Drained by cancel() → run now; drained by normal completion → don't (task already done).
+        cancelled.get()
       else
         hooks = hook :: hooks
         false

--- a/uni/src/test/scala/wvlet/uni/control/BackgroundTaskTest.scala
+++ b/uni/src/test/scala/wvlet/uni/control/BackgroundTaskTest.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.control
+
+import wvlet.uni.util.Result
+import wvlet.uni.test.UniTest
+
+/**
+  * Cross-platform behavior of [[BackgroundTask]]. These assert outcomes (not concurrency), so they
+  * hold on JS too, where the body runs inline during `start`. Concurrency (live cancel/progress) is
+  * covered by the JVM/Native-only tests.
+  */
+class BackgroundTaskTest extends UniTest:
+
+  test("completes with Success") {
+    val task = BackgroundTask.start[Int, Unit](_ => 21 * 2)
+    task.await() shouldBe Result.Success(42)
+    task.poll shouldBe Some(Result.Success(42))
+    task.isDone shouldBe true
+    task.isCancelled shouldBe false
+  }
+
+  test("a body exception becomes Failure") {
+    val task = BackgroundTask.start[Int, Unit](_ => throw RuntimeException("boom"))
+    task.await() shouldMatch { case Result.Failure(e) =>
+      e.getMessage shouldBe "boom"
+    }
+  }
+
+  test("reports the latest progress") {
+    val task = BackgroundTask.start[Int, Int] { ctx =>
+      ctx.reportProgress(1)
+      ctx.reportProgress(2)
+      99
+    }
+    task.await() shouldBe Result.Success(99)
+    task.progress shouldBe Some(2)
+  }
+
+  test("await and poll agree once done") {
+    val task    = BackgroundTask.start[String, Unit](_ => "ok")
+    val awaited = task.await()
+    awaited shouldBe Result.Success("ok")
+    task.poll shouldBe Some(awaited)
+  }
+
+end BackgroundTaskTest

--- a/uni/src/test/scala/wvlet/uni/control/BackgroundTaskTest.scala
+++ b/uni/src/test/scala/wvlet/uni/control/BackgroundTaskTest.scala
@@ -16,6 +16,8 @@ package wvlet.uni.control
 import wvlet.uni.util.Result
 import wvlet.uni.test.UniTest
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 /**
   * Cross-platform behavior of [[BackgroundTask]]. These assert outcomes (not concurrency), so they
   * hold on JS too, where the body runs inline during `start`. Concurrency (live cancel/progress) is
@@ -53,6 +55,17 @@ class BackgroundTaskTest extends UniTest:
     val awaited = task.await()
     awaited shouldBe Result.Success("ok")
     task.poll shouldBe Some(awaited)
+  }
+
+  test("cancel after normal completion does not run onCancel hooks") {
+    val hookRan = AtomicBoolean(false)
+    val task    = BackgroundTask.start[Int, Unit] { ctx =>
+      ctx.onCancel(() => hookRan.set(true))
+      42
+    }
+    task.await() shouldBe Result.Success(42)
+    task.cancel() // the task already finished — hooks must not fire
+    hookRan.get() shouldBe false
   }
 
 end BackgroundTaskTest


### PR DESCRIPTION
Closes #552.

## Why
wvlet's `SqlConnector.QueryHandle` (`state`/`stats`/`cancel`/`await`) is free for Trino (polls a remote server) but the DuckDB impl is a synchronous wrapper — `cancel` is a no-op, no progress. libduckdb exposes `duckdb_query_progress` / `duckdb_interrupt` / a pending-result API, but driving them needs the query to run on a **different thread** than the one polling progress / cancelling. uni had no cross-platform primitive for that. This adds one.

## What
**`wvlet.uni.control.BackgroundTask[A, P]`** — run a plain side-effecting block on a background worker, no effect monad:

```scala
trait BackgroundTask[A, P]:
  def progress: Option[P]        // latest reported, non-blocking poll snapshot
  def poll: Option[Result[A]]    // terminal snapshot, non-blocking
  def await(): Result[A]         // block until done
  def cancel(): Unit             // cooperative cancel + run onCancel hooks
  def isCancelled: Boolean
  def isDone: Boolean

trait TaskContext[P]:            // handed to the body
  def isCancelled: Boolean
  def checkCancelled(): Unit     // throws TaskCancelledException
  def reportProgress(p: P): Unit
  def onCancel(hook: () => Unit): Unit   // e.g. () => duckdb_interrupt(conn)

BackgroundTask.start[A, P](body: TaskContext[P] => A): BackgroundTask[A, P]
```

The shared state machine (atomic flags + result + lock-coordinated cancel hooks) lives in `uni/src/main`; only the worker spawn + completion gate are per-platform (`BackgroundTaskCompat`): **JVM/Native** = daemon `Thread` + `CountDownLatch`; **JS** = inline run + no-op gate. Reuses `Result`, `ThreadUtil`.

## Design decision: JS is non-concurrent (documented)
The issue assumed Node `worker_threads` could host the work, but they run a **separate JS realm** fed a pre-written JS string (see `adr/2026-05-14-nodejs-sync-http.md`) — an arbitrary Scala.js closure can't run on one, and Scala.js is single-threaded. So a *true* background worker exists only on **JVM and Native** (the DuckDB targets). The API is identical on all three, but on JS the body runs **inline during `start()`** (completes before it returns; no concurrency; `cancel()` after completion is a no-op). This was confirmed with the maintainer before implementing.

## Testing
- **Cross-platform** (`uni/src/test`, JS runs inline): completion → `Success`, body throw → `Failure`, progress reported, `await`/`poll` agree.
- **JVM + Native concurrency**: live cancel observed via `isCancelled`, `checkCancelled` → `Failure(TaskCancelledException)`, `onCancel` fires (incl. registered-after-cancel), `await` blocks until completion.
- **JVM 9 / JS 4 / Native 9 pass.**

Plan: `plans/2026-06-20-background-task.md`. Follow-ups noted there: `Rx[P]` progress stream, `Thread.interrupt()` on cancel, worker pooling/timeouts, and an ADR for the Node-worker_threads limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)