### PR TITLE
docs: Make the Introduction page more engaging

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,52 +1,105 @@
 # Introduction
 
-**Uni** — Essential Scala Utilities, refined for Scala 3 with minimal dependencies.
+**Uni is the standard library Scala 3 didn't ship with.**
 
-Uni provides small, reusable building blocks that complement the Scala standard library. It consolidates foundational utilities from the [wvlet/airframe](https://github.com/wvlet/airframe) project into a single, cohesive library.
+Logging, dependency injection, JSON & MessagePack, reactive streams, HTTP
+clients and servers, RPC, and a browser UI toolkit — small, composable pieces
+that work *identically* on the **JVM**, in the **browser** (Scala.js), and as
+**native binaries** (Scala Native), with almost no external dependencies.
 
-## What is Uni?
+It distills the most-used building blocks of the
+[Airframe](https://github.com/wvlet/airframe) ecosystem into one cohesive,
+Scala-3-first library.
 
-Uni provides:
+::: tip Get going in 30 seconds
+Add one dependency ([Installation](./installation)) and you have all of it —
+no à-la-carte modules to assemble.
+:::
 
-- **Design** - Object wiring with lifecycle management
-- **Logging** - Structured logging with source code location tracking
-- **Serialization** - JSON parsing/generation and MessagePack binary format
-- **FileSystem** - Cross-platform file I/O and path handling for JVM, Scala.js, and Scala Native
-- **HTTP Client** - Cross-platform client with retry and streaming support
-- **Reactive Streams** - Rx-based operators for async data flows
-- **Control Flow** - Retry logic, circuit breakers, and resource management
-- **CLI Utilities** - Terminal styling, progress bars, and command launching
-- **Type Introspection** - Compile-time reflection with Surface
+## A quick taste
 
-## Design Philosophy
+Dependency injection, structured logging, and lifecycle management — three
+things you usually reach for three libraries for — in a handful of lines:
 
-uni follows these principles:
+```scala
+import wvlet.uni.design.Design
+import wvlet.uni.log.LogSupport
 
-1. **Minimal Dependencies** - Core functionality without heavy external dependencies
-2. **Cross-Platform** - Works on JVM, Scala.js, and Scala Native
-3. **Scala 3 First** - Modern Scala 3 syntax and features
-4. **Composable** - Small, focused utilities that combine well
-5. **Production Ready** - Battle-tested code from the Airframe ecosystem
+class GreeterService extends LogSupport:
+  def greet(name: String): String =
+    info(s"Greeting ${name}")      // logs with source file + line
+    s"Hello, ${name}!"
 
-## Module Structure
+@main def main =
+  Design.newDesign
+    .bindSingleton[GreeterService]
+    .build[GreeterService] { greeter =>   // wired, started, and cleaned up
+      println(greeter.greet("Uni"))
+    }
+```
 
-### uni — Core Utilities
+## Why Uni?
+
+- 🪶 **Minimal dependencies** — foundational utilities without dragging in a
+  heavy framework.
+- 🌍 **One codebase, three runtimes** — the same source compiles for JVM,
+  Scala.js, and Scala Native.
+- 🧩 **Composable** — small, focused APIs designed to combine, not to lock you in.
+- ⚡ **Scala 3 first** — built around `derives`, `given`, enums, and macros.
+- 🔋 **Production-tested** — battle-hardened code, refined from the Airframe
+  ecosystem.
+
+## What's inside
+
+#### Core
 
 | Module | Description |
 |--------|-------------|
-| [Design](/core/design) | Object wiring with lifecycle management |
-| [Logging](/core/logging) | Structured logging with source code location tracking |
-| [JSON](/core/json) | JSON parsing and generation |
-| [MessagePack](/core/msgpack) | Binary serialization format |
+| [Design](/core/design) | Object wiring (DI) with lifecycle management |
+| [Logging](/core/logging) | Logging with source-location tracking |
 | [Surface](/core/surface) | Compile-time type introspection |
-| [FileSystem](/core/filesystem) | Cross-platform file I/O with `IOPath` for JVM, Scala.js, and Scala Native |
-| [HTTP](/http/) | HTTP client with retry and streaming support |
+| [FileSystem](/core/filesystem) | Cross-platform file I/O with `IOPath` |
+
+#### Data & Serialization
+
+| Module | Description |
+|--------|-------------|
+| [JSON](/core/json) | Pure-Scala JSON parser and DSL |
+| [MessagePack](/core/msgpack) | Compact binary serialization |
+| [Weaver](/core/weaver) | Derivation-based codecs — JSON / MessagePack / `Map` from one `derives Weaver` |
+
+#### Async & Control Flow
+
+| Module | Description |
+|--------|-------------|
 | [Rx](/rx/) | Reactive streams and async data flows |
-| [Control](/control/) | Retry logic, circuit breakers, and caching |
-| [CLI](/cli/) | Terminal styling, progress bars, and command launching |
+| [Control](/control/) | Retry, circuit breaker, rate limiter, cache, resources |
+| [BackgroundTask](/control/background-task) | Cancellable, progress-pollable background workers |
 
-## Next Steps
+#### HTTP & RPC
 
-- [Installation](./installation) - Add uni to your project
-- [Design Principles](./principles) - Learn about the architecture
-- [Core Utilities](/core/) - Explore the foundational APIs
+| Module | Description |
+|--------|-------------|
+| [HTTP](/http/) | Cross-platform client **and** server (Netty / Node.js / Native) |
+| [RPC](/http/rpc) | Type-safe remote calls, with client code generation |
+| [WebSocket](/http/websocket) | Cross-platform bidirectional WebSocket client |
+| [Server-Sent Events](/http/sse) | One-way server→client streaming |
+
+#### UI & CLI
+
+| Module | Description |
+|--------|-------------|
+| [CLI](/cli/) | Terminal styling, progress bars, command launching |
+| [Web UI](/dom/) | Reactive browser UIs with RxElement (Scala.js) |
+
+#### Testing
+
+| Module | Description |
+|--------|-------------|
+| [UniTest](/core/unitest) | Lightweight, expressive, cross-platform test framework |
+
+## Next steps
+
+- 📦 [**Installation**](./installation) — add Uni to your sbt / Scala CLI project
+- 🧭 [**Design Principles**](./principles) — the architecture and the *why*
+- 🔍 [**Core Utilities**](/core/) — start exploring the foundational APIs


### PR DESCRIPTION
## Why

The [Introduction](https://wvlet.org/uni/guide/) page read as a flat feature list, had no code, and predated several modules (Weaver, BackgroundTask, WebSocket client, Web UI). First impressions matter — this reworks it to actually sell the library on arrival.

## What

- **Stronger hook** — "the standard library Scala 3 didn't ship with" + a one-paragraph value prop emphasizing the cross-platform story.
- **A quick taste** — a short, real DI + logging + lifecycle example (verified APIs: `Design.newDesign` / `bindSingleton` / `build`, `LogSupport`).
- **Why Uni?** — five scannable value props with icons (minimal deps, three runtimes, composable, Scala 3 first, production-tested).
- **What's inside** — module tables grouped by theme (Core / Data & Serialization / Async & Control / HTTP & RPC / UI & CLI / Testing), now including Weaver, BackgroundTask, WebSocket, and the Web UI toolkit.
- Styled **Next steps**.

## Verification

- All internal links resolve; `pnpm docs:build` passes (dead-link-clean).
- Code snippet uses APIs already documented and verified elsewhere in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)