### PR TITLE
docs(book): Complete The Uni Book — all chapters and appendices

### DIFF
--- a/docs/book/appendix-a-scala3.md
+++ b/docs/book/appendix-a-scala3.md
@@ -1,22 +1,100 @@
 # Appendix A: Scala 3 Syntax Notes for This Book
 
-::: warning Coming soon
-This appendix is an outline. The full draft ships in a follow-up PR.
-:::
+This book uses a handful of Scala 3 features in nearly every example. If
+you are coming from Scala 2, Java, or another typed language, this
+appendix is the short reference for the syntax you'll see — just enough to
+read the chapters comfortably.
 
-## What this appendix will cover
+## Indentation-based syntax
 
-A concise reference for the Scala 3 features this book relies on,
-aimed at readers coming from Scala 2, Java, or another
-strongly-typed language.
+Scala 3 lets you replace braces with significant indentation. A class
+body, method body, or block opens with `:` (for definitions) or is simply
+indented:
 
-Topics:
+```scala
+class Greeter:
+  def greet(name: String): String =
+    val message = s"Hello, ${name}"
+    message
+```
 
-- Indentation-based syntax (and when braces are still handy).
-- `@main` annotated entry points.
-- `given` / `using` for contextual parameters.
-- Enum types and pattern matching.
-- Extension methods.
-- Why `new` is almost never needed.
+Braces still work and are still useful — for a short lambda passed to a
+method, the book often keeps them: `design.build[App] { app => … }`. Use
+whichever reads more clearly; they mean the same thing.
+
+## `@main` entry points
+
+A program's entry point is a method annotated with `@main`, not a magic
+signature on an object:
+
+```scala
+@main def run(): Unit =
+  println("started")
+```
+
+Arguments become method parameters. `@main def fetch(args: String*)` gives
+you the command-line arguments directly, which is how the CLI app in
+[Chapter 2](./ch02-00-cli-app) starts.
+
+## `given` / `using` — contextual parameters
+
+A `using` parameter is supplied by the compiler from a matching `given`
+in scope, instead of being passed explicitly at the call site:
+
+```scala
+given Weaver[User] = Weaver.of[User]
+
+def toJson[A](a: A)(using weaver: Weaver[A]): String = weaver.toJson(a)
+
+toJson(user)   // the Weaver[User] given is found and passed for you
+```
+
+This is how [Weaver](./ch05-00-data) codecs and other typeclass-style
+values travel through the code without cluttering every signature. A
+`derives` clause (`case class User(...) derives Weaver`) generates the
+`given` for you.
+
+## Enums and pattern matching
+
+Scala 3 enums declare a closed set of cases, which you then match on:
+
+```scala
+enum Color:
+  case Red, Green, Blue
+
+def hex(c: Color): String =
+  c match
+    case Color.Red   => "#f00"
+    case Color.Green => "#0f0"
+    case Color.Blue  => "#00f"
+```
+
+The compiler warns if a `match` misses a case, so adding `Color.Black`
+later points you at every place that needs updating. Uni uses enums for
+closed sets like log levels and RPC status codes.
+
+## Extension methods
+
+An `extension` adds methods to a type you don't own:
+
+```scala
+extension (s: String)
+  def shout: String = s.toUpperCase + "!"
+
+"hello".shout   // "HELLO!"
+```
+
+Several Uni APIs read fluently because of extensions — the `shouldBe` in
+[Chapter 11](./ch11-00-testing)'s tests is an extension method on any
+value.
+
+## Why `new` is almost never needed
+
+Scala 3 lets you construct a class by calling it like a function, so the
+book writes `StringBuilder()` and `FakeDatabase()`, not `new
+StringBuilder()`. You'll only see `new` in this book for the rare
+anonymous-class case (overriding methods inline, as with a
+`WebSocketHandler`). If you wrote Scala 2, dropping `new` is the habit to
+unlearn first.
 
 [← 11. Testing with UniTest](./ch11-00-testing) | [Next → Appendix B: Uni and Airframe](./appendix-b-airframe)

--- a/docs/book/appendix-b-airframe.md
+++ b/docs/book/appendix-b-airframe.md
@@ -1,21 +1,55 @@
 # Appendix B: Uni and Airframe — History and Relationship
 
