### PR TITLE
docs: Expand coverage for cross-platform HTTP, Weaver, BackgroundTask, Web UI, and RPC codegen

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -161,6 +161,7 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Logging', link: '/core/logging' },
             { text: 'JSON Processing', link: '/core/json' },
             { text: 'MessagePack', link: '/core/msgpack' },
+            { text: 'Weaver (Serialization)', link: '/core/weaver' },
             { text: 'Type Introspection', link: '/core/surface' },
             { text: 'IO', link: '/core/io' },
             { text: 'FileSystem', link: '/core/filesystem' },
@@ -176,7 +177,8 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Circuit Breaker', link: '/control/circuit-breaker' },
             { text: 'Rate Limiter', link: '/control/rate-limiter' },
             { text: 'Caching', link: '/control/cache' },
-            { text: 'Resource Management', link: '/control/resource' }
+            { text: 'Resource Management', link: '/control/resource' },
+            { text: 'Background Task', link: '/control/background-task' }
           ]
         },
         {
@@ -207,6 +209,12 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Terminal Styling', link: '/cli/tint' },
             { text: 'Progress Indicators', link: '/cli/progress' },
             { text: 'Command Launcher', link: '/cli/launcher' }
+          ]
+        },
+        {
+          text: 'Web UI (Scala.js)',
+          items: [
+            { text: 'RxElement', link: '/dom/' }
           ]
         }
       ],
@@ -228,6 +236,7 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Logging', link: '/core/logging' },
             { text: 'JSON Processing', link: '/core/json' },
             { text: 'MessagePack', link: '/core/msgpack' },
+            { text: 'Weaver (Serialization)', link: '/core/weaver' },
             { text: 'Type Introspection', link: '/core/surface' },
             { text: 'IO', link: '/core/io' },
             { text: 'FileSystem', link: '/core/filesystem' },
@@ -243,7 +252,8 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Circuit Breaker', link: '/control/circuit-breaker' },
             { text: 'Rate Limiter', link: '/control/rate-limiter' },
             { text: 'Caching', link: '/control/cache' },
-            { text: 'Resource Management', link: '/control/resource' }
+            { text: 'Resource Management', link: '/control/resource' },
+            { text: 'Background Task', link: '/control/background-task' }
           ]
         },
         {
@@ -274,6 +284,12 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Terminal Styling', link: '/cli/tint' },
             { text: 'Progress Indicators', link: '/cli/progress' },
             { text: 'Command Launcher', link: '/cli/launcher' }
+          ]
+        },
+        {
+          text: 'Web UI (Scala.js)',
+          items: [
+            { text: 'RxElement', link: '/dom/' }
           ]
         }
       ]

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -190,6 +190,7 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Router', link: '/http/router' },
             { text: 'RPC', link: '/http/rpc' },
             { text: 'Server-Sent Events', link: '/http/sse' },
+            { text: 'WebSocket Client', link: '/http/websocket' },
             { text: 'Retry Strategies', link: '/http/retry' }
           ]
         },
@@ -265,6 +266,7 @@ export default defineConfig<UniThemeConfig>({
             { text: 'Router', link: '/http/router' },
             { text: 'RPC', link: '/http/rpc' },
             { text: 'Server-Sent Events', link: '/http/sse' },
+            { text: 'WebSocket Client', link: '/http/websocket' },
             { text: 'Retry Strategies', link: '/http/retry' }
           ]
         },

