### PR TITLE
docs(book): Add Part VIII — Scala.js and the NPM ecosystem (facades + Vite)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -135,6 +135,13 @@ export default defineConfig<UniThemeConfig>({
           ]
         },
         {
+          text: 'Part VIII — Scala.js & the JS Ecosystem',
+          items: [
+            { text: '12. Calling NPM Modules', link: '/book/ch12-00-npm-facades' },
+            { text: '13. Bundling with Vite', link: '/book/ch13-00-vite' }
+          ]
+        },
+        {
           text: 'Appendices',
           items: [
             { text: 'A. Scala 3 Syntax Notes', link: '/book/appendix-a-scala3' },

--- a/docs/book/appendix-a-scala3.md
+++ b/docs/book/appendix-a-scala3.md
@@ -97,4 +97,4 @@ anonymous-class case (overriding methods inline, as with a
 `WebSocketHandler`). If you wrote Scala 2, dropping `new` is the habit to
 unlearn first.
 
-[← 11. Testing with UniTest](./ch11-00-testing) | [Next → Appendix B: Uni and Airframe](./appendix-b-airframe)
+[← 13. Bundling with Vite](./ch13-00-vite) | [Next → Appendix B: Uni and Airframe](./appendix-b-airframe)

--- a/docs/book/ch11-00-testing.md
+++ b/docs/book/ch11-00-testing.md
@@ -111,15 +111,15 @@ You can now test a Uni application the way it's meant to be tested:
 - One suite runs on **all three platforms**, and stays **fast** because
   it's in-process.
 
-That completes the book's main path. You have built, wired, logged,
+That completes the book's core path. You have built, wired, logged,
 serialized, reacted, recovered, served, connected, ported, and tested a
 Uni application — the full arc from `Design.build` to a green test suite
 on three runtimes.
 
-The appendices go sideways from here: [Appendix A](./appendix-a-scala3)
-collects the Scala 3 syntax the book leans on, [Appendix
-B](./appendix-b-airframe) traces Uni's relationship to Airframe, and
-[Appendix C](./appendix-c-glossary) is a glossary of the terms you've
-met.
+Next, [Part VIII](./ch12-00-npm-facades) follows the Scala.js thread out
+into the wider JavaScript world: calling npm packages from Scala through
+small hand-written facades, and bundling the result with Vite. After that,
+the appendices collect supporting material — Scala 3 syntax, the Airframe
+relationship, and a glossary.
 
-[← 10. One Codebase, Three Runtimes](./ch10-00-cross-platform) | [Next → Appendix A: Scala 3 Syntax Notes](./appendix-a-scala3)
+[← 10. One Codebase, Three Runtimes](./ch10-00-cross-platform) | [Next → 12. Calling NPM Modules](./ch12-00-npm-facades)

--- a/docs/book/ch12-00-npm-facades.md
+++ b/docs/book/ch12-00-npm-facades.md
@@ -1,0 +1,140 @@
+# 12. Calling NPM Modules from Scala.js
+
+You're building a browser app with Uni ([Chapter 10](./ch10-00-cross-platform)),
+and you need something the JavaScript world already solved: a Markdown
+renderer, a charting library, a date picker. It's on npm, written in
+JavaScript, with no Scala types. How do you call it from Scala 3 without
+giving up type safety — and without dragging in a code generator?
+
+The answer is a **facade**: a few lines of Scala that declare the shape
+of the JavaScript you actually use. You write it by hand, and it is
+smaller than you expect.
+
+## A facade is a typed declaration
+
+Say you want [`marked`](https://www.npmjs.com/package/marked), which turns
+Markdown into HTML. In JavaScript you'd write:
+
+```javascript
+import { marked } from 'marked'
+marked.parse('# Hello')   // "<h1>Hello</h1>"
+```
+
+The Scala.js facade for exactly that is:
+
+```scala
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+@js.native
+@JSImport("marked", "marked")
+object Marked extends js.Object:
+  def parse(markdown: String): String = js.native
+```
+
+And you call it like any Scala object:
+
+```scala
+val html = Marked.parse("# Hello")   // "<h1>Hello</h1>"
+```
+
+That's the whole thing. Four pieces are doing the work:
+
+- **`@JSImport("marked", "marked")`** says where the value comes from: the
+  named export `marked` from the npm package `marked`. Scala.js turns this
+  into a real `import { marked } from "marked"` in its JavaScript output.
+- **`@js.native`** marks this as a declaration, not an implementation —
+  the code lives on the JavaScript side.
+- **`extends js.Object`** types it as a JavaScript object.
+- **`= js.native`** is the method body you don't write, because the real
+  one is in the npm package.
+
+You declared *only* `parse`, because that's the only method you call. A
+facade describes your usage, not the whole library — if you later need
+`marked.lexer`, you add one line.
+
+## Default exports and other shapes
+
+Packages export values in a few shapes, and `@JSImport` has a form for
+each. A **named** export uses its name (as above). A **default** export
+uses `JSImport.Default`:
+
+```scala
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+// JavaScript:  import confetti from 'canvas-confetti'; confetti()
+@js.native
+@JSImport("canvas-confetti", JSImport.Default)
+object Confetti extends js.Object:
+  def apply(): Unit = js.native
+```
+
+A method that *returns* a JavaScript object gets its own `@js.native`
+trait — no `@JSImport`, because you don't import it, you receive it:
+
+```scala
+@js.native
+@JSImport("some-db", JSImport.Default)
+object DB extends js.Object:
+  def open(path: String): Connection = js.native
+
+@js.native
+trait Connection extends js.Object:
+  def query(sql: String): js.Array[js.Any] = js.native
+```
+
+JavaScript values map to `js`-prefixed types: `js.Object`, `js.Array[A]`,
+`js.Function`, `js.Dictionary[A]` for string-keyed maps, and `js.Any`
+when you genuinely don't care. When even a typed facade is more ceremony
+than a one-off call deserves, `js.Dynamic` is the escape hatch — fully
+untyped, method calls resolved at runtime:
+
+```scala
+import scala.scalajs.js
+val mod = js.Dynamic.global.someGlobal
+mod.doThing("arg")   // no types, no facade — use sparingly
+```
+
+Reach for `js.Dynamic` to prototype; promote to a real facade once you
+know which three methods you actually call.
+
+## Why not ScalablyTyped?
+
+[ScalablyTyped](https://scalablytyped.org/) generates Scala facades
+automatically from a package's TypeScript definitions. It is impressive,
+and for this book's purposes it is the wrong default.
+
+The cost is out of proportion to the need. A typical npm package ships
+thousands of lines of `.d.ts`; ScalablyTyped turns that into a large
+generated Scala library that your build must convert and compile, every
+clean build, whether or not you call more than three of its functions.
+That's slower builds, a heavier toolchain, and generated names you didn't
+choose leaking into your code.
+
+What you actually need from `marked` was one method. The hand-written
+facade for it is four lines you can read, that compile instantly, and
+that say exactly what your program depends on. The trade is real — you
+write the declarations yourself instead of having them generated — but
+for the handful of calls a typical app makes into a JS library, four
+honest lines beat ten thousand generated ones. Write the facade.
+
+## What you have, what comes next
+
+You can now call JavaScript libraries from Scala with types you control:
+
+- A **facade** is a `@js.native @JSImport(...)` declaration of just the
+  parts of a package you use.
+- **`JSImport.Default`** for default exports, **`"name"`** for named ones;
+  returned objects get their own `@js.native` trait.
+- **`js.Dynamic`** is the untyped escape hatch for prototyping.
+- Skip **ScalablyTyped** — a few hand-written lines beat a generated
+  library for the calls a real app makes.
+
+But there's a missing piece. Your facade says `@JSImport("marked", …)`,
+and Scala.js faithfully emits `import { marked } from "marked"` — yet
+nothing has *installed* `marked` or resolved that import for the browser.
+That is the bundler's job. Next, [Chapter 13](./ch13-00-vite) wires it all
+together with Vite.
+
+[← 11. Testing with UniTest](./ch11-00-testing) | [Next → 13. Bundling with Vite](./ch13-00-vite)

--- a/docs/book/ch13-00-vite.md
+++ b/docs/book/ch13-00-vite.md
@@ -1,0 +1,175 @@
+# 13. Bundling with Vite
+
+Your facade from [Chapter 12](./ch12-00-npm-facades) says
+`@JSImport("marked", "marked")`, and Scala.js dutifully emits
+`import { marked } from "marked"` in its output. But nothing has installed
+`marked`, and a browser has no idea what the bare name `"marked"` resolves
+to. Something has to fetch the package, follow its imports, and produce
+JavaScript a browser can load. That something is a **bundler**, and
+[Vite](https://vitejs.dev/) is a good one.
+
+This chapter wires the two worlds together: Scala.js on one side emitting
+ES module imports, Vite on the other resolving them against npm.
+
+## Step 1: emit ES modules
+
+For `@JSImport` to become a real `import` a bundler can follow, Scala.js
+must emit ES modules. Set the module kind once in `build.sbt`:
+
+```scala
+import org.scalajs.linker.interface.ModuleKind
+
+lazy val app = project
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.ESModule) }
+  )
+```
+
+This is the one setting that makes the whole chain work. Without it,
+Scala.js can't emit the `import { marked } from "marked"` that Vite needs
+to see. (Uni's own JS builds use exactly this setting.)
+
+`sbt app/fastLinkJS` then produces a folder of ES modules under
+`target/scala-3.x/app-fastopt/`, with `main.js` as the entry. The
+production command is `app/fullLinkJS`, which emits an optimized build
+under `app-opt/`.
+
+## Step 2: install the npm package
+
+Vite resolves `"marked"` the npm way — from `node_modules`. So install it,
+along with Vite itself:
+
+```bash
+$ npm install marked
+$ npm install --save-dev vite
+```
+
+This is the half of the contract Scala can't fulfill: the facade *names*
+the package, and `npm install` *provides* it.
+
+## Step 3: a Vite entry point
+
+Vite serves an `index.html` that loads one JavaScript entry module:
+
+```html
+<!-- index.html -->
+<body>
+  <script type="module" src="/main.js"></script>
+</body>
+```
+
+`main.js` is the seam between the npm world and the Scala.js world. It
+imports your styles and any npm modules you want to set up, then pulls in
+the Scala.js output to start your app:
+
+```javascript
+// main.js
+import './style.css'
+
+// Start the Scala.js application (the fastLinkJS output entry module)
+import('./target/scala-3.x/app-fastopt/main.js')
+```
+
+When Scala.js code runs and hits your `Marked.parse(...)` facade, the
+emitted `import { marked } from "marked"` resolves through Vite to the
+installed package. The facade, the linker, and the bundler are now one
+pipeline: Scala types on top, npm code underneath.
+
+## Step 4: run it
+
+Two processes, one for each compiler:
+
+```bash
+$ sbt "~app/fastLinkJS"   # recompile Scala.js on change
+$ npx vite                # dev server with hot reload
+```
+
+`vite` serves the app with instant hot-module reload; the `~` keeps
+Scala.js relinking as you edit. For production, `sbt app/fullLinkJS`
+followed by `npx vite build` emits a minified bundle to `dist/`.
+
+A minimal `vite.config.js` needs almost nothing:
+
+```javascript
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  base: "./",
+})
+```
+
+## When a module won't bundle cleanly
+
+Most npm packages bundle without fuss. Two situations need a nudge, and
+both have a one-line fix.
+
+**A library that's easier to load as a global.** Some packages (editors,
+WASM modules) are simplest to load in `main.js` and hand to Scala.js
+through the `window` object. Expose it:
+
+```javascript
+// main.js
+import { marked } from 'marked'
+window.marked = marked
+```
+
+and facade it with `@JSGlobal` instead of `@JSImport`:
+
+```scala
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+@js.native
+@JSGlobal("marked")
+object Marked extends js.Object:
+  def parse(markdown: String): String = js.native
+```
+
+This `window` bridge is how the
+[Wvlet playground](https://github.com/wvlet/wvlet/tree/main/wvlet-ui-playground)
+wires its Monaco editor — `main.js` sets `window.MonacoEditor`, and Scala
+reads it via `@JSGlobal`.
+
+**A package with a dependency the browser can't use.** A library may pull
+in a Node-only module the bundler can't resolve. Point Vite at a
+browser-safe replacement with `resolve.alias`:
+
+```javascript
+export default defineConfig({
+  resolve: {
+    alias: {
+      // swap a Node-only dep for a browser stub
+      "node-only-pkg": "/stubs/browser-stub.js",
+    },
+  },
+})
+```
+
+The playground does this for `koffi` (a native-binding library its DuckDB
+backend needs on Node but never on the web) — aliasing it to a stub that
+throws if anything ever calls it. Reach for `alias` only when a transitive
+dependency fights the browser; you won't need it for ordinary UI packages.
+
+## What you have, what comes next
+
+You can now ship a Scala.js app that uses the npm ecosystem:
+
+- **`ModuleKind.ESModule`** makes Scala.js emit imports a bundler can
+  follow.
+- **`npm install`** provides the package your facade named.
+- A **`main.js` entry** imports the Scala.js output and any npm setup;
+  Vite resolves the bare imports and serves the app.
+- **`@JSGlobal` + `window`** bridges stubborn modules, and
+  **`resolve.alias`** swaps out browser-hostile dependencies.
+
+That completes Part VIII — Scala.js is now a full participant in the
+JavaScript ecosystem, with types on your side of the boundary and npm on
+the other.
+
+From here the appendices collect the supporting material:
+[Appendix A](./appendix-a-scala3) on Scala 3 syntax,
+[Appendix B](./appendix-b-airframe) on Uni's relationship to Airframe, and
+[Appendix C](./appendix-c-glossary), the glossary.
+
+[← 12. Calling NPM Modules from Scala.js](./ch12-00-npm-facades) | [Next → Appendix A: Scala 3 Syntax Notes](./appendix-a-scala3)

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -61,6 +61,11 @@ are, and the Book links into them when you need depth.
 
 - [Chapter 11: Testing with UniTest](./ch11-00-testing)
 
+### Part VIII — Scala.js in the JavaScript Ecosystem
+
+- [Chapter 12: Calling NPM Modules from Scala.js](./ch12-00-npm-facades)
+- [Chapter 13: Bundling with Vite](./ch13-00-vite)
+
 ### Appendices
 
 - [Appendix A: Scala 3 Syntax Notes for This Book](./appendix-a-scala3)


### PR DESCRIPTION
Adds a new **Part VIII** to [The Uni Book](https://wvlet.org/uni/book/) on using the JavaScript/npm ecosystem from a Scala.js Uni app — without ScalablyTyped, as requested.

## Chapters

- **Ch 12 — Calling NPM Modules from Scala.js**: hand-written facades with `@js.native` + `@JSImport` (default vs named exports), the `js.*` type vocabulary, the `js.Dynamic` escape hatch, and a clear-eyed *why not ScalablyTyped* (a few honest lines beat a generated TS→Scala library for the handful of calls a real app makes).
- **Ch 13 — Bundling with Vite**: `ModuleKind.ESModule` so `@JSImport` emits real imports; `npm install`; a `main.js` entry that loads the Scala.js output and lets Vite resolve the bare imports; and the two real-world escape hatches — the `@JSGlobal` + `window` bridge and `resolve.alias` for browser-hostile transitive deps.

## Grounded in real code

Patterns come from the [`wvlet-ui-playground`](https://github.com/wvlet/wvlet/tree/main/wvlet-ui-playground) reference you pointed to:
- the verified `Koffi.scala` facade (`@JSImport("koffi", JSImport.Default)`),
- the playground's `vite.config.js` (`resolve.alias` koffi→stub, `base: "./"`), `main.js` (`window.MonacoEditor` bridge, dynamic import of the Scala.js output), and `package.json`,
- `ModuleKind.ESModule` confirmed against both uni's and wvlet's `build.sbt`.

## Wiring

- New Part VIII in the book ToC and the `/book/` sidebar.
- Nav re-threaded: ch11 → 12 → 13 → appendices (ch11 closing and appendix-A `prev` updated accordingly).
- `pnpm docs:build` passes (dead-link-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)