-::: warning Coming soon
-This appendix is an outline. The full draft ships in a follow-up PR.
-:::
+If you've worked in the Scala ecosystem, the ideas in this book may feel
+familiar. That is not an accident: Uni is a refinement of code that began
+in the [Airframe](https://github.com/wvlet/airframe) project. This
+appendix explains the relationship — useful background if you have
+existing Airframe code, and reassurance that what you've learned
+transfers.
 
-## What this appendix will cover
+## Where Uni comes from
 
-Uni is a refinement of code that started life in the
-[Airframe](https://github.com/wvlet/airframe) project. This
-appendix explains what stayed, what changed, and how to think about
-the relationship if you have existing Airframe code.
+Airframe is a broad Scala library and ecosystem built up over many years,
+spanning dependency wiring, logging, serialization, RPC, and more, across
+Scala 2 and Scala 3. Uni takes the most-used, most-foundational pieces of
+that work and re-presents them as a single, cohesive library built **for
+Scala 3 from the start**.
 
-Topics:
+The mental models you've built reading this book — `Design` as object
+wiring, `Rx` as a composable stream, `Surface` for compile-time type
+information, codecs derived rather than hand-written — all originated in
+Airframe. They carry over because they are the same ideas, sharpened.
 
-- The migration from Airframe to Uni: package renames, deprecations,
-  and what survives identically.
-- What Uni deliberately dropped from Airframe, and why.
-- Using Uni and Airframe in the same project during a migration.
+## What changed
+
+Uni is a refinement, and the refinements pull in one direction: smaller
+and more modern.
+
+- **Scala 3 only.** Uni drops Scala 2 cross-building, so its APIs can use
+  `given`/`using`, `enum`, `derives`, and indentation syntax directly
+  instead of working around their absence. The
+  [syntax notes](./appendix-a-scala3) are the features this buys.
+- **Minimal dependencies.** Uni keeps its dependency surface deliberately
+  small, so adding it to a project doesn't pull in a framework.
+- **Trimmed scope.** Pieces of Airframe that were niche, or better served
+  by a dedicated tool, are left out rather than carried forward. Uni aims
+  to be the *essential* set, not the exhaustive one.
+- **A fresh package root.** Uni lives under `wvlet.uni.*`, distinct from
+  Airframe's `wvlet.airframe.*`.
+
+## If you have Airframe code
+
+Because Uni and Airframe occupy different package roots, they are separate
+libraries and can sit in the same build during a migration — you are not
+forced to move everything at once. The conceptual translation is usually
+direct: an Airframe `Design` and a Uni `Design` express the same wiring
+idea, an Airframe codec and a Uni `Weaver` solve the same serialization
+problem.
+
+The exact mapping — which APIs are identical, which were renamed, which
+were dropped — is a moving target better served by the project's
+migration notes than by a printed table here. Start from the concept you
+know in Airframe, find its chapter in this book, and you'll usually
+recognize the Uni shape immediately.
 
 [← Appendix A: Scala 3 Syntax Notes](./appendix-a-scala3) | [Next → Appendix C: Glossary](./appendix-c-glossary)

--- a/docs/book/appendix-c-glossary.md
+++ b/docs/book/appendix-c-glossary.md
@@ -1,26 +1,78 @@
 # Appendix C: Glossary
 
-::: warning Coming soon
-This appendix is an outline. The full draft ships in a follow-up PR.
-:::
+Short definitions of terms as this book uses them. The intent is to make
+cross-references precise, not to define every word in Scala. Each entry
+points to the chapter where the concept is developed.
 
-## What this appendix will cover
+**Binding** — One entry in a [Design](#design): a rule for how to produce
+a value of some type. Created with `bindSingleton`, `bindInstance`,
+`bindImpl`, or `bindProvider`. See [Chapter 3](./ch03-00-design).
 
-A short glossary of terms as this book uses them. The intent is to
-make cross-references precise, not to define every word in Scala.
+**Cancelable** — The handle returned by `Rx.subscribe` / `Rx.run`. Calling
+`cancel` tears down the subscription and stops further values. Holding and
+releasing it is how `Rx` avoids leaked streams. See
+[Chapter 6](./ch06-00-rx).
 
-Terms to include (non-exhaustive):
+**Circuit breaker** — A control-flow primitive that stops calling a
+backend once its failure rate crosses a threshold, "opening" to fail fast
+until the backend recovers. See [Chapter 7](./ch07-00-control).
 
-- **Design** — an immutable description of how types are wired.
-- **Session** — a runtime context built from a Design; owns
-  singletons and lifecycle hooks.
-- **Binding** — one entry in a Design (`bindSingleton`, `bindImpl`,
-  etc.).
-- **LogSupport** — the trait mixed in to give a class a `logger`.
-- **Rx** — Uni's asynchronous / streaming abstraction.
-- **Surface** — compile-time type reflection used by the codec layer.
-- **Launcher** — the annotation-driven CLI argument parser.
-- **Codec** — a bidirectional translator between bytes (JSON /
-  MessagePack) and Scala values.
+**Codec** — A bidirectional translator between bytes (JSON or MessagePack)
+and Scala values. In Uni the codec is a [Weaver](#weaver). See
+[Chapter 5](./ch05-00-data).
+
+**Cross-project** — An sbt module declared once with `crossProject` and
+compiled for the JVM, Scala.js, and Scala Native. Shared code lives in
+`src/`; platform-specific code in `.jvm` / `.js` / `.native`. See
+[Chapter 10](./ch10-00-cross-platform).
+
+**Design** — An immutable description of how types are wired together —
+which implementations satisfy which dependencies, and which values live as
+singletons. A `Design` is a value: building it runs nothing. See
+[Chapter 3](./ch03-00-design).
+
+**Launcher** — The annotation-driven CLI argument parser. It populates a
+plain case class from `Array[String]` using `@option` and `@argument`. See
+[Chapter 2](./ch02-00-cli-app).
+
+**LogSupport** — The trait a class mixes in to get `trace` / `debug` /
+`info` / `warn` / `error` methods and a logger named after the class. Log
+messages carry their source `(file:line)`, captured at compile time. See
+[Chapter 4](./ch04-00-logging).
+
+**Resource** — A control primitive (`Resource.withResource`) that lends
+you a resource for a block and closes it on exit, on both the normal and
+exception paths — the loan pattern. See [Chapter 7](./ch07-00-control).
+
+**Retry** — A policy (`Retry.withBackOff`) that re-runs a failing
+operation with increasing delays. Safe only for idempotent operations. See
+[Chapter 7](./ch07-00-control).
+
+**RPC** — Calling a remote service through a shared Scala trait, so the
+client and server are checked against one contract by the compiler. See
+[Chapter 9](./ch09-00-rpc).
+
+**Rx** — Uni's abstraction for a value that arrives later or changes over
+time: a lazy description of zero or more values that you compose with
+`map` / `flatMap` / `filter` and consume with `subscribe`. See
+[Chapter 6](./ch06-00-rx).
+
+**RxVar** — A mutable `Rx` you can watch: created with `Rx.variable`,
+updated with `:=`, and observed by subscribers. See
+[Chapter 6](./ch06-00-rx).
+
+**Session** — The runtime context `Design.build` (or `withSession`) opens:
+it owns the singletons it constructs and runs their `onStart` / `onShutdown`
+lifecycle hooks. A session has a lifetime; closing it tears the graph
+down. See [Chapter 3](./ch03-00-design).
+
+**Surface** — Compile-time type reflection. It captures a type's structure
+(fields, parameters, type arguments) for the codec layer to use, without
+runtime reflection — which is what lets derivation work on Scala.js and
+Native. See [Chapter 5](./ch05-00-data).
+
+**Weaver** — Uni's derivation-based codec. One `Weaver[A]` serializes a
+type to JSON *or* MessagePack; you get it with `derives Weaver`. See
+[Chapter 5](./ch05-00-data).
 
 [← Appendix B: Uni and Airframe](./appendix-b-airframe) | [Back to the Book](./)

--- a/docs/book/ch03-00-design.md
+++ b/docs/book/ch03-00-design.md
@@ -1,36 +1,214 @@
 # 3. Wiring with Design
 
-::: warning Coming soon
-This chapter is an outline. The full draft ships in a follow-up PR.
-:::
+Your app has a `UserService`, an `OrderService`, and a `ReportService`.
+All three need the same database connection. How do you get the
+connection to them — without making it a global, and without threading
+it by hand through every constructor at every call site?
 
-## What this chapter will cover
+This is the question `Design` answers. You met it in Chapter 2 as the
+*wire* step; this chapter explains it properly. By the end you should be
+able to read an unfamiliar `Design.newDesign…` block and know exactly
+what it says.
 
-Part III goes back to the `Design.build` shape you already met in
-Parts I and II, and explains it properly. By the end of it you should
-be able to look at an unfamiliar `Design.newDesign...` block and know
-exactly what it is saying.
+## A first wiring
 
-Concepts introduced:
+Two services, one shared dependency:
 
-- Why constructor injection is preferred over globals, service
-  locators, and runtime reflection.
-- `bindSingleton`, `bindImpl`, `bindInstance`, `bindProvider` — which
-  to reach for, and why.
-- `design.build[A] { ... }` as the convenience entry point, and
-  `withSession` underneath it for cases where you need access to the
-  session itself.
-- Sessions, child sessions, and scoping: when one instance lives for
-  the whole process vs. per-request.
-- Lifecycle hooks (`onStart`, `onShutdown`) and how they compose with
-  sessions.
-- Overriding a design for tests (the foundation for Chapter 11).
-- Common mistakes and how to read the error messages Design produces.
+```scala
+import wvlet.uni.design.Design
 
-## Reference you can read now
+class Database:
+  def query(sql: String): Seq[String] = Seq("alice", "bob")
 
-While this chapter is in progress, the reference page is complete:
+class UserService(db: Database):
+  def listUsers(): Seq[String] = db.query("select name from users")
 
-- [Design (module reference)](/core/design)
+@main def main =
+  val design = Design.newDesign
+    .bindSingleton[Database]
+    .bindSingleton[UserService]
+
+  design.build[UserService] { users =>
+    println(users.listUsers())
+  }
+```
+
+```bash
+$ sbt run
+List(alice, bob)
+```
+
+`UserService` takes its `Database` as a constructor parameter. It never
+constructs one, never looks one up — it just declares that it needs one.
+The wiring lives somewhere else entirely.
+
+## Walking the code
+
+**Each class names its dependencies in its constructor.**
+`UserService(db: Database)` is a complete, honest statement of what the
+class needs to do its job. There is no hidden `Database.getInstance()`
+call buried three methods deep. If you can construct a `UserService`, you
+have everything it needs; if you can't, the compiler tells you which
+type is missing.
+
+**A `Design` is a plan, not a container.** `Design.newDesign` starts an
+empty plan. `bindSingleton[Database]` adds a line to it: "when something
+needs a `Database`, build one and share it." `bindSingleton[UserService]`
+adds another. A `Design` is an immutable value — every `bind…` call
+returns a new `Design`, so you can build them up, pass them around, and
+combine them without anyone mutating yours.
+
+**`build` turns the plan into objects.** `design.build[UserService] { … }`
+reads the plan, constructs the graph from the bottom up (the `Database`
+first, then the `UserService` that needs it), and hands you the root.
+When the block returns, the graph is torn down.
+
+### Why not just pass it as a constructor argument yourself?
+
+You could. `UserService(Database())` works for two classes. The reason
+to reach for `Design` shows up at scale and under change:
+
+- **No globals.** A `Database` reachable through a global is reachable
+  from anywhere, which means *anything* can depend on it without saying
+  so. Dependencies you can't see are dependencies you can't test or
+  replace. Constructor parameters keep the dependency graph honest.
+- **No service locator.** A `locator.get[Database]` hides the dependency
+  from the type system — you discover a missing binding when the call
+  runs, not when it compiles. `Design` resolves the graph from
+  constructor *types*, so a missing piece is a wiring error you can find
+  before shipping.
+- **One place to look.** The entire dependency graph of your program is
+  one `Design.newDesign…` block. Growing from two services to twenty
+  does not scatter `new` calls across the codebase.
+
+## The four ways to bind
+
+`bindSingleton` is the common case, but you reach for different bindings
+depending on how the value is produced.
+
+```scala
+import wvlet.uni.design.Design
+
+// 1. Build it for me, once, and share it.
+Design.newDesign.bindSingleton[Database]
+
+// 2. Use this exact object I already have.
+Design.newDesign.bindInstance[Database](Database())
+
+// 3. This type is a trait — use this implementation for it.
+trait UserRepo
+class InMemoryUserRepo extends UserRepo
+Design.newDesign.bindImpl[UserRepo, InMemoryUserRepo]
+
+// 4. Build it with a function that itself needs dependencies.
+case class Config(url: String)
+Design.newDesign
+  .bindInstance[Config](Config("jdbc:db"))
+  .bindProvider[Config, Database] { config => Database() }
+```
+
+| Binding | Use it when |
+|---------|-------------|
+| `bindSingleton[A]` | `A` is a class Design can construct; you want one shared instance |
+| `bindInstance[A](v)` | you already hold the value (config, a pre-built client) |
+| `bindImpl[A, B]` | `A` is an interface and `B` is the implementation to use |
+| `bindProvider[D, A](d => a)` | building `A` needs other bound values |
+
+`bindImpl` is the seam that makes a program configurable: bind `UserRepo`
+to `InMemoryUserRepo` in development and to `PostgresUserRepo` in
+production, and nothing that *uses* `UserRepo` changes. See the full
+[binding reference](/core/design#binding-summary) for the complete set.
+
+## Sessions and lifecycle
+
+`design.build[A] { … }` is shorthand for opening a **session**, building
+the graph inside it, and closing it when the block ends. A session is the
+lifetime of a set of wired objects.
+
+That lifetime is where cleanup hooks attach. Bind a value with an
+`onStart`/`onShutdown` hook and the session runs them at the edges:
+
+```scala
+import wvlet.uni.design.Design
+
+class Server:
+  def start(): Unit   = println("listening")
+  def stop(): Unit    = println("stopped")
+
+val design = Design.newDesign
+  .bindSingleton[Server]
+  .onStart(_.start())     // when the session starts
+  .onShutdown(_.stop())   // when the session ends — even on exception
+
+design.build[Server] { server =>
+  // server.start() has already run here
+  println("serving requests")
+}
+// server.stop() has run by here
+```
+
+```bash
+$ sbt run
+listening
+serving requests
+stopped
+```
+
+The shutdown hook runs whether the block returns normally or throws, so
+resources don't leak on the error path. Chapter 2 used the compact form
+of this — `.onShutdown(_.close())` on the HTTP client — and it is the
+same mechanism. For a type that is already `AutoCloseable`, Design can
+call `close()` for you; the [lifecycle reference](/core/design#lifecycle-management)
+lists every hook and the order they fire in.
+
+When you need the session itself — to open short-lived **child
+sessions**, say, one per web request, while singletons live for the whole
+process — use `design.withSession { session => … }` instead of `build`.
+[Session management](/core/design#session-management) covers child
+sessions in depth.
+
+## Overriding a design
+
+A `Design` is a value, and two designs combine with `+`. When both bind
+the same type, the one on the right wins. That single rule is the
+foundation of testing and per-environment configuration:
+
+```scala
+// Production wiring, defined once.
+val appDesign = Design.newDesign
+  .bindSingleton[Database]
+  .bindSingleton[UserService]
+
+// A test swaps in a fake Database — everything else is unchanged.
+val testDesign = appDesign +
+  Design.newDesign.bindInstance[Database](FakeDatabase())
+
+testDesign.build[UserService] { users =>
+  // users is the real UserService, wired to FakeDatabase
+}
+```
+
+`UserService` does not know or care that its `Database` was replaced —
+it asked for a `Database`, and it got one. This is the override
+mechanism Chapter 11 builds on to test services without their real
+dependencies. See [Testing with Design](/core/design#testing) for the
+patterns.
+
+## What you have, what comes next
+
+You can now read and write a `Design`:
+
+- Classes declare dependencies as **constructor parameters**; `Design`
+  supplies them.
+- **`bindSingleton` / `bindInstance` / `bindImpl` / `bindProvider`** cover
+  how a value is produced.
+- **`build`** opens a session, wires the graph, and tears it down;
+  **`onStart` / `onShutdown`** hook the edges of that lifetime.
+- **`+`** overrides a design, which is how tests swap real dependencies
+  for fakes.
+
+Next, [Chapter 4](./ch04-00-logging) adds the first thing every one of
+these services wants — logging that tells you not just *what* happened
+but *where*.
 
 [← 2. A URL Fetcher](./ch02-00-cli-app) | [Next → 4. Logging That Finds You](./ch04-00-logging)

--- a/docs/book/ch04-00-logging.md
+++ b/docs/book/ch04-00-logging.md
@@ -1,33 +1,143 @@
 # 4. Logging That Finds You
 
-::: warning Coming soon
-This chapter is an outline. The full draft ships in a follow-up PR.
-:::
+A log line that reads `save failed` is almost useless if your codebase
+has twenty `save` methods. The first question you ask is always the same:
+*where did this come from?* This chapter is about a logger that answers
+that for you, for free.
 
-## What this chapter will cover
+## Logging in one line
 
-Logs in a Uni application are written for **a human reading output**,
-not for a log-aggregation pipeline to parse. That framing shapes what
-Uni's logger does, and — just as importantly — what it chooses not to
-do.
+Mix in `LogSupport` and call a level method:
 
-Concepts introduced:
+```scala
+import wvlet.uni.log.LogSupport
 
-- The `LogSupport` trait and why mixing it in beats passing a
-  `Logger` around.
-- Source-location capture: how Uni captures file and line at compile
-  time, and what that means at runtime.
-- Log levels and how to choose between them without lying to your
-  future self.
-- Per-package log configuration at runtime.
-- Why Uni's logger intentionally has **no structured-logging API**:
-  logs are developer context, not machine-parsed records. When you
-  need fields, IDs, and correlation, reach for a telemetry tool
-  (metrics, traces) instead of encoding state into log lines.
-- Formatting choices for terminals and for log files.
+class OrderService extends LogSupport:
+  def placeOrder(id: String): Unit =
+    info(s"Placing order ${id}")
+    // ... do the work ...
+```
 
-## Reference you can read now
+```bash
+$ sbt run
+2024-01-15 10:30:45.123+0900  info [OrderService] Placing order A-100 - (OrderService.scala:5)
+```
 
-- [Logging (module reference)](/core/logging)
+Look at the end of that line: `(OrderService.scala:5)`. The log tells
+you the exact file and line that produced it. You did not pass it; you
+did not configure it. That is the whole idea.
 
-[← 3. Wiring with Design](./ch03-00-design) | [Next → 5. JSON & MessagePack](./ch05-00-data)
+## Walking the code
+
+**`LogSupport` is a mixin.** Extending it gives the class `trace`,
+`debug`, `info`, `warn`, and `error` methods and a logger named after the
+class (`[OrderService]`). There is no `private val logger =
+LoggerFactory.getLogger(getClass)` line to copy-paste and get wrong.
+
+**The five levels are ordered.** From quietest to loudest: `trace`,
+`debug`, `info`, `warn`, `error`. You set a threshold and everything at
+or above it prints. The [levels reference](/core/logging#log-levels) has
+the full table.
+
+**The source location is captured at compile time.** `(file:line)` is not
+found by walking a stack trace at runtime — that would be slow and would
+break under inlining. Uni captures it with a Scala 3 macro when your code
+compiles, so it is exact and free. This is the "finds you" payoff: in a
+real incident, the location turns "something failed" into "*this line*
+failed," and you skip the search.
+
+## You don't guard log calls
+
+In many logging frameworks you learn to write this, because building the
+message is expensive and you don't want to pay for it when `debug` is
+off:
+
+```scala
+// The defensive pattern you do NOT need here:
+if logger.isDebugEnabled then
+  logger.debug(s"State dump: ${expensiveSnapshot()}")
+```
+
+With Uni you write the obvious thing:
+
+```scala
+debug(s"State dump: ${expensiveSnapshot()}")
+```
+
+The level methods are `inline` macros, so the argument is only evaluated
+when the level is enabled. If `debug` is off, `expensiveSnapshot()` never
+runs and there is no allocation — the call compiles down to nothing. The
+guard is built in, so the readable form is also the fast form. See
+[zero-overhead logging](/core/logging#zero-overhead-logging-with-scala-macros)
+for what the macro expands to.
+
+## Errors carry their cause
+
+Pass the exception as a second argument and the stack trace rides along:
+
+```scala
+import wvlet.uni.log.LogSupport
+
+class PaymentService extends LogSupport:
+  def charge(amount: Int): Unit =
+    try
+      gateway.charge(amount)
+    catch
+      case e: Exception =>
+        error(s"Charge of ${amount} failed", e)  // message + full stack trace
+        throw e
+```
+
+The log keeps your message *and* the exception's stack trace together, so
+you see the human-readable context and the machine detail in one record.
+
+## Why the message is a sentence, not a struct
+
+Some ecosystems push you toward structured logs — every line a bag of
+key/value fields, meant to be parsed by a machine. Uni's logger is
+deliberately *not* that. A log line here is a sentence written for a
+person reading it during an incident: prose, with the source location and
+any exception attached.
+
+That is a choice, not an omission. Uni's position is that logs are
+**developer context**, not your metrics or analytics pipeline. When you
+need machine-readable records — counters, traces, events to aggregate —
+emit them explicitly to a system built for it, and keep logs for the
+human who is paging through them at 2 a.m. Mixing the two jobs tends to
+serve neither well.
+
+## Tuning what prints
+
+You usually leave the defaults alone, but two knobs cover most needs:
+
+```scala
+import wvlet.uni.log.{Logger, LogLevel}
+
+Logger.setDefaultLogLevel(LogLevel.DEBUG)          // global threshold
+Logger("OrderService").setLogLevel(LogLevel.TRACE) // one logger, louder
+```
+
+A class that mixes in `LogSupport` already has a logger named after it,
+so you can dial one noisy component up or down without touching the
+others. Outside a class, `Logger("name")` gives you a named logger
+directly. To send logs to a rotating file — on the JVM, Node.js, or
+Native — point a [`FileLogHandler`](/core/logging#writing-logs-to-a-file)
+at a path.
+
+## What you have, what comes next
+
+Logging is now a one-line, zero-ceremony tool:
+
+- **`extends LogSupport`** gives any class `trace`/`debug`/`info`/`warn`/`error`
+  and a logger named after it.
+- Every message carries its **`(file:line)`**, captured at compile time.
+- Level methods are **macros**, so unguarded `debug(...)` calls cost
+  nothing when disabled.
+- Logs are **human context** by design; `error(msg, e)` keeps the cause
+  attached.
+
+Next, [Chapter 5](./ch05-00-data) turns to data crossing your program's
+edges — parsing JSON, writing MessagePack, and deriving both from your
+case classes with one line.
+
+[← 3. Wiring with Design](./ch03-00-design) | [Next → 5. Data In, Data Out](./ch05-00-data)

--- a/docs/book/ch05-00-data.md
+++ b/docs/book/ch05-00-data.md
@@ -1,32 +1,127 @@
 # 5. Data In, Data Out — JSON & MessagePack
 
-::: warning Coming soon
-This chapter is an outline. The full draft ships in a follow-up PR.
+Every service eats and produces data. A request arrives as a JSON body;
+a cache stores a MessagePack frame; a config file is a blob of text. This
+chapter is about the boundary where bytes become Scala values and back —
+and how Uni crosses it without per-type boilerplate.
+
+There are two situations, and Uni has a tool for each:
+
+- You **don't** know (or control) the shape — a third-party response, a
+  config blob. Parse it into a JSON tree and navigate.
+- You **do** own the shape — it's your case class. Derive a codec once
+  and round-trip it to JSON *or* MessagePack.
+
+## When you don't own the shape: parse and navigate
+
+`JSON.parse` turns text into a navigable tree:
+
+```scala
+import wvlet.uni.json.JSON
+
+val doc = JSON.parse("""
+  { "user": { "id": 123, "name": "Alice" },
+    "posts": [ { "title": "Hello" }, { "title": "World" } ] }
+""")
+
+val name  = doc("user")("name").toStringValue   // "Alice"
+val id     = doc("user")("id").toLongValue        // 123
+val first = doc("posts")(0)("title").toStringValue // "Hello"
+```
+
+You index into objects with `(key)` and arrays with `(index)`, then read
+a leaf with a typed accessor like `toStringValue` or `toLongValue`. When
+a path might be missing, navigate with `/` and pattern-match or use
+`Option` instead of asserting it exists. The
+[JSON reference](/core/json) covers the full DSL, including building and
+mutating trees.
+
+This is the right tool for *loosely* structured data. But when the shape
+is yours, threading `("user")("name")` through your code throws away the
+types you already have.
+
+## When you own the shape: derive a codec
+
+Define the data as case classes and add `derives Weaver`:
+
+```scala
+import wvlet.uni.weaver.Weaver
+
+case class User(id: Long, name: String) derives Weaver
+
+val alice = User(123, "Alice")
+
+val json = Weaver.toJson(alice)        // {"id":123,"name":"Alice"}
+val back = Weaver.fromJson[User](json) // User(123, Alice)
+```
+
+```bash
+$ sbt run
+{"id":123,"name":"Alice"}
+User(123,Alice)
+```
+
+`derives Weaver` asks the compiler to build a serializer for `User` from
+its structure. No annotations on each field, no hand-written
+`toJson`/`fromJson`, no companion-object ceremony. Nested case classes,
+collections, `Option`, enums, and sealed traits all derive the same way —
+see the [Weaver reference](/core/weaver) for the full type list.
+
+## The same type, as binary
+
+Here is the part that pays off: the *same* `Weaver[User]` also speaks
+MessagePack, a compact binary encoding. You don't define a second codec —
+you call a different method:
+
+```scala
+// Continues the User from above.
+val bytes: Array[Byte] = Weaver.weave(alice)     // MessagePack
+val user                = Weaver.unweave[User](bytes)
+```
+
+Reach for MessagePack when the bytes matter: a cache entry, a queue
+message, an internal RPC payload. It is smaller and faster to parse than
+JSON, and it is binary-safe. Reach for JSON when a human or a browser is
+on the other end. Either way, your *type* is the same; only the format at
+the edge changes.
+
+## Why one codec for two formats
+
+It would be easy to ship a JSON library and a separate MessagePack
+library, each with its own derivation. Uni deliberately does not. The
+insight is that **the wire format is a boundary decision, not a modeling
+decision.** `User` is `User` whether it travels as text or as bytes — so
+you describe it once, and choose the encoding where the data actually
+leaves your program.
+
+That keeps the choice cheap. Storing sessions in Redis and decide
+MessagePack is leaner? Change `toJson` to `weave` at that one boundary;
+`User` does not move. A reader does not learn two derivation systems, and
+the two formats cannot drift apart, because they are the same `Weaver`.
+
+::: tip Cross-platform, by construction
+`derives Weaver` resolves at **compile time** — no runtime reflection.
+That is what lets the identical codec run on the JVM, in the browser
+(Scala.js), and as a native binary. A reflection-based serializer would
+not survive the trip to Scala.js or Native; a derived one does. We return
+to this theme in [Chapter 10](./ch10-00-cross-platform).
 :::
 
-## What this chapter will cover
+## What you have, what comes next
 
-Every service eats and produces data. This chapter covers how Uni
-turns bytes on the wire into Scala 3 case classes, and back, without
-per-type boilerplate.
+You can now move data across your program's edges:
 
-Concepts introduced:
+- **`JSON.parse`** for data whose shape you don't own — navigate a tree
+  with `(key)` / `(index)` and typed accessors.
+- **`derives Weaver`** for data you do own — one derivation, no
+  per-field boilerplate.
+- **`Weaver.toJson` / `fromJson`** for text, **`Weaver.weave` / `unweave`**
+  for MessagePack — same codec, format chosen at the boundary.
+- Derivation is compile-time, so the codec is cross-platform.
 
-- `JSON` for parsing, mutation, and generation of JSON trees.
-- Case-class codecs via `Surface` — no annotation or companion
-  boilerplate required.
-- When to reach for MessagePack instead of JSON (size, performance,
-  binary-safe payloads).
-- Streaming: parsing documents larger than memory, and producing them
-  incrementally.
-- Error handling: what happens when the bytes do not match the type.
-- Interop with existing JSON libraries when you must speak someone
-  else's schema.
-
-## Reference you can read now
-
-- [JSON Processing](/core/json)
-- [MessagePack](/core/msgpack)
-- [Type Introspection (Surface)](/core/surface)
+That closes Part III: you can wire a program ([Design](./ch03-00-design)),
+see what it does ([Logging](./ch04-00-logging)), and move data through it.
+Next, [Part IV](./ch06-00-rx) makes those services *react* — `Rx`, Uni's
+composable stream, for values that change over time.
 
 [← 4. Logging That Finds You](./ch04-00-logging) | [Next → 6. Rx, the Composable Stream](./ch06-00-rx)

--- a/docs/book/ch06-00-rx.md
+++ b/docs/book/ch06-00-rx.md
@@ -1,34 +1,156 @@
 # 6. Rx, the Composable Stream
 
-::: warning Coming soon
-This chapter is an outline. The full draft ships in a follow-up PR.
-:::
+Two things in your program refuse to sit still. An async HTTP call does
+not return a `Response` — it returns one *later*. A configuration value
+or a UI field changes *while the app runs*. Both are "a value that isn't
+simply here right now," and Uni models both with one type: `Rx`.
 
-## What this chapter will cover
+This chapter is about that type and the handful of operators that make it
+compose.
 
-`Rx` is Uni's abstraction for anything that happens over time:
-asynchronous results, event streams, websockets, server-sent events,
-timers. It is a single type with a small set of operators, and it is
-the backbone of async code across the library.
+## A value that changes
 
-Concepts introduced:
+The simplest `Rx` is a variable you can watch:
 
-- `Rx[A]` as a description of "something that will produce zero or
-  more `A` values".
-- The four shapes: `single`, `stream`, `completable`, `never`, and
-  when each is the right pick.
-- The operator set: `map`, `flatMap`, `filter`, `take`,
-  `zip`, `merge`, `recover`.
-- How Rx composes with `Design` lifecycle: closing a session cancels
-  the streams it owns.
-- Backpressure, cancellation, and the common mistakes (`subscribe`
-  without a handle, unbounded buffering).
+```scala
+import wvlet.uni.rx.Rx
 
-## Reference you can read now
+val count = Rx.variable(0)
 
-- [Reactive Streams — Overview](/rx/)
-- [Rx Basics](/rx/basics)
-- [Rx Operators](/rx/operators)
-- [Rx Concurrency](/rx/concurrency)
+count.subscribe { v =>
+  println(s"count is now ${v}")
+}
 
-[← 5. JSON & MessagePack](./ch05-00-data) | [Next → 7. Retry, Circuit Breakers, Resources](./ch07-00-control)
+count := 1
+count := 2
+```
+
+```bash
+$ sbt run
+count is now 0
+count is now 1
+count is now 2
+```
+
+`subscribe` runs your function once with the current value and again on
+every change. `:=` sets a new value. You are not polling and you are not
+wiring callbacks by hand — you describe what should happen when the value
+changes, and `Rx` makes it happen.
+
+## Walking the code
+
+**`Rx[A]` is a description, not a result.** An `Rx[A]` says "this will
+produce zero or more `A` values over time." It does nothing until someone
+*runs* it — `subscribe` (react to every value) or `run` (run an effect)
+or `await` (block for the value, JVM only). Nothing fires until then,
+which means you can build an `Rx` pipeline freely and pay only when you
+attach a consumer.
+
+**`subscribe` hands you a `Cancelable`.** Watching a stream is a
+resource: it keeps a subscription alive. The return value is a
+`Cancelable` you call when you're done. This is the one piece of
+bookkeeping `Rx` asks of you — hold the handle, cancel it when the work
+that needed it ends.
+
+```scala
+val sub = count.subscribe(v => println(v))
+// ... later, when you no longer care ...
+sub.cancel
+```
+
+## Composing without unwrapping
+
+The point of `Rx` is that you transform the *stream*, not the values one
+at a time. The operators look exactly like the ones on `Option` and
+`List`, because they mean the same thing:
+
+```scala
+import wvlet.uni.rx.Rx
+
+val count = Rx.variable(0)
+
+val label: Rx[String] =
+  count
+    .filter(_ % 2 == 0)        // keep even values
+    .map(n => s"even: ${n}")   // turn each into a label
+
+label.subscribe(println)
+
+count := 1   // filtered out — nothing prints
+count := 2   // prints: even: 2
+```
+
+`map` transforms each value, `filter` drops the ones you don't want, and
+`flatMap` lets one stream depend on another (run a second `Rx` for each
+value of the first). You build a pipeline once; every value that flows
+through `count` takes the whole path. The
+[operators reference](/rx/operators) lists the full set, including `zip`
+to combine streams and `recover` to handle errors.
+
+## Where Rx shows up: async results
+
+Back in Chapter 2 the *synchronous* client returned an
+`HttpResponse` directly. The async client returns the value-over-time
+version of exactly that:
+
+```scala
+import wvlet.uni.http.{Http, Request}
+
+val client = Http.client.newAsyncClient
+
+val title: Rx[String] =
+  client
+    .send(Request.get("https://example.com"))   // Rx[HttpResponse]
+    .map(_.status.toString)                      // Rx[String]
+
+title.subscribe(println)
+```
+
+The HTTP response is "a value that isn't here yet," so the async client
+gives you an `Rx[HttpResponse]`. You compose it with the same `map` you
+used on the counter — there is no separate callback API, no second mental
+model for "async" versus "reactive." One type covers both, which is why
+`Rx` is the backbone of async code across Uni: HTTP, WebSockets, and
+server-sent events all surface as `Rx`.
+
+## Why Rx instead of Future or callbacks
+
+A `Future` starts running the moment you create it and can only ever
+deliver one value. A callback delivers many values but composes badly —
+nest two and you have a pyramid. `Rx` is chosen to avoid both traps:
+
+- **Lazy.** Building an `Rx` runs nothing. You assemble the pipeline,
+  then decide when (and whether) to start it. A `Future` has already
+  left the gate.
+- **One-shot *and* streaming.** The same type and operators serve a
+  single async result and an endless event stream. You learn one thing.
+- **Cancellable.** `subscribe`/`run` return a `Cancelable`, so a stream
+  you no longer need stops cleanly — no leaked timer, no listener firing
+  into a dead component.
+- **Cross-platform.** `Rx` runs the same on the JVM, in the browser, and
+  on Native, so async code moves between platforms unchanged.
+
+That cancellation handle is also how `Rx` cooperates with
+[Design](./ch03-00-design): give a session ownership of a subscription
+and closing the session cancels it, so streams wind down with the objects
+that created them. The [concurrency reference](/rx/concurrency) covers the
+threading and cancellation model in depth.
+
+## What you have, what comes next
+
+You can now describe values that change and results that arrive later
+with one tool:
+
+- **`Rx[A]`** is a lazy description of zero or more `A` over time;
+  nothing runs until you `subscribe`/`run`/`await`.
+- **`Rx.variable` + `:=`** is a value you can watch; **`map` / `filter` /
+  `flatMap`** compose the stream.
+- **`subscribe` returns a `Cancelable`** — hold it, cancel it when done.
+- The **async HTTP client** returns `Rx[HttpResponse]`, so async and
+  reactive code share one model.
+
+Next, [Chapter 7](./ch07-00-control) is about what happens when those
+calls *fail* — retries, circuit breakers, and resource lifetimes that
+clean up after themselves.
+
+[← 5. Data In, Data Out](./ch05-00-data) | [Next → 7. Living With Failure](./ch07-00-control)

--- a/docs/book/ch07-00-control.md
+++ b/docs/book/ch07-00-control.md
@@ -1,35 +1,157 @@
 # 7. Living With Failure — Retry, Circuit Breakers, Resources
 
-::: warning Coming soon
-This chapter is an outline. The full draft ships in a follow-up PR.
-:::
+A call across a network will fail. Not *if* — *when*. The interesting
+question is what you do about it, and there are three different answers
+depending on the failure:
 
-## What this chapter will cover
+- It was a blip — the packet dropped, the server hiccuped. **Retry it.**
+- The backend is genuinely down — every call is failing. **Stop hammering
+  it.**
+- The call failed and left a connection open. **Clean it up anyway.**
 
-Production code spends most of its time either failing or recovering
-from something that failed a moment ago. This chapter covers the three
-Uni primitives that let you write that gracefully: `Retry`,
-`CircuitBreaker`, and `Resource`.
+Uni gives you one primitive for each: `Retry`, `CircuitBreaker`, and
+`Resource`.
 
-Concepts introduced:
+## Retry a transient failure
 
-- Retry policies: exponential backoff, jitter, and which errors are
-  safe to retry (and which are dangerous to).
-- Circuit breakers: when a backend is clearly down, stop making it
-  worse. The state machine (closed → open → half-open) and how Uni
-  models it.
-- Idempotency as a precondition for retry — and how to tell whether
-  your call is idempotent.
-- `Resource` for scoped resource lifetimes that compose with `Design`
-  sessions.
-- Combining the three: the canonical "HTTP call with retry, circuit
-  breaker, and a bounded connection pool" pattern.
+Wrap the flaky call in a retry policy and `run` it:
 
-## Reference you can read now
+```scala
+import wvlet.uni.control.Retry
 
-- [Control Flow — Overview](/control/)
-- [Retry](/control/retry)
-- [Circuit Breaker](/control/circuit-breaker)
-- [Resource](/control/resource)
+val result = Retry
+  .withBackOff(maxRetry = 3)
+  .run {
+    callFlakyService()   // runs up to 4 times: 1 try + 3 retries
+  }
+```
+
+`withBackOff` waits longer between each attempt — a tenth of a second,
+then more, then more — instead of retrying in a tight loop. That spacing
+matters: a service that just hiccuped needs a moment, and a hundred
+clients retrying in lockstep would knock it over again the instant it
+recovers. For that lockstep problem specifically, `Retry.withJitter()`
+randomizes the delays so clients don't synchronize. If every attempt
+fails, the policy gives up by throwing `MaxRetryException`. The
+[retry reference](/control/retry) covers tuning the intervals and
+choosing *which* errors to retry.
+
+### Why you can't retry everything
+
+Retry has a precondition that is easy to miss: the operation must be
+**idempotent** — safe to run more than once. Reading a URL is idempotent;
+running it twice returns the same page. `POST /charge-card` is *not* —
+run it twice and you've billed the customer twice.
+
+Before you wrap a call in `Retry`, ask: if this runs twice, is the world
+the same as if it ran once? If not, retrying turns a transient failure
+into a correctness bug. Make the call idempotent first (an idempotency
+key, an upsert), *then* retry it.
+
+## Stop calling a backend that's down
+
+Retry handles a blip. It is exactly the wrong tool when a backend is
+*actually* down: now every request retries four times before failing, so
+you've quadrupled the load on a service that's already on the floor, and
+every caller waits through the full backoff to get an error it could have
+had instantly.
+
+A `CircuitBreaker` watches the failure rate and, once it crosses a
+threshold, "opens" — failing calls instantly without touching the backend
+at all:
+
+```scala
+import wvlet.uni.control.{CircuitBreaker, CircuitBreakerOpenException}
+
+val breaker = CircuitBreaker.withConsecutiveFailures(5)
+
+try
+  breaker.run {
+    callBackend()
+  }
+catch
+  case e: CircuitBreakerOpenException =>
+    // fail fast — the breaker is open, we didn't even try
+    useFallback()
+```
+
+It runs a small state machine: **closed** (calls pass through), **open**
+(calls fail instantly), and **half-open** (after a cooldown, it lets one
+trial call through to see if the backend recovered). The point is to
+*fail fast* while a dependency is down — protecting both the caller, who
+gets an immediate answer, and the backend, which gets room to recover
+instead of a retry storm. `withConsecutiveFailures(5)` trips after five
+failures in a row; `withFailureThreshold` trips on a failure *rate*. See
+the [circuit breaker reference](/control/circuit-breaker) for the states
+and recovery policy.
+
+## Clean up no matter what
+
+Both tools above can fail the call. When they do, anything the call
+opened — a file, a socket, a connection — still needs to close.
+`Resource.withResource` guarantees it:
+
+```scala
+import wvlet.uni.control.Resource
+
+Resource.withResource(openConnection()) { conn =>
+  conn.query("select 1")
+}   // conn.close() runs here — even if query threw
+```
+
+This is the loan pattern: `withResource` lends you the resource for the
+duration of the block and closes it when the block exits, on the normal
+path *and* the exception path. You can't forget the `close()`, because
+you never wrote it.
+
+If that mechanism feels familiar, it should — it is the same guarantee
+`Design`'s `onShutdown` gives a whole session
+([Chapter 3](./ch03-00-design)). `Resource` is the local, block-scoped
+version; `Design` is the application-scoped version. Reach for
+`Resource` when a resource lives for one operation, and for a `Design`
+lifecycle hook when it lives for the program.
+
+## Putting them together
+
+A hardened call to a flaky dependency uses all three at once: a
+`Resource` for the connection, a `CircuitBreaker` to fail fast when the
+dependency is down, and `Retry` to ride out the blips that get through:
+
+```scala
+import wvlet.uni.control.{CircuitBreaker, Resource, Retry}
+
+val breaker = CircuitBreaker.withConsecutiveFailures(5)
+
+def fetch(url: String): String =
+  breaker.run {
+    Retry.withBackOff(maxRetry = 3).run {
+      Resource.withResource(openConnection()) { conn =>
+        conn.get(url)
+      }
+    }
+  }
+```
+
+Read it from the inside out: the resource is always cleaned up, retries
+absorb transient failures, and the breaker stops the whole thing from
+piling onto a backend that's already down. Each layer does one job, and
+they compose because each is an ordinary value wrapping an ordinary
+block.
+
+## What you have, what comes next
+
+You can now write code that survives the network:
+
+- **`Retry.withBackOff(...).run { }`** absorbs transient failures —
+  *only for idempotent operations*.
+- **`CircuitBreaker.run { }`** fails fast when a backend is down, so you
+  stop making it worse.
+- **`Resource.withResource(r) { }`** closes resources on every path, the
+  block-scoped cousin of `Design`'s `onShutdown`.
+
+That closes Part IV: your services can react ([Rx](./ch06-00-rx)) and
+recover (this chapter). Next, [Part V](./ch08-00-http) puts them on the
+network for real — building HTTP clients and servers, then typed RPC on
+top.
 
 [← 6. Rx, the Composable Stream](./ch06-00-rx) | [Next → 8. HTTP Clients and Servers](./ch08-00-http)

--- a/docs/book/ch08-00-http.md
+++ b/docs/book/ch08-00-http.md
@@ -1,36 +1,156 @@
 # 8. HTTP Clients and Servers
 
-::: warning Coming soon
-This chapter is an outline. The full draft ships in a follow-up PR.
+Chapter 2 made a single HTTP call to get a CLI tool working. This chapter
+takes HTTP seriously from both sides: the **client** that calls out, and
+the **server** that answers. The two share a request/response model, so
+once you know one, the other reads naturally.
+
+## The client, synchronous first
+
+The simplest client blocks until the response arrives:
+
+```scala
+import wvlet.uni.http.{Http, Request}
+
+val client = Http.client.newSyncClient
+
+val response = client.send(Request.get("https://httpbin.org/get"))
+println(response.status)                       // 200 OK
+println(response.contentAsString.getOrElse("")) // the body
+```
+
+`Request.get(url)` builds a request; `client.send` runs it and returns an
+`HttpResponse`. `response.status` is a typed `HttpStatus`, and
+`response.contentAsString` is an `Option[String]` because some responses
+have no body. You build other verbs the same way — `Request.post(url)`,
+then `.withJsonContent("""{"name":"Alice"}""")` to attach a body.
+
+Start with the sync client. It is the easy thing to reason about: one
+call, one result, top to bottom. Reach for async only when you need
+concurrency.
+
+## The client, asynchronously
+
+The async client returns the value-over-time version of the response — an
+`Rx[HttpResponse]`, exactly the shape from [Chapter 6](./ch06-00-rx):
+
+```scala
+import wvlet.uni.http.{Http, Request}
+
+val client = Http.client.newAsyncClient
+
+client
+  .send(Request.get("https://httpbin.org/get"))
+  .map(_.contentAsString.getOrElse(""))
+  .subscribe(println)
+```
+
+Because the result is an `Rx`, you compose it with `map` and `subscribe`
+instead of blocking. The same operators you learned for streams work
+here — async HTTP is not a separate world.
+
+Both clients come configured with sensible defaults, including the retry
+policy from [Chapter 7](./ch07-00-control). Tune them with `withXxx`
+setters before creating the client:
+
+```scala
+val client = Http.client
+  .withConnectTimeoutMillis(5000)
+  .withMaxRetry(3)
+  .newSyncClient
+```
+
+## The server
+
+A server answers requests. At its simplest, a handler is a function from
+`Request` to a response — and that form runs on **every** platform:
+
+```scala
+import wvlet.uni.http.{Request, Response}
+import wvlet.uni.http.netty.NettyServer
+import wvlet.uni.rx.Rx
+
+NettyServer
+  .withPort(8080)
+  .withRxHandler { (request: Request) =>
+    Rx.single(Response.ok(s"You asked for ${request.path}"))
+  }
+  .start { server =>
+    println(s"listening on ${server.localPort}")
+  }
+```
+
+`start { server => … }` runs the server for the duration of the block and
+shuts it down cleanly when the block ends — the same lifecycle shape as
+`Design.build`. On Scala.js and Native you swap `NettyServer` for
+`NodeServer` or `NativeServer`; the builder API is identical.
+
+## Routing without a switch statement
+
+A real API has many endpoints, and you don't want one giant `match` on
+`request.path`. On the JVM, annotate the methods of a controller and let
+the router dispatch:
+
+```scala
+import wvlet.uni.http.HttpMethod
+import wvlet.uni.http.router.{Endpoint, Router}
+import wvlet.uni.http.netty.{NettyServer, RouterHandler}
+
+class UserController:
+  @Endpoint(HttpMethod.GET, "/users/:id")
+  def getUser(id: String): String = s"""{"id":"${id}"}"""
+
+  @Endpoint(HttpMethod.GET, "/users")
+  def listUsers(): Seq[String] = Seq("alice", "bob")
+
+val router = Router.of[UserController]
+
+NettyServer
+  .withPort(8080)
+  .withRxHandler(RouterHandler(router))
+  .start { _ => /* serve */ }
+```
+
+`Router.of[UserController]` reads the annotations at compile time and
+builds the route table; path parameters like `:id` bind to method
+parameters by name, and a returned `Seq` or case class is serialized to
+JSON for you (via the [Weaver](./ch05-00-data) machinery from Chapter 5).
+The [server reference](/http/server) covers query parameters, filters,
+and combining controllers.
+
+::: tip JVM-only routing
+The annotation router (`@Endpoint`, `Router.of`, `RouterHandler`) is a
+JVM/Netty feature. On Scala.js / Native, route inside a functional
+`withRxHandler` by matching on `request.path`. The server *itself* runs
+on all three platforms; only the annotation-based routing is JVM-only.
 :::
 
-## What this chapter will cover
+## One client, three platforms
 
-You met the HTTP client in Chapter 2. This chapter covers it
-properly, alongside the server that serves requests from the other
-side.
+The client code at the top of this chapter compiles and runs unchanged on
+the JVM, in the browser and Node.js (Scala.js), and as a native binary —
+because `Http.client` resolves to the right transport for each runtime
+(`java.net.http`, the Fetch API, or libcurl). You write the request once.
+The one constraint worth knowing: browsers have no synchronous HTTP, so
+in browser code use `newAsyncClient`. [Chapter 10](./ch10-00-cross-platform)
+is about this property in general; the [client reference](/http/client)
+has the per-platform backend table.
 
-Concepts introduced:
+For responses too large to hold in memory, or for a server pushing
+updates to a client, see [streaming and server-sent events](/http/sse).
 
-- Sync vs. async clients: when to use each, and why most code should
-  start with sync.
-- Configuring the client: timeouts, retry, rate limiting, connection
-  pooling.
-- The REST server: defining endpoints, binding them to a Design, and
-  running them.
-- The Router: composing endpoints into a larger service, including
-  sub-routers.
-- Server-sent events and streaming responses.
-- Interop: how the client behaves identically on JVM, Scala.js, and
-  Scala Native.
+## What you have, what comes next
 
-## Reference you can read now
+You can now build both ends of an HTTP exchange:
 
-- [HTTP — Overview](/http/)
-- [HTTP Client](/http/client)
-- [REST Server](/http/server)
-- [Router](/http/router)
-- [Server-Sent Events](/http/sse)
-- [Retry Strategies](/http/retry)
+- **`Http.client.newSyncClient`** for blocking calls,
+  **`newAsyncClient`** for `Rx[HttpResponse]`.
+- A **server** from a functional handler (every platform) or an
+  **annotation router** (`@Endpoint` + `Router.of`, JVM).
+- The same client source runs on JVM, Scala.js, and Native.
 
-[← 7. Retry, Circuit Breakers, Resources](./ch07-00-control) | [Next → 9. Typed RPC](./ch09-00-rpc)
+Next, [Chapter 9](./ch09-00-rpc) removes the hand-written URLs and JSON
+entirely: define a trait once and get a typed client and server that
+speak it.
+
+[← 7. Living With Failure](./ch07-00-control) | [Next → 9. Typed RPC](./ch09-00-rpc)

--- a/docs/book/ch09-00-rpc.md
+++ b/docs/book/ch09-00-rpc.md
@@ -1,28 +1,128 @@
 # 9. Typed RPC
 
-::: warning Coming soon
-This chapter is an outline. The full draft ships in a follow-up PR.
-:::
+In Chapter 8 both ends of the call wrote out the contract by hand: the
+server picked the path `/users/:id` and shaped the JSON; the client typed
+the same path and parsed the same JSON back. Nothing connects those two
+copies. Rename a field on the server and the client keeps compiling — and
+breaks at runtime, in production, against the one response you didn't
+test.
 
-## What this chapter will cover
+RPC closes that gap. You write the contract *once*, as a Scala trait, and
+both sides are checked against it by the compiler.
 
-Uni's RPC layer lets two services share a trait definition and get a
-working client + server pair, without per-endpoint glue code. This
-chapter walks through defining, implementing, and consuming an RPC
-service.
+## Define the contract once
 
-Concepts introduced:
+The API is an ordinary trait. The server implements it; the client will
+call it.
 
-- RPC traits: declaring an interface once, using it on both sides.
-- The wire format and why MessagePack is a sensible default.
-- Error handling across process boundaries: what your exception looks
-  like on the other side.
-- Evolving an RPC API without breaking existing clients.
-- When RPC is the right tool — and when to use plain HTTP / REST
-  instead.
+```scala
+case class User(id: Long, name: String, email: String) derives Weaver
 
-## Reference you can read now
+trait UserService:
+  def getUser(id: Long): User
+  def createUser(name: String, email: String): User
 
-- [RPC](/http/rpc)
+class UserServiceImpl extends UserService:
+  def getUser(id: Long): User =
+    User(id, "Alice", "alice@example.com")
+  def createUser(name: String, email: String): User =
+    User(1L, name, email)
+```
 
-[← 8. HTTP Clients and Servers](./ch08-00-http) | [Next → 10. Cross-Platform Development](./ch10-00-cross-platform)
+There is no annotation on the methods, no per-endpoint glue. `getUser` is
+a normal method; RPC will turn it into a network call without you
+describing the wire shape.
+
+## Serve it
+
+`RPCRouter.of[UserService]` reads the trait at compile time and builds
+the routes; `RPCHandler` turns that router into something a server can
+run:
+
+```scala
+import wvlet.uni.http.rpc.RPCRouter
+import wvlet.uni.http.netty.{NettyServer, RPCHandler}
+
+val router = RPCRouter.of[UserService](UserServiceImpl())
+
+NettyServer
+  .withPort(8080)
+  .withRxHandler(RPCHandler(router))
+  .start { _ => /* serving */ }
+```
+
+Each method becomes a `POST /UserService/{methodName}` endpoint. You
+never chose those paths — they fall out of the trait, which is the point:
+there is no path for the client and server to disagree about.
+
+## Call it like a local method
+
+On the client side, the `sbt-uni` plugin generates a typed client from
+the *same* trait (see [client generation](/http/rpc#generating-a-client)
+for the build setup). Calling a remote method then looks like calling a
+local one:
+
+```scala
+import wvlet.uni.http.Http
+import com.example.client.UserServiceClient
+
+val client = UserServiceClient.SyncClient(
+  Http.client.withBaseUri("http://localhost:8080").newSyncClient
+)
+
+val user: User = client.getUser(42)   // a network round-trip, fully typed
+```
+
+`client.getUser(42)` is checked by the compiler against `UserService`.
+Pass a `String` where the trait wants a `Long`, or rename `getUser` on
+the server, and the *client* stops compiling — the failure moves from a
+2 a.m. production page to your build. That is the entire value
+proposition: the contract is one artifact, and a violation is a compile
+error.
+
+## What crosses the wire
+
+Arguments and return values are serialized with [Weaver](./ch05-00-data),
+the same derivation you met in Chapter 5 — which is why `User` has
+`derives Weaver`. Over the wire RPC uses MessagePack by default: it is
+compact and fast, and since both ends were generated from one trait,
+there is no human reading the bytes who would prefer JSON. The encoding
+is an internal detail you mostly never see.
+
+Errors cross the boundary as data too. When the server throws, the client
+sees an `RPCException` carrying a structured `RPCStatus` — a typed code
+like `NOT_FOUND` or `INVALID_ARGUMENT` — rather than a bare HTTP number
+you have to interpret. The [RPC reference](/http/rpc#rpc-status-codes)
+lists the status categories.
+
+## When RPC, when REST
+
+RPC is the right tool when **you own both ends** — two of your own
+services, or your frontend and backend, evolving together. The shared
+trait is a feature: it keeps them in lockstep.
+
+It is the *wrong* tool when the other end is not yours to recompile. A
+public API consumed by third parties, a webhook, anything that must speak
+a stable, language-neutral contract — that wants plain
+[HTTP/REST](./ch08-00-http), where the wire format *is* the interface and
+no client needs your trait. Use RPC inside your system; use REST at its
+public edge.
+
+## What you have, what comes next
+
+You can now connect two services without hand-written glue:
+
+- **A trait is the contract** — implemented on the server, generated into
+  a client, checked by the compiler on both sides.
+- **`RPCRouter.of[T](impl)` + `RPCHandler`** serves it;
+  **`sbt-uni`** generates the typed client.
+- Payloads ride **Weaver/MessagePack**; errors arrive as typed
+  **`RPCStatus`**.
+- Reach for RPC when you own both ends, REST at the public edge.
+
+That closes Part V. Next, [Part VI](./ch10-00-cross-platform) steps back
+to the property that has been quietly true this whole time: nearly
+everything you've written runs on three different runtimes from one
+codebase.
+
+[← 8. HTTP Clients and Servers](./ch08-00-http) | [Next → 10. One Codebase, Three Runtimes](./ch10-00-cross-platform)

--- a/docs/book/ch10-00-cross-platform.md
+++ b/docs/book/ch10-00-cross-platform.md
@@ -1,32 +1,120 @@
 # 10. One Codebase, Three Runtimes
 
-::: warning Coming soon
-This chapter is an outline. The full draft ships in a follow-up PR.
+Here is something that has been quietly true for the whole book: almost
+every snippet you've written — `Design`, `Rx`, `Weaver`, the HTTP client —
+already runs on the JVM, in the browser through Scala.js, and as a native
+binary through Scala Native. You didn't do anything special to make that
+happen. This chapter explains *how*, and what to do for the handful of
+things that genuinely can't be shared.
+
+## One build, three targets
+
+A cross-platform module is declared once with `crossProject`:
+
+```scala
+// build.sbt
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+
+lazy val app = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .settings(
+    libraryDependencies += "org.wvlet.uni" %%% "uni" % "__UNI_VERSION__"
+  )
+```
+
+That one declaration produces three projects — `appJVM`, `appJS`,
+`appNative`. The `%%%` (three percent signs) is the cross-platform
+dependency operator: it pulls in the build of `uni` that matches each
+target. `sbt appJVM/run`, `sbt appJS/fastLinkJS`, and `sbt appNative/run`
+build the same source three ways.
+
+## Where code lives
+
+`CrossType.Pure` gives each module these source roots:
+
+```
+app/
+  src/main/scala/        # shared — compiled for all three platforms
+  .jvm/src/main/scala/   # JVM-only
+  .js/src/main/scala/    # Scala.js-only
+  .native/src/main/scala/ # Native-only
+```
+
+The vast majority of your code goes in the shared `src/` and is compiled
+three times. The `.jvm` / `.js` / `.native` folders hold only the code
+that *must* differ per platform. If you never need them, you never create
+them — and most application logic never does.
+
+## Why most code doesn't care
+
+The reason the shared folder stays large is that Uni already wraps the
+platform-specific pieces behind cross-platform APIs:
+
+- File I/O goes through the [FileSystem](/core/filesystem) abstraction
+  (`IOPath`), not `java.nio.file.Path` — so reading a file is the same
+  call everywhere.
+- The [HTTP client](./ch08-00-http) resolves to `java.net.http`, the
+  Fetch API, or libcurl depending on the runtime, behind one
+  `Http.client`.
+- `Rx`, `Design`, and `Weaver` are pure Scala with no platform
+  assumptions.
+
+Because your business logic talks to these abstractions instead of to JDK
+classes directly, it lands in the shared folder and compiles everywhere
+unchanged. That is the whole trick: depend on the abstraction, and the
+platform detail is someone else's problem.
+
+## Isolating what you truly can't share
+
+Sometimes you need a real platform primitive — a JVM library with no JS
+equivalent, a browser DOM call, a native syscall. The pattern is to
+declare a small shared interface and put one implementation in each
+platform folder:
+
+```scala
+// src/main/scala — shared: the shape everyone agrees on
+trait Clock:
+  def nowMillis(): Long
+
+// .jvm/src/main/scala — the JVM implementation
+object PlatformClock extends Clock:
+  def nowMillis(): Long = System.currentTimeMillis()
+```
+
+Each platform folder supplies its own `PlatformClock`; the shared code
+only ever sees the `Clock` interface. The seam is exactly the one from
+[Chapter 3](./ch03-00-design) — program against an interface, bind the
+implementation elsewhere — applied to platforms instead of test doubles.
+
+The payoff is that the gap is caught at **compile time**: if a platform
+is missing its implementation, that platform's build fails. You don't
+discover a missing piece when a user in a browser hits it; you discover it
+when `appJS` won't compile. The type system, not a test matrix, keeps the
+three builds honest.
+
+::: tip A few things are inherently platform-bound
+Browsers have no synchronous HTTP and no filesystem; native binaries
+have no DOM. Uni surfaces these honestly — for example, the sync HTTP
+client throws in the browser rather than pretending. When a capability
+only exists on one platform, keep the code that uses it in that platform's
+folder.
 :::
 
-## What this chapter will cover
+## What you have, what comes next
 
-Scala 3 can target the JVM, JavaScript (via Scala.js), and native
-binaries (via Scala Native). Uni is designed so that a single piece of
-business logic compiles to all three. This chapter takes a working
-JVM service and shows the minimum changes needed to also ship it as a
-browser app and as a native binary.
+You can now ship one codebase to three runtimes:
 
-Concepts introduced:
+- **`crossProject(JVMPlatform, JSPlatform, NativePlatform)`** with `%%%`
+  dependencies builds the same source three ways.
+- Shared code lives in **`src/`**; only genuinely platform-specific code
+  goes in **`.jvm` / `.js` / `.native`**.
+- Uni's abstractions (FileSystem, HTTP, Rx, Design, Weaver) keep most
+  code in the shared folder.
+- Unshareable primitives hide behind a **shared interface with a
+  per-platform implementation**, and missing platforms fail at compile
+  time.
 
-- `sbt-crossproject`: one `build.sbt`, three platforms.
-- The `.jvm`, `.js`, and `.native` source folders and what belongs in
-  each.
-- Platform abstractions Uni gives you (HTTP, filesystem, timers) so
-  your code stays identical.
-- Things you *cannot* share: JVM-only file paths, browser-only DOM
-  access, native-only syscalls — and how to isolate them.
-- Building and distributing: a fat JAR, an optimized JS bundle, and a
-  stripped native binary.
-
-## Reference you can read now
-
-- [Design Principles — Cross-Platform First](/guide/principles#cross-platform-first)
-- [HTTP Client — platform notes](/http/client)
+Next, the final chapter, [Chapter 11](./ch11-00-testing), tests all of
+this — and the same suite runs on all three runtimes.
 
 [← 9. Typed RPC](./ch09-00-rpc) | [Next → 11. Testing with UniTest](./ch11-00-testing)

--- a/docs/book/ch11-00-testing.md
+++ b/docs/book/ch11-00-testing.md
@@ -1,29 +1,125 @@
 # 11. Testing with UniTest
 
-::: warning Coming soon
-This chapter is an outline. The full draft ships in a follow-up PR.
-:::
+A service under test needs a database, a payment gateway, and the current
+time. The reflex is to mock all three. Uni pushes you the other way: run
+the *real* code, and substitute as narrowly as you can. This chapter is
+about writing tests that way — and why it produces tests you can trust.
 
-## What this chapter will cover
+## A first test
 
-Tests in a Uni codebase favor the real implementation with narrow
-substitutions, rather than deep mocking. This chapter covers the
-shape of a UniTest suite and how Design makes substitutions clean.
+Extend `UniTest`, declare cases with `test`, and assert with `shouldBe`:
 
-Concepts introduced:
+```scala
+import wvlet.uni.test.UniTest
 
-- The `UniTest` base class and the assertion vocabulary (`shouldBe`,
-  `shouldContain`, `shouldMatch`).
-- Why the project avoids mocks, and what to do instead: narrow
-  overrides via `Design` and in-process fakes.
-- Property-based testing primitives.
-- Async tests with `Rx` and `Future`.
-- Cross-platform tests: writing one suite that runs under JVM,
-  Scala.js, and Scala Native.
-- Speed: keeping a Uni test suite under a second, and why that matters.
+class CalculatorTest extends UniTest:
+  test("adds two numbers") {
+    val result = 2 + 3
+    result shouldBe 5
+  }
 
-## Reference you can read now
+  test("a list contains a value") {
+    Seq("a", "b", "c") shouldContain "b"
+  }
+```
 
-- [UniTest (module reference)](/core/unitest)
+```bash
+$ sbt test
+[info] CalculatorTest:
+[info]  - adds two numbers
+[info]  - a list contains a value
+```
+
+`test("name") { … }` is a case; the block is the body. There is no
+annotation, no separate runner to register. The assertion vocabulary is
+small and reads as English: `shouldBe`, `shouldNotBe`, `shouldContain`,
+and `shouldMatch { case … => }` for matching a shape rather than a value.
+The [UniTest reference](/core/unitest) has the full list.
+
+## Substitute, don't mock
+
+The interesting question is the service with dependencies. You met the
+mechanism already, in [Chapter 3](./ch03-00-design): a `Design` is a
+value, and `+` overrides it. A test takes the real application wiring and
+swaps in exactly one piece.
+
+```scala
+import wvlet.uni.design.Design
+import wvlet.uni.test.UniTest
+
+class UserServiceTest extends UniTest:
+  test("looks up a user by id") {
+    // appDesign is the real production wiring from Chapter 3.
+    val testDesign = appDesign +
+      Design.newDesign.bindInstance[Database](FakeDatabase())
+
+    testDesign.build[UserService] { users =>
+      users.findUser("123") shouldBe Some("Alice")
+    }
+  }
+```
+
+`UserService` is the real class, running its real logic. Only the
+`Database` underneath it is a fake — an in-process stand-in with no
+network. Every other binding stays production. The test exercises the
+code that ships, not a hollowed-out copy of it.
+
+## Why not mock?
+
+A mock encodes *your belief* about how a dependency behaves: "when I call
+`query`, it returns these rows." The test then checks your code against
+that belief. If your belief is wrong — the real database orders results
+differently, throws a different exception, paginates — the mock-based test
+passes anyway, and the bug ships. You tested the mock, not the system.
+
+Uni's stance is to keep the real objects and replace only what you must:
+the genuinely external edge (a network, a clock, a payment processor)
+with an in-process fake you control. Everything between your entry point
+and that edge is real, so the test catches the integration mistakes a
+mock would paper over. A fake `Database` that actually stores and returns
+rows tells you more than a mock that returns a canned list.
+
+This is why Uni ships no mocking framework and the guides steer you away
+from one. The tool you need is `Design` override, which you already have.
+
+## One suite, three platforms
+
+Because `UniTest` is itself cross-platform, a test you write once runs
+under the JVM, Scala.js, and Scala Native — the same `sbt test` story as
+[Chapter 10](./ch10-00-cross-platform), now for your tests. A suite over
+shared logic verifies all three builds at once, so "compiles on Native"
+becomes "*passes* on Native" without a second test to write.
+
+## Fast on purpose
+
+Notice what these tests don't do: spin up a container, open a socket, hit
+a real clock. A `Design`-substituted suite is in-process and
+dependency-free, which is why it finishes in well under a second. That
+speed is not a bonus — it is the point. A suite you can run on every save
+gets run on every save; a slow one gets run before lunch, if then. Keeping
+tests fast keeps them used, and the substitution approach is what keeps
+them fast.
+
+## What you have, what comes next
+
+You can now test a Uni application the way it's meant to be tested:
+
+- **`extends UniTest`** with `test("…") { … }` and a small assertion
+  vocabulary — `shouldBe`, `shouldContain`, `shouldMatch`.
+- **`Design` override (`+`)** substitutes one dependency and keeps the
+  rest real — the alternative to mocking.
+- One suite runs on **all three platforms**, and stays **fast** because
+  it's in-process.
+
+That completes the book's main path. You have built, wired, logged,
+serialized, reacted, recovered, served, connected, ported, and tested a
+Uni application — the full arc from `Design.build` to a green test suite
+on three runtimes.
+
+The appendices go sideways from here: [Appendix A](./appendix-a-scala3)
+collects the Scala 3 syntax the book leans on, [Appendix
+B](./appendix-b-airframe) traces Uni's relationship to Airframe, and
+[Appendix C](./appendix-c-glossary) is a glossary of the terms you've
+met.
 
 [← 10. One Codebase, Three Runtimes](./ch10-00-cross-platform) | [Next → Appendix A: Scala 3 Syntax Notes](./appendix-a-scala3)

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -69,6 +69,6 @@ are, and the Book links into them when you need depth.
 
 ## Status
 
-Parts I and II are drafted. Parts III through VIII are stubs with
+Parts I through III are drafted. Parts IV through VII are stubs with
 outlines; they will ship in follow-up pull requests. If a link leads to
 a "Coming soon" page, that is working as intended.

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -69,6 +69,6 @@ are, and the Book links into them when you need depth.
 
 ## Status
 
-Parts I through III are drafted. Parts IV through VII are stubs with
-outlines; they will ship in follow-up pull requests. If a link leads to
-a "Coming soon" page, that is working as intended.
+All parts are drafted, Foreword through the appendices. The book is best
+read front to back the first time; afterwards, use it as a jumping-off
+point into the [reference docs](/guide/).


### PR DESCRIPTION
Completes [The Uni Book](https://wvlet.org/uni/book/): graduates every remaining stub (Chapters 3–11 plus Appendices A–C) into full drafts. Parts I–II were already written; this branch finishes Parts III–VII and the appendices, so the book now reads end to end with no "Coming soon" pages.

Each chapter follows the book's authoring guide (`docs/book/CLAUDE.md`) — Rust-Book style: opening question → runnable example → walk the *why* → extend → "what you have, what comes next" recap with nav footers — and matches the voice of the existing model chapter (ch02): second person, present tense, no emoji, links **into** reference docs rather than restating them.

## Chapters

- **Part III** — 3 Wiring with Design · 4 Logging That Finds You · 5 Data In, Data Out (JSON & MessagePack)
- **Part IV** — 6 Rx, the Composable Stream · 7 Living With Failure (Retry / Circuit Breaker / Resource)
- **Part V** — 8 HTTP Clients and Servers · 9 Typed RPC
- **Part VI** — 10 One Codebase, Three Runtimes
- **Part VII** — 11 Testing with UniTest
- **Appendices** — A Scala 3 Syntax Notes · B Uni and Airframe · C Glossary

## Through-lines

The chapters build on each other deliberately: Design's override seam (ch3) returns as test substitution (ch11) and platform isolation (ch10); Weaver (ch5) powers both RPC payloads (ch9) and cross-platform derivation (ch10); Rx (ch6) is the async HTTP shape (ch8). Each *why* the guide asks for is answered (why constructor injection, why no structured logging, why one codec for two formats, why idempotency gates retry, why substitute over mock).

## Verification

- Every code snippet checked against current source — e.g. `Retry.withBackOff` (capital O), `CircuitBreaker.run` + `CircuitBreakerOpenException`, `RPCRouter.of[T]` + `RPCHandler`, `Http.client.withBaseUri`, the `crossProject(...)` setup, UniTest assertions.
- Book index status updated to "all parts drafted".
- `pnpm docs:build` passes (dead-link-clean); sidebar already listed every chapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)