--- a/docs/control/background-task.md
+++ b/docs/control/background-task.md
@@ -1,0 +1,153 @@
+# Background Task
+
+`BackgroundTask[A, P]` runs a unit of work on a background worker that is
+**cooperatively cancellable** and **progress-pollable** from another thread. It
+is the non-`Rx` counterpart to a fiber: the body is a plain side-effecting block
+(no effect monad), so it fits long-running, blocking work — a database query, a
+file scan, a REPL evaluation — that you want to cancel or report progress on.
+
+- `A` — the result type the body returns
+- `P` — the progress type the body reports
+
+```scala
+import wvlet.uni.control.BackgroundTask
+
+val task = BackgroundTask.start[Int, Int] { ctx =>
+  var sum = 0
+  for i <- 1 to 100 do
+    ctx.checkCancelled()        // abort cooperatively if cancelled
+    sum += i
+    ctx.reportProgress(i)       // publish progress (0–100)
+  sum
+}
+
+val result = task.await()       // Result[Int] — blocks until done
+println(result.getOrElse(0))    // 5050
+```
+
+## Starting a Task
+
+`BackgroundTask.start` takes a body `TaskContext[P] => A` and returns immediately
+with a handle:
+
+```scala
+def start[A, P](body: TaskContext[P] => A): BackgroundTask[A, P]
+```
+
+On **JVM** and **Scala Native** the body runs on a daemon thread, so the caller
+can poll, cancel, and block concurrently. On **Scala.js** there are no threads,
+so the body runs **inline during `start`** and has already completed when `start`
+returns — see [Platform behavior](#platform-behavior).
+
+## The Task Context (body side)
+
+The body receives a `TaskContext[P]` to cooperate with the caller:
+
+| Method | Purpose |
+|--------|---------|
+| `isCancelled: Boolean` | `true` once `cancel()` was called — poll it in loops |
+| `checkCancelled(): Unit` | Throws `TaskCancelledException` if cancelled — call at safe points |
+| `reportProgress(p: P): Unit` | Publish the latest progress to the caller |
+| `onCancel(hook: () => Unit): Unit` | Register a hook to interrupt an in-flight blocking call |
+
+Cancellation is **cooperative**: `cancel()` only sets a flag. The body must poll
+`isCancelled` / call `checkCancelled()` at safe points (typically loop
+iterations) for cancellation to take effect.
+
+For a call already blocked in native/FFI code that can't poll a flag, register an
+`onCancel` hook — it runs on the caller's thread when `cancel()` is invoked, and
+is the escape hatch for interrupting work in flight:
+
+```scala
+val task = BackgroundTask.start[QueryResult, Unit] { ctx =>
+  val handle = nativeQuery.start()
+  ctx.onCancel(() => nativeQuery.interrupt(handle))  // e.g. duckdb_interrupt
+  nativeQuery.awaitResult(handle)
+}
+```
+
+## The Task Handle (caller side)
+
+| Method | Blocks? | Returns |
+|--------|---------|---------|
+| `progress: Option[P]` | no | latest reported progress, or `None` |
+| `progressStream: Rx[P]` | no | push stream of progress, completing when the task ends |
+| `poll: Option[Result[A]]` | no | `None` while running, `Some(result)` once finished |
+| `await(): Result[A]` | yes | the terminal result (blocks until done) |
+| `cancel(): Unit` | no | signals cooperative cancellation, runs `onCancel` hooks |
+| `isCancelled: Boolean` | no | whether `cancel()` was called |
+| `isDone: Boolean` | no | whether the task has terminated |
+
+### Results
+
+`await()` and `poll` return a [`Result[A]`](../core/result) — `Success(value)`
+or `Failure(error)`. The body's failures are **recorded, not rethrown**, so
+`await()` always returns rather than throwing:
+
+```scala
+task.await() match
+  case Result.Success(value) => println(s"Done: ${value}")
+  case Result.Failure(e)     => println(s"Failed: ${e.getMessage}")
+```
+
+A cancelled task whose body calls `checkCancelled()` completes as a
+`Failure(TaskCancelledException)`.
+
+### Polling vs. streaming progress
+
+Use the non-blocking `progress` snapshot to render a progress bar from another
+thread:
+
+```scala
+while !task.isDone do
+  task.progress.foreach(p => render(p))
+  Thread.sleep(100)
+```
+
+Or subscribe to `progressStream` for a push feed that completes with the task:
+
+```scala
+task.progressStream.subscribe { p =>
+  println(s"progress: ${p}")
+}
+```
+
+The stream holds only the latest value (it does not buffer), so an unconsumed
+`progressStream` won't accumulate updates.
+
+## Cancellation
+
+```scala
+val task = BackgroundTask.start[Unit, Int] { ctx =>
+  while !ctx.isCancelled do
+    doOneStep()
+}
+
+// later, from another thread:
+task.cancel()
+task.await()   // returns once the body observes the flag and exits
+```
+
+`cancel()` after the task has already completed is a **no-op** — `onCancel`
+hooks are drained on completion, so a late cancel can't fire them against an
+unrelated operation.
+
+## Platform behavior
+
+| Platform | Worker | Concurrency |
+|----------|--------|-------------|
+| JVM | daemon thread | full — poll / cancel / `await` from another thread |
+| Scala Native | daemon thread | full |
+| Scala.js | inline during `start` | none — body completes before `start` returns |
+
+On Scala.js the API is identical, but because the body runs inline:
+
+- the task is already done when `start` returns, so `cancel()` is effectively a
+  no-op;
+- a `progressStream` subscriber attached afterwards sees only the **final**
+  reported value, not a live feed — use the `progress` snapshot instead.
+
+For the full rationale (why JS can't host a true worker thread, the
+catch-`Throwable`-and-signal contract that keeps `await` from hanging, and the
+`progressStream` design), see the
+[ADR](https://github.com/wvlet/uni/blob/main/adr/2026-06-20-background-task.md).

--- a/docs/control/index.md
+++ b/docs/control/index.md
@@ -11,6 +11,7 @@ uni provides utilities for handling failures gracefully and managing resources p
 | [Rate Limiter](./rate-limiter) | Throttle operation throughput (JVM) |
 | [Cache](./cache) | TTL and LRU caching |
 | [Resource](./resource) | Safe resource acquisition and release |
+| [Background Task](./background-task) | Cancellable, progress-pollable background worker |
 
 ## Quick Example
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -11,9 +11,10 @@ The `uni` module provides essential utilities for Scala application development.
 | [Logging](./logging) | Structured logging with LogSupport |
 | [JSON](./json) | Pure Scala JSON parser and DSL |
 | [MessagePack](./msgpack) | Binary serialization format |
+| [Weaver](./weaver) | Derivation-based serialization (JSON / MessagePack / Map) |
 | [Surface](./surface) | Compile-time type introspection |
 | [FileSystem](./filesystem) | Cross-platform file I/O with IOPath |
-| [Utilities](./utilities) | UUIDv7, Base62, NanoId, DataSize, Count, ElapsedTime |
+| [Utilities](./utilities) | IDs (UUIDv7, ULID, NanoId), encodings (Base62, CrockfordBase32), value types (DataSize, Count, ElapsedTime), timing (StopWatch, Timer) |
 
 ## Quick Start
 

--- a/docs/core/utilities.md
+++ b/docs/core/utilities.md
@@ -71,6 +71,30 @@ val (hi, low): (Long, Long) = Base62.decode128bits(raw)
 Base62.isValid("0K9mFb3xYz1Qw5Rv8NpJ2a")  // true
 ```
 
+## CrockfordBase32
+
+[Crockford's Base32](https://www.crockford.com/base32.html) encoding — the
+case-insensitive, human-friendly alphabet (it excludes `I`, `L`, `O`, `U` to
+avoid ambiguity) that backs [ULID](#ulid). Use it directly when you need to
+encode raw 128-bit or 48-bit values in the same format.
+
+```scala
+import wvlet.uni.util.CrockfordBase32
+
+// Encode / decode a 128-bit value (26 characters)
+val s: String = CrockfordBase32.encode128bits(hi = 0x0123456789abcdefL, low = 0xfedcba9876543210L)
+val (hi, low): (Long, Long) = CrockfordBase32.decode128bits(s)
+
+// Decode a 48-bit value (e.g. a ULID timestamp prefix)
+val millis: Long = CrockfordBase32.decode48bits("01ARZ3NDEK")
+
+// Validate
+CrockfordBase32.isValidBase32("01arz3ndektsv4rrffq69g5fav")  // true
+```
+
+For ID generation prefer [ULID](#ulid) (which encodes with this alphabet) or
+[Base62](#base62); reach for `CrockfordBase32` only when you need the raw codec.
+
 ## NanoId
 
 Compact, URL-safe random IDs for cases where time-ordering is not needed. Useful as user-facing tokens, short links, or external keys that map back to an internal UUIDv7.
@@ -138,6 +162,31 @@ val fromBytes: ULID = ULID.fromBytes(bytes)
 ```
 
 </details>
+
+## PrefixedULID
+
+A [ULID](#ulid) tagged with a human-readable type prefix — handy for
+self-describing IDs like `user:01arz3ndektsv4rrffq69g5fav` where the prefix
+identifies the entity. The string form is `<prefix>:<ulid>` (delimiter `:`), and
+values sort by prefix first, then by the embedded ULID timestamp.
+
+```scala
+import wvlet.uni.util.PrefixedULID
+
+// Generate
+val id: PrefixedULID = PrefixedULID.newPrefixedULID("user")
+println(id)                    // "user:01arz3ndektsv4rrffq69g5fav"
+
+// Or directly as a string
+val s: String = PrefixedULID.newPrefixedULIDString("order")
+
+// Access parts
+id.prefix                      // "user"
+id.ulid                        // the underlying ULID
+
+// Parse back (splits on the last ':' so prefixes may contain ':')
+val parsed = PrefixedULID.fromString("user:01arz3ndektsv4rrffq69g5fav")
+```
 
 ## DataSize
 
@@ -265,6 +314,51 @@ duration.convertToMostSuccinctTimeUnit                  // ElapsedTime(1.50, MIN
 | `MINUTES` | m | `"5m"` |
 | `HOURS` | h | `"2.5h"` |
 | `DAYS` | d | `"1d"` |
+
+## StopWatch
+
+A simple elapsed-time timer. It starts running on creation and reports seconds
+as a `Double`.
+
+```scala
+import wvlet.uni.util.StopWatch
+
+val sw = StopWatch()
+// ... do work ...
+val seconds: Double = sw.getElapsedTime   // elapsed since creation/reset
+
+sw.stop                                   // pause; returns the last interval
+sw.resume                                 // continue measuring
+sw.reset                                  // restart from zero
+println(sw.reportElapsedTime)             // e.g. "0.42 sec."
+```
+
+## Timer
+
+For micro-benchmarking, extend the `Timer` trait and wrap code in `time` /
+nested `block`. A `TimeReport` captures total and per-block timing, and `repeat`
+runs blocks multiple times to smooth out JIT/GC noise.
+
+```scala
+import wvlet.uni.util.Timer
+
+class Benchmark extends Timer:
+  val report = time("search", repeat = 10) {
+    block("linear") {
+      // candidate A
+    }
+    block("binary") {
+      // candidate B
+    }
+  }
+
+  // Inspect per-block statistics
+  report("linear").average   // average seconds over the repeats
+  report("binary").min       // min / max / median / elapsedSeconds also available
+
+val b = Benchmark()
+println(b.report)            // formatted multi-line timing report
+```
 
 ## Best Practices
 

--- a/docs/core/weaver.md
+++ b/docs/core/weaver.md
@@ -1,0 +1,204 @@
+# Weaver
+
+`Weaver[A]` is uni's derivation-based serialization framework. A single `Weaver`
+instance can read and write a value of type `A` as **MessagePack**, **JSON**, or
+a loosely-typed `Map[String, Any]` — so you derive the codec once and pick the
+wire format at the call site.
+
+Weaver is the engine behind JSON/MessagePack serialization in the
+[HTTP client](../http/client) and [RPC](../http/rpc) layers, and it builds on
+[Surface](./surface) for compile-time type information.
+
+```scala
+import wvlet.uni.weaver.Weaver
+
+case class Person(name: String, age: Int) derives Weaver
+
+val json = Weaver.toJson(Person("Alice", 30))   // {"name":"Alice","age":30}
+val back = Weaver.fromJson[Person](json)         // Person(Alice,30)
+```
+
+## Deriving a Weaver
+
+A `Weaver[A]` is derived at compile time for case classes, enums, and sealed
+traits. There are three equivalent ways to obtain one:
+
+```scala
+// 1. derives clause (recommended for types you own)
+case class Person(name: String, age: Int) derives Weaver
+
+// 2. Weaver.of for an explicit given
+given Weaver[Person] = Weaver.of[Person]
+
+// 3. Inline at the call site
+val w: Weaver[Person] = Weaver.of[Person]
+```
+
+Most API methods take the `Weaver[A]` as a `using` parameter, so a `derives`
+clause or a `given` in scope is all you need.
+
+## Serialization Formats
+
+The same derived `Weaver` exposes every format. The companion-object methods
+resolve the `Weaver[A]` implicitly:
+
+```scala
+import wvlet.uni.weaver.Weaver
+
+case class User(name: String, age: Int) derives Weaver
+val user = User("Alice", 30)
+
+// JSON
+val json: String = Weaver.toJson(user)
+val u1: User     = Weaver.fromJson[User](json)
+
+// MessagePack (compact binary)
+val bytes = Weaver.weave(user)            // Array[Byte]
+val u2    = Weaver.unweave[User](bytes)
+
+// Map[String, Any] — handy with YAML/HOCON-style parsers
+val map: Map[String, Any] = Weaver.toMap(user)
+val u3                     = Weaver.fromMap[User](map)
+```
+
+The instance methods on `Weaver[A]` mirror these and add a couple of
+lower-overhead entry points when you already hold a `Weaver`:
+
+| Method | Direction | Format |
+|--------|-----------|--------|
+| `toJson(v)` / `fromJson(s)` | encode / decode | JSON string |
+| `weave(v)` / `unweave(b)` | encode / decode | MessagePack `Array[Byte]` |
+| `toMap(v)` / `fromMap(m)` | encode / decode | `Map[String, Any]` |
+| `toMsgPack(v)` | encode | MessagePack `Array[Byte]` |
+| `fromJSONValue(v)` | decode | parsed [`JSONValue`](./json) (no string roundtrip) |
+| `pack(p, v, c)` / `unpack(u, c)` | encode / decode | low-level [MessagePack](./msgpack) packer/unpacker |
+
+## Supported Types
+
+Weaver resolves codecs for these out of the box (cross-platform):
+
+- **Primitives**: `Int`, `Long`, `Short`, `Byte`, `Double`, `Float`, `Boolean`,
+  `Char`, `String`, `BigInt`, `BigDecimal`
+- **Common value types**: `UUID`, `java.time.Instant`,
+  [`ULID`](./utilities#ulid), [`ElapsedTime`](./utilities#elapsedtime),
+  `scala.concurrent.duration.Duration`, `java.net.URI`
+- **Collections**: `Option`, `Seq`/`List`/`Vector`/`IndexedSeq`, `Set`, `Map`,
+  `ListMap`, `Array`, `Either`, tuples
+- **Java collections**: `java.util.List`, `java.util.Set`, `java.util.Map`
+- **Case classes** with any combination of the above
+- **Enums and sealed traits** (see [ADTs](#enums-and-sealed-traits))
+
+### JVM-only types
+
+On the JVM, additional `given` weavers are available by importing them
+explicitly (they live in `JvmWeaver` because they depend on JDK types not
+available on Scala.js / Native):
+
+```scala
+import wvlet.uni.weaver.codec.JvmWeaver.given
+// adds: ZonedDateTime, OffsetDateTime, LocalDate, LocalDateTime,
+//       java.time.Duration, java.io.File, java.net.URL,
+//       java.nio.file.Path, java.util.Optional[A]
+```
+
+## Enums and Sealed Traits
+
+Scala 3 enums encode as their **case name** string:
+
+```scala
+enum Color derives Weaver:
+  case Red, Green, Blue
+
+Weaver.toJson(Color.Green)            // "Green"
+Weaver.fromJson[Color](""""Blue"""")  // Color.Blue
+```
+
+Sealed traits (ADTs) encode as a **flat object with a discriminator field**
+added alongside the case's own fields. The default discriminator is `@type`:
+
+```scala
+sealed trait Shape derives Weaver
+case class Circle(radius: Double)            extends Shape
+case class Rectangle(w: Double, h: Double)   extends Shape
+case object Unknown                          extends Shape
+
+Weaver.toJson(Circle(1.0))   // {"@type":"Circle","radius":1.0}
+Weaver.toJson(Unknown)       // {"@type":"Unknown"}
+```
+
+Change the discriminator via [`WeaverConfig`](#configuration):
+
+```scala
+import wvlet.uni.weaver.WeaverConfig
+
+val cfg = WeaverConfig().withDiscriminatorFieldName("kind")
+Weaver.toJson(Circle(1.0), cfg)   // {"kind":"Circle","radius":1.0}
+```
+
+## Configuration
+
+`WeaverConfig` is an optional last argument on every method (it defaults to
+`WeaverConfig()`):
+
+| Field | Default | Effect |
+|-------|---------|--------|
+| `discriminatorFieldName` | `"@type"` | Field name used to tag sealed-trait cases |
+
+```scala
+import wvlet.uni.weaver.WeaverConfig
+
+val config = WeaverConfig().withDiscriminatorFieldName("type")
+val json   = Weaver.toJson(shape, config)
+```
+
+## Runtime Weavers from Surface
+
+When you only have a [`Surface`](./surface) — for example deriving a codec for a
+method's parameter types in the RPC layer — build a `Weaver` at runtime instead
+of compile time:
+
+```scala
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.surface.Surface
+
+val surface = Surface.of[Person]
+val weaver  = Weaver.fromSurface(surface)   // Weaver[?]
+```
+
+`fromSurface` caches results, supports self-recursive types (e.g.
+`class Tree(children: List[Tree])`), and is what the RPC framework uses to wire
+up codecs without compile-time type information.
+
+For types that aren't directly supported, `fromSurface` falls back to a lossy
+empty-object weaver. Use `Weaver.fromSurfaceOpt(surface)`, which returns `None`
+when the resulting weaver tree contains that fallback at any position, if you
+want to detect the gap and choose a different encoding. See the
+[ADR](https://github.com/wvlet/uni/blob/main/adr/2026-05-04-fromsurfaceopt-and-innerweavers.md)
+for the rationale.
+
+## Custom Weavers
+
+Provide a `given Weaver[A]` to control encoding for a type Weaver can't derive
+(or shouldn't derive losslessly — e.g. an open abstract type). Implement `pack`
+and `unpack` against the low-level [MessagePack](./msgpack) packer/unpacker:
+
+```scala
+import wvlet.uni.weaver.{Weaver, WeaverConfig, WeaverContext}
+import wvlet.uni.msgpack.spi.{Packer, Unpacker}
+
+opaque type Email = String
+
+given Weaver[Email] with
+  def pack(p: Packer, v: Email, config: WeaverConfig): Unit =
+    p.packString(v)
+  def unpack(u: Unpacker, context: WeaverContext): Unit =
+    context.setObject(u.unpackString)
+```
+
+Once in scope, the custom weaver participates in derivation: any case class with
+an `Email` field will use it automatically.
+
+## Cross-Platform Support
+
+Weaver works on JVM, Scala.js, and Scala Native. The core type set is identical
+on all three; only the `JvmWeaver` extras above are JVM-specific.

--- a/docs/dom/index.md
+++ b/docs/dom/index.md
@@ -1,0 +1,267 @@
+# Web UI (RxElement)
+
+`wvlet.uni.dom` is a reactive DOM toolkit for building browser UIs in Scala.js.
+Components are plain Scala classes, the HTML/SVG DSL is type-checked, and any
+[`Rx`](../rx/) value embedded in the markup re-renders the affected DOM in place
+when it changes — no virtual DOM, no separate template language.
+
+::: warning Scala.js only
+This module lives under `uni/.js` and targets the browser. There is no JVM or
+Scala Native counterpart. Add the `uni` dependency to a Scala.js project to use
+it.
+:::
+
+## Setup
+
+Every example below assumes these imports. The `given` import enables embedding
+`String`, `Int`, `Rx`, `Seq`, and `Option` directly as children/attribute
+values; `implicitConversions` is required by Scala 3 for those conversions.
+
+```scala
+import wvlet.uni.dom.all.*
+import wvlet.uni.dom.all.given
+import wvlet.uni.rx.Rx
+import scala.language.implicitConversions
+```
+
+## Hello World
+
+Extend `RxElement` and implement the single abstract method `def render`, then
+mount it with the `renderTo` extension:
+
+```scala
+class Hello extends RxElement:
+  override def render: RxElement = div("Hello, World!")
+
+Hello().renderTo("app")   // mounts into <div id="app"> (created if absent)
+```
+
+`renderTo(nodeId)` returns an [`RxDomNode`](#mounting-and-teardown). If no element
+with that id exists, it creates a `<div id=nodeId>` and appends it to
+`document.body`.
+
+## Components
+
+### RxElement
+
+`RxElement` is the component base. Override `render` to return the markup; add
+lifecycle hooks as needed (all default to no-ops):
+
+| Hook | When |
+|------|------|
+| `def render: RxElement` | produces the markup (required) |
+| `beforeRender: Unit` | before the first render |
+| `onMount(node: Any): Unit` | after the element is attached to the DOM (`node` is the `dom.Node`) |
+| `beforeUnmount: Unit` | before the element is detached |
+
+```scala
+class Panel extends RxElement:
+  override def beforeRender: Unit  = println("about to render")
+  override def onMount(node: Any): Unit = println("mounted")
+  override def render: RxElement   = div(cls -> "panel", "content")
+```
+
+Components nest by embedding one in another's markup:
+
+```scala
+class Inner extends RxElement:
+  override def render: RxElement = span("inner")
+
+class Outer extends RxElement:
+  override def render: RxElement = div(Inner())
+```
+
+### RxComponent
+
+`RxComponent` is a `trait` for "chrome" that wraps caller-provided content.
+Override `render(content: RxElement)` and invoke it with `apply(content)` (or
+`apply()` for empty content):
+
+```scala
+object MainFrame extends RxComponent:
+  override def render(content: RxElement): RxElement =
+    div(cls -> "main-frame", content)
+
+MainFrame(span("editor")).renderTo("app")   // chrome wraps "editor"
+```
+
+## HTML DSL
+
+### Tags
+
+HTML tags are values (`div`, `span`, `h1`–`h6`, `p`, `a`, `img`, `ul`, `li`,
+`table`, `form`, `input`, `button`, `select`, …). Calling a tag with children
+and attributes builds an element:
+
+```scala
+div(cls -> "container", id -> "main",
+  h1("Title"),
+  p("Some content"),
+  a(href -> "/next", "Go next")
+)
+```
+
+### Attributes
+
+Attributes use `name -> value` (or call syntax `name(value)`):
+
+```scala
+input(tpe -> "email", placeholder -> "you@example.com", required.noValue)
+div(data("user-id") -> "123", data("role") -> "admin")   // data-* attributes
+```
+
+A few names are suffixed to avoid clashing with same-named tags — the **tag**
+keeps the bare name:
+
+| Use this attribute | for the HTML attribute | because the bare name is the tag |
+|--------------------|------------------------|----------------------------------|
+| `cls` (or `` `class` ``) | `class` | — |
+| `styleAttr` | `style` | `style` is the `<style>` tag / CSS builder |
+| `titleAttr` | `title` | `title` is the `<title>` tag |
+| `tpe` (or `` `type` ``) | `type` | — |
+| `forId` (or `` `for` ``) | `for` | — |
+
+Use `+=` to **append** to an existing value (handy for classes), and `.noValue`
+for boolean attributes:
+
+```scala
+div(cls -> "base", cls += "highlighted")   // class="base highlighted"
+button(disabled.noValue, "Can't click")
+```
+
+### Events
+
+Event handlers accept either a typed `E => U` or a no-arg `() => U`:
+
+```scala
+button(onclick -> { () => println("clicked") }, "Click me")
+input(oninput -> { (e: dom.Event) => handle(e) })
+form(onsubmit -> { (e: dom.Event) => e.preventDefault() })
+```
+
+The full set is available: mouse, keyboard, form (`onchange`, `oninput`,
+`onsubmit`), focus, clipboard, drag, touch, pointer, wheel, animation, and media
+events.
+
+### Inline styles and CSS
+
+The `style` object is dual-purpose — typed CSS properties, a raw string, or the
+`<style>` tag:
+
+```scala
+div(style(display := "flex", gap := "8px", color := "blue"))  // typed properties
+div(styleAttr -> "display:flex; gap:8px;")                    // raw string
+head(style("body { margin: 0; }"))                            // <style> element
+```
+
+### Conditionals
+
+`when` / `unless` include markup conditionally (they render nothing when the
+condition doesn't hold):
+
+```scala
+div(
+  when(isLoggedIn, span("Welcome back")),
+  unless(items.isEmpty, ul(/* ... */))
+)
+```
+
+### SVG
+
+SVG tags and attributes are in scope from the same import; the SVG namespace is
+applied automatically to children of an `<svg>`:
+
+```scala
+svg(viewBox -> "0 0 100 100",
+  circle(cx -> 50, cy -> 50, r -> 40, fill -> "blue")
+)
+```
+
+## Reactivity
+
+### Embedding Rx
+
+Embed an `Rx[A]` (or `RxVar[A]`) anywhere a child is expected; the toolkit
+subscribes and re-renders just that section when the value changes:
+
+```scala
+class Counter extends RxElement:
+  private val count = Rx.variable(0)
+  override def render: RxElement =
+    div(cls -> "counter",
+      p(count.map(c => s"Count: ${c}")),
+      button(onclick -> { () => count.update(_ + 1) }, "Increment")
+    )
+```
+
+`Rx.variable(x)` creates an `RxVar`; mutate it with `update(f)`, `set(v)`, or
+`:= v`. An `Rx` passed as an **attribute** value is likewise subscribed:
+
+```scala
+val activeClass = Rx.variable("idle")
+div(cls -> activeClass, "status")   // class updates when activeClass changes
+```
+
+### Two-way form binding
+
+Bind a `RxVar` to a form control so edits flow back into the variable and
+programmatic changes flow into the DOM:
+
+```scala
+val username = Rx.variable("")
+input(tpe -> "text", value.bind(username))      // text input / textarea
+
+val subscribed = Rx.variable(false)
+input(tpe -> "checkbox", checked.bind(subscribed))
+```
+
+Use `value.bindOnChange(v)` to update on the `change` event (e.g. for `<select>`)
+instead of on every keystroke.
+
+## Mounting and teardown
+
+`renderTo` (and the lower-level `DomRenderer`) returns an `RxDomNode` holding the
+created `dom.Node` and a `Cancelable`. **Keep it and call `cancel()`** to detach
+listeners and unsubscribe the `Rx` bindings when the component goes away:
+
+```scala
+val mounted = MyApp().renderTo("app")
+// later:
+mounted.cancelable.cancel
+```
+
+`RxDomNode` also exposes `outerHTML`, `innerHTML`, and `textContent` for
+inspection (used heavily in tests).
+
+For advanced cases, `wvlet.uni.dom.DomRenderer` offers `renderToNode`,
+`renderTo(node, ...)`, `createNode`, and `renderToHtml` (server-side string
+rendering).
+
+## Browser Integrations
+
+The package includes reactive wrappers over common browser APIs. Each is an
+`object` exposing `Rx` streams and/or helper nodes (imported via
+`wvlet.uni.dom.all.*`):
+
+| Module | What it does |
+|--------|--------------|
+| `Router` | Client-side routing over the History API — `Route`/`RouterInstance`, `outlet: Rx[A]`, `push`/`replace`, `link`, `isActive` |
+| `Portal` | Render children into a different DOM subtree (`Portal.toBody`, `Portal.to(id)`) |
+| `Clipboard` | Read/write the clipboard, `onCopy`/`onPaste` handlers, `copyOnClick` |
+| `DragDrop` | Drag-and-drop state machine — `draggable`, `dropZone`, `fileDropZone`, `state: Rx[DragState]` |
+| `Geolocation` | `getCurrentPosition`, `watch` → `position: Rx[Option[GeoPosition]]` |
+| `Storage` | Reactive `localStorage`/`sessionStorage` — `Storage.local[A](key, default)` → an `RxVar`-like `StorageVar` |
+| `MediaQuery` | `MediaQuery.matches(query)` → `.rx: Rx[Boolean]` for responsive layouts |
+| `Focus` | Focus tracking (`active: Rx[Option[Element]]`), focus traps, autofocus on mount |
+| `Keyboard` | Global shortcuts — `Keyboard.bind("ctrl+s", () => save())`, `isPressed`, `modifiers` |
+| `ClickOutside` | Detect clicks outside an element (`hide(visible)` for menus/popovers) |
+| `NetworkStatus` | `online`/`offline: Rx[Boolean]` |
+| `WindowScroll` / `WindowDimensions` / `WindowVisibility` | Reactive window scroll position, size, and tab visibility |
+| `AnimationFrame` | `requestAnimationFrame` loops — `loop`, `once`, `fixedStep`, `timed` |
+| `Transition` | Enter/leave CSS transitions — `fade(visible)(...)`, `slide(visible)(...)` |
+| `Validate` | Form validation — `required`, `minLength`, `pattern`, `email`; field and whole-form state |
+| `DomRef` | Direct element handles — `current: Option[E]`, `focus()`, `getBoundingClientRect()` |
+| `DomObservers` | `IntersectionObserver` / `ResizeObserver` bindings (lazy load, element-size → `RxVar`) |
+
+Each integration that attaches global listeners returns a `Cancelable` (or has a
+`stop()`), so you can detach it during teardown.

--- a/docs/http/client.md
+++ b/docs/http/client.md
@@ -18,6 +18,42 @@ val client = Http.client.newSyncClient
 val asyncClient = Http.client.newAsyncClient
 ```
 
+## Platform Backends
+
+The same `Http.client` API runs on all three Scala platforms. uni selects the
+right transport for the runtime automatically — you write the request once and
+it works on JVM, Scala.js, and Scala Native.
+
+| Platform | Sync (`newSyncClient`) | Async (`newAsyncClient`) | Underlying transport |
+|----------|------------------------|--------------------------|----------------------|
+| **JVM** | `JavaHttpChannel` | `JavaHttpAsyncChannel` | `java.net.http.HttpClient` (Java 11+) |
+| **Scala.js** | `NodeSyncHttpChannel` *(Node.js only)* | `FetchChannel` | Fetch API (browser + Node), Node `worker_threads` for sync |
+| **Scala Native** | `CurlChannel` | `CurlAsyncChannel` | libcurl |
+
+Both client types share the same `send` / `sendStreaming` interface, so most
+code is platform-agnostic. A few platform constraints are worth knowing:
+
+- **Browsers have no synchronous HTTP.** On Scala.js, `newSyncClient` works
+  only under Node.js (it uses `worker_threads` + `Atomics.wait` on a
+  `SharedArrayBuffer`). In a browser, calling it throws `NotImplementedError` —
+  use `newAsyncClient`, which returns `Rx[HttpResponse]`, instead. For the
+  background on the Node sync implementation, see the
+  [ADR](https://github.com/wvlet/uni/blob/main/adr/2026-05-14-nodejs-sync-http.md).
+- **Scala Native requires libcurl** to be available at runtime; the factory
+  initializes it globally the first time a client is created.
+- **The async client is the cross-platform common denominator.** If you target
+  the browser, prefer the async API everywhere so the same code compiles for
+  every platform.
+
+To plug in a custom transport (testing, a different HTTP library), set a
+channel factory globally:
+
+```scala
+import wvlet.uni.http.Http
+
+Http.setDefaultChannelFactory(myChannelFactory)
+```
+
 ## Making Requests
 
 ### GET Request

--- a/docs/http/index.md
+++ b/docs/http/index.md
@@ -9,8 +9,11 @@ automatic retry, streaming support, and reactive integration.
 | Component | Description |
 |-----------|-------------|
 | [HTTP Client](./client) | Sync and async HTTP clients |
-| [REST Server](./server) | Netty-based HTTP server with routing |
+| [REST Server](./server) | Cross-platform HTTP server (Netty / Node.js / Native) with routing |
 | [Router](./router) | Type-safe route definitions |
+| [RPC](./rpc) | Type-safe remote calls over HTTP, with client code generation |
+| [Server-Sent Events](./sse) | One-way server→client streaming |
+| [WebSocket Client](./websocket) | Cross-platform bidirectional WebSocket client |
 | [Retry Strategies](./retry) | Automatic retry for transient failures |
 
 ## Quick Start

--- a/docs/http/index.md
+++ b/docs/http/index.md
@@ -1,6 +1,8 @@
 # HTTP Framework
 
-uni provides a cross-platform HTTP client and a Netty-based HTTP server with automatic retry, streaming support, and reactive integration.
+uni provides a cross-platform HTTP client and server — running on the JVM
+(Netty), Scala.js (Fetch / Node.js), and Scala Native (libcurl) — with
+automatic retry, streaming support, and reactive integration.
 
 ## Overview
 

--- a/docs/http/rpc.md
+++ b/docs/http/rpc.md
@@ -83,6 +83,89 @@ Parameters are sent as JSON in the request body:
 
 Parameter names are matched flexibly — `userId`, `user_id`, and `user-id` all match the same parameter. Missing optional parameters (`Option[T]`) default to `None`, and parameters with default values use those defaults.
 
+## Generating a Client
+
+Instead of hand-writing request URLs and JSON, generate a **type-safe client**
+from the same service trait with the `sbt-uni` plugin. The generated client
+mirrors the trait's methods, so calls are checked by the compiler.
+
+::: tip JVM build-time only
+Client generation runs at build time on the JVM via sbt. The *generated* client
+is ordinary code that compiles for any platform the trait supports.
+:::
+
+### Enable the plugin
+
+In `project/plugins.sbt`:
+
+```scala
+addSbtPlugin("org.wvlet.uni" % "sbt-uni" % "__UNI_VERSION__")
+```
+
+In `build.sbt`, enable `UniPlugin` on the project that should contain the
+generated client, depend on the project that defines the service trait, and list
+your generation targets:
+
+```scala
+lazy val app = project
+  .enablePlugins(UniPlugin)
+  .dependsOn(api) // project containing UserService
+  .settings(
+    uniHttpClients := Seq("com.example.api.UserService:rpc")
+  )
+```
+
+`uniHttpClients` is wired into `Compile / sourceGenerators`, so clients are
+regenerated and compiled automatically on the next `compile`. Generation runs
+in-process (no forked JVM) and skips files whose content is unchanged.
+
+### Target spec format
+
+Each entry is `"fullyQualifiedTrait:clientType[:targetPackage]"`:
+
+| Part | Values | Notes |
+|------|--------|-------|
+| `clientType` | `sync`, `async`, `both`, `rpc` | `rpc` is an alias for `sync` |
+| `targetPackage` | optional | defaults to the trait's package + `.client` |
+
+```scala
+uniHttpClients := Seq(
+  "com.example.api.UserService:rpc",                       // SyncClient, default package
+  "com.example.api.OrderService:both:com.example.client"   // Sync + Async clients
+)
+```
+
+Override the output directory with `uniHttpCodegenOutDir` (defaults to
+`Compile / sourceManaged`).
+
+### Using the generated client
+
+Generation produces an `object <ServiceName>Client` containing a `SyncClient`
+and/or `AsyncClient`, each wrapping an [HTTP client](./client). Construct one
+over a configured client pointed at the server's base URL:
+
+```scala
+import wvlet.uni.http.Http
+import com.example.client.UserServiceClient
+
+// Sync — methods return the declared types directly
+val sync = UserServiceClient.SyncClient(
+  Http.client.withBaseUri("http://localhost:8080").newSyncClient
+)
+val user: User = sync.getUser(42)
+
+// Async — methods return Rx[...]
+val async = UserServiceClient.AsyncClient(
+  Http.client.withBaseUri("http://localhost:8080").newAsyncClient
+)
+async.getUser(42).map(user => println(user.name))
+```
+
+Under the hood the generated methods delegate to `RPCClient`, which serializes
+arguments and decodes responses with [Weaver](../core/weaver) — the same wire
+format the [RPC router](#creating-an-rpc-router) expects, so client and server
+stay in sync.
+
 ## RPC Status Codes
 
 `RPCStatus` provides structured error codes organized by category:

--- a/docs/http/server.md
+++ b/docs/http/server.md
@@ -1,6 +1,16 @@
 # REST Server
 
-uni provides a Netty-based HTTP server with a type-safe router framework for building REST APIs.
+uni provides HTTP servers on all three Scala platforms — Netty on the JVM,
+the Node.js `http` module on Scala.js, and a native socket server on Scala
+Native — behind one shared configuration API. On the JVM you additionally get a
+type-safe, annotation-based router framework for building REST APIs.
+
+::: tip Which API is cross-platform?
+**Functional handlers** (`withHandler` / `withRxHandler`) and **filters** work
+on every platform. The **annotation router** (`@Endpoint`, `Router.of[T]`,
+`RouterHandler`) and **WebSocket routes** are **JVM/Netty-only** today — see
+[Cross-Platform Servers](#cross-platform-servers).
+:::
 
 ## Quick Start
 
@@ -29,6 +39,73 @@ NettyServer
     // Server runs until the block completes
   }
 ```
+
+## Cross-Platform Servers
+
+Each platform has its own server entry point, but they expose the **same
+configuration API** and all start an [`HttpServer`](#server-lifecycle):
+
+| Platform | Entry point | Import | Backend |
+|----------|-------------|--------|---------|
+| **JVM** | `NettyServer` | `wvlet.uni.http.netty.NettyServer` (module `uni-netty`) | Netty |
+| **Scala.js** | `NodeServer` | `wvlet.uni.http.NodeServer` | Node.js `http` |
+| **Scala Native** | `NativeServer` | `wvlet.uni.http.NativeServer` | native sockets |
+
+All three share these builder methods:
+
+```scala
+.withPort(8080)                       // 0 picks a random free port
+.withHost("0.0.0.0")
+.withName("my-server")
+.withHandler(f: Request => Response)        // sync handler
+.withRxHandler(f: Request => Rx[Response])  // async handler
+.withFilter(filter)                         // RxHttpFilter
+.start { server => ... }                    // block form, auto-stops
+.start()                                    // returns the HttpServer
+```
+
+A handler that compiles and runs identically on every platform:
+
+```scala
+// JVM example — swap NettyServer for NodeServer / NativeServer on JS / Native
+import wvlet.uni.http.{Request, Response}
+import wvlet.uni.http.netty.NettyServer
+
+NettyServer
+  .withPort(8080)
+  .withRxHandler { request =>
+    Rx.single(Response.ok(s"Hello from ${request.path}"))
+  }
+  .start { server =>
+    println(s"Listening on ${server.localAddress}")
+  }
+```
+
+::: warning JVM-only features
+The annotation router (`@Endpoint`, `Router.of[T]`, `RouterHandler`),
+[server-side WebSocket](#websocket), and the Netty tuning knobs
+(`withMaxContentLength`, native transport, graceful shutdown) exist only on the
+JVM. On Scala.js / Scala Native, route requests yourself inside a functional
+handler:
+
+```scala
+import wvlet.uni.http.NodeServer  // or NativeServer
+
+NodeServer
+  .withPort(8080)
+  .withRxHandler { request =>
+    request.path match
+      case "/health"      => Rx.single(Response.ok("ok"))
+      case s"/users/${id}" => Rx.single(Response.ok(s"user ${id}"))
+      case _              => Rx.single(Response.notFound)
+  }
+  .start()
+```
+:::
+
+The rest of this page uses `NettyServer` and the JVM annotation router, which is
+the richest path. The request/response model, response conversion, and filters
+described below apply to functional handlers on every platform.
 
 ## Defining Endpoints
 

--- a/docs/http/server.md
+++ b/docs/http/server.md
@@ -474,7 +474,8 @@ NettyServer
 ```
 
 WebSocket support is server-side and JVM (Netty) only. WebSocket routes coexist with REST endpoints
-on the same server and port.
+on the same server and port. For connecting *to* a WebSocket endpoint, see the cross-platform
+[WebSocket Client](./websocket).
 
 ## Combining Controllers
 

--- a/docs/http/websocket.md
+++ b/docs/http/websocket.md
@@ -1,0 +1,103 @@
+# WebSocket Client
+
+uni includes a cross-platform WebSocket **client** that runs on the JVM, Scala.js,
+and Scala Native. It connects to `ws://` / `wss://` endpoints and uses the same
+`WebSocketHandler` / `WebSocketContext` abstraction as the
+[server-side WebSocket](./server#websocket) support, so handler code is symmetric
+on both ends.
+
+## Connecting
+
+`Http.webSocketClient` returns the platform's `WebSocketClient`. Call `connect`
+with the URL and a handler; it returns an `Rx[WebSocketContext]` that emits the
+open context once the handshake completes (or fails with the handshake error):
+
+```scala
+import wvlet.uni.http.{Http, WebSocketContext, WebSocketHandler}
+
+val handler = new WebSocketHandler:
+  override def onTextMessage(ctx: WebSocketContext, message: String): Unit =
+    println(s"received: ${message}")
+
+Http.webSocketClient
+  .connect("ws://localhost:8080/ws/echo", handler)
+  .subscribe { ctx =>
+    ctx.send("hello")     // connection is open here
+  }
+```
+
+The handler's `onOpen(ctx)` fires for the same event, so you can also do the
+initial send there instead of in `subscribe`.
+
+## Handler Callbacks
+
+The client implements the same `WebSocketHandler` as the server. Every callback
+has a no-op default, so override only what you need:
+
+| Callback | When it fires |
+|----------|---------------|
+| `onOpen(ctx)` | the handshake completed |
+| `onTextMessage(ctx, message)` | a text message arrived |
+| `onBinaryMessage(ctx, message)` | a binary message arrived (`Array[Byte]`) |
+| `onClose(ctx)` | the connection closed; delivered exactly once |
+| `onError(ctx, e)` | a **handler callback** threw |
+
+::: tip Errors vs. close
+Transport/protocol failures map to `onClose`, not `onError` — `onError` is
+reserved for exceptions thrown inside your own callbacks. A failure *before* the
+connection opens surfaces through the `connect` stream (as an `Rx` error).
+:::
+
+## Sending and Closing
+
+The `WebSocketContext` controls the connection; its `send`/`close` methods are
+safe to call from any thread:
+
+```scala
+ctx.request                       // the original HTTP upgrade Request
+ctx.send("hello")                 // text frame
+ctx.send(Array[Byte](1, 2, 3))    // binary frame
+ctx.close()                       // normal closure (1000)
+ctx.close(1001, "going away")     // close with a status code and reason
+```
+
+## Heartbeat (ping/pong)
+
+A client-side ping/pong heartbeat detects a dead-but-idle connection. It is
+**off by default** and enabled by passing a ping interval (in milliseconds) as
+the third argument to `connect`:
+
+```scala
+// Ping an idle connection every 30s; close it if the peer stops responding.
+Http.webSocketClient.connect("wss://example.com/ws", handler, pingIntervalMillis = 30000)
+```
+
+When enabled, an idle interval sends a `Ping`; if the next interval is still idle
+with the ping unanswered, the client closes the connection (status `1011`, "ping
+timeout"). Any inbound frame proves liveness and clears a pending ping.
+
+::: warning Not available on Scala.js
+The browser/Node global `WebSocket` API cannot send protocol pings, so
+`pingIntervalMillis` is **ignored on Scala.js**. Use it on JVM/Native, or
+implement application-level keepalive messages if you need liveness detection in
+the browser.
+:::
+
+## Platform Support
+
+| Platform | Backend | Transport | Notes |
+|----------|---------|-----------|-------|
+| **JVM** | `JavaWebSocketClient` | `java.net.http.WebSocket` (Java 11+) | `ws://` and `wss://`; heartbeat supported |
+| **Scala.js** | `JSWebSocketClient` | global `WebSocket` | browsers or **Node.js ≥ 22**; `pingIntervalMillis` ignored |
+| **Scala Native** | `NativeWebSocketClient` | raw POSIX socket | `ws://` only (no TLS); host must be an IP or `localhost` (no DNS); max frame 1 MB |
+
+`Http.webSocketClient` resolves to the right backend automatically. On a platform
+without WebSocket support the base client throws
+`NotImplementedError`, but all three shipped platforms provide a backend.
+
+## See Also
+
+- [Server-side WebSocket](./server#websocket) — register `WebSocketHandler`
+  routes on a Netty server (JVM).
+- [Server-Sent Events](./sse) — one-way server→client streaming when you don't
+  need a bidirectional channel.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,9 @@ features:
   - title: CLI Utilities
     details: Terminal styling, progress indicators, and type-safe command-line argument parsing.
     link: /cli/
+  - title: Web UI (Scala.js)
+    details: Build reactive browser UIs with RxElement — type-checked HTML/SVG, Rx-driven updates, and browser integrations (Router, Storage, Keyboard, and more).
+    link: /dom/
   - title: UniTest
     details: Lightweight testing framework with expressive assertions, property-based testing, and cross-platform support.
     link: /core/unitest


### PR DESCRIPTION
## Why

Several major, user-facing modules were undocumented or only mentioned in passing, so the docs undersold the library. This pass closes those gaps with reference pages **verified against source** (per `docs/CLAUDE.md` Rule #0), and the cross-platform capabilities are now featured explicitly rather than implied.

## What

| Area | Change |
|------|--------|
| **HTTP client** | New *Platform Backends* section — JVM `java.net.http`, Scala.js Fetch + Node sync, Scala Native libcurl; browser-no-sync and libcurl caveats |
| **HTTP server** | No longer presented as Netty-only — documents `NettyServer`/`NodeServer`/`NativeServer` behind one config API, with the honest caveat that the annotation router + WebSocket are **JVM/Netty-only** |
| **Weaver** | New page (`core/weaver.md`) for the core derivation-based serialization engine (JSON / MessagePack / Map, enums & sealed traits, custom weavers, `fromSurface`) |
| **BackgroundTask** | New page (`control/background-task.md`) for the new cancellable, progress-pollable worker + JVM/Native-vs-JS behavior |
| **Utilities** | Added CrockfordBase32, PrefixedULID, StopWatch, Timer |
| **Web UI** | New page (`dom/index.md`) + sidebar section for the Scala.js RxElement DOM toolkit (~40 files) |
| **RPC** | New section documenting sbt-time type-safe client generation via the `sbt-uni` plugin |

## Verification

- Every documented API/signature/option checked against source and tests (e.g. corrected an invented `withServerAddress` → real `withBaseUri`; confirmed `RouterHandler` is JVM-only; sbt plugin coords/usage checked against `sbt-uni/src/sbt-test`).
- Sidebars updated in **both** `/guide/` and `/` blocks.
- `pnpm docs:build` passes (no dead links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)