### PR TITLE
docs: Fix Introduction wording — Node.js + avoid "dependency injection"

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,10 +2,11 @@
 
 **Uni is the standard library Scala 3 didn't ship with.**
 
-Logging, dependency injection, JSON & MessagePack, reactive streams, HTTP
+Logging, object wiring, JSON & MessagePack, reactive streams, HTTP
 clients and servers, RPC, and a browser UI toolkit — small, composable pieces
-that work *identically* on the **JVM**, in the **browser** (Scala.js), and as
-**native binaries** (Scala Native), with almost no external dependencies.
+that work *identically* on the **JVM**, in the **browser and Node.js**
+(Scala.js), and as **native binaries** (Scala Native), with almost no external
+dependencies.
 
 It distills the most-used building blocks of the
 [Airframe](https://github.com/wvlet/airframe) ecosystem into one cohesive,
@@ -18,8 +19,8 @@ no à-la-carte modules to assemble.
 
 ## A quick taste
 
-Dependency injection, structured logging, and lifecycle management — three
-things you usually reach for three libraries for — in a handful of lines:
+Object wiring, structured logging, and lifecycle management — three things you
+usually reach for three libraries for — in a handful of lines:
 
 ```scala
 import wvlet.uni.design.Design
@@ -55,7 +56,7 @@ class GreeterService extends LogSupport:
 
 | Module | Description |
 |--------|-------------|
-| [Design](/core/design) | Object wiring (DI) with lifecycle management |
+| [Design](/core/design) | Object wiring with lifecycle management |
 | [Logging](/core/logging) | Logging with source-location tracking |
 | [Surface](/core/surface) | Compile-time type introspection |
 | [FileSystem](/core/filesystem) | Cross-platform file I/O with `IOPath` |


### PR DESCRIPTION
Two corrections to the reworked [Introduction](https://wvlet.org/uni/guide/) page:

- **Node.js** — Scala.js runs in both the browser and Node.js (and uni has Node-specific HTTP client/server support), so the cross-platform line now reads "browser and Node.js (Scala.js)".
- **Drop "dependency injection"** — `Design` is intentionally described as *object wiring*, not DI. The rewrite had introduced "dependency injection"/"DI" phrasing in three spots; reverted to the project's wording.

`pnpm docs:build` passes.

> Note: a few other pages (`principles.md`, `uni-walkthrough.md`, `installation.md`, `surface.md`, `unitest.md`, `router.md`) still use "dependency injection"/"DI" for Design — pre-existing, not touched here. Happy to clean those up in a follow-up if you'd like the convention applied site-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)