### PR TITLE
docs(book): Add Part IX — Scala Native and the C/Rust world (FFI both directions)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -142,6 +142,13 @@ export default defineConfig<UniThemeConfig>({
           ]
         },
         {
+          text: 'Part IX — Scala Native & the C/Rust World',
+          items: [
+            { text: '14. Calling C from Scala Native', link: '/book/ch14-00-calling-c' },
+            { text: '15. Exposing Scala Native to C & Rust', link: '/book/ch15-00-exposing-native' }
+          ]
+        },
+        {
           text: 'Appendices',
           items: [
             { text: 'A. Scala 3 Syntax Notes', link: '/book/appendix-a-scala3' },

--- a/docs/book/appendix-a-scala3.md
+++ b/docs/book/appendix-a-scala3.md
@@ -97,4 +97,4 @@ anonymous-class case (overriding methods inline, as with a
 `WebSocketHandler`). If you wrote Scala 2, dropping `new` is the habit to
 unlearn first.
 
-[← 13. Bundling with Vite](./ch13-00-vite) | [Next → Appendix B: Uni and Airframe](./appendix-b-airframe)
+[← 15. Exposing Scala Native to C and Rust](./ch15-00-exposing-native) | [Next → Appendix B: Uni and Airframe](./appendix-b-airframe)

--- a/docs/book/ch13-00-vite.md
+++ b/docs/book/ch13-00-vite.md
@@ -167,9 +167,9 @@ That completes Part VIII — Scala.js is now a full participant in the
 JavaScript ecosystem, with types on your side of the boundary and npm on
 the other.
 
-From here the appendices collect the supporting material:
-[Appendix A](./appendix-a-scala3) on Scala 3 syntax,
-[Appendix B](./appendix-b-airframe) on Uni's relationship to Airframe, and
-[Appendix C](./appendix-c-glossary), the glossary.
+Next, [Part IX](./ch14-00-calling-c) does the mirror image for the other
+end of the platform spectrum: Scala Native and the C/Rust world — calling
+C libraries from Scala, and exposing your Scala as a library that C, C++,
+and Rust can call.
 
-[← 12. Calling NPM Modules from Scala.js](./ch12-00-npm-facades) | [Next → Appendix A: Scala 3 Syntax Notes](./appendix-a-scala3)
+[← 12. Calling NPM Modules from Scala.js](./ch12-00-npm-facades) | [Next → 14. Calling C from Scala Native](./ch14-00-calling-c)

--- a/docs/book/ch14-00-calling-c.md
+++ b/docs/book/ch14-00-calling-c.md
@@ -1,0 +1,129 @@
+# 14. Calling C from Scala Native
+
+Compile a Uni app with Scala Native ([Chapter 10](./ch10-00-cross-platform))
+and you get a real native binary — and with it, direct access to the
+entire C ecosystem: `libcurl`, `sqlite`, `openssl`, anything with a C
+ABI. No JNI, no subprocess, no serialization across a boundary. You call
+a C function the way you call a Scala one, once you've declared it.
+
+This chapter is the Scala-Native counterpart to
+[Chapter 12](./ch12-00-npm-facades): there you wrote a facade for a
+JavaScript module; here you write one for a C library.
+
+## An `@extern` binding
+
+To call C, you declare the functions you need in an `@extern` object and
+tell the linker which library provides them. Here is the shape, taken
+from how Uni's own Native HTTP client binds `libcurl`:
+
+```scala
+import scala.scalanative.unsafe.*
+
+@link("curl")
+@extern
+object curl:
+  @name("curl_easy_init")
+  def easyInit(): Ptr[Byte] = extern
+
+  @name("curl_easy_setopt")
+  def easySetOpt(handle: Ptr[Byte], option: CInt, value: CString): CInt = extern
+
+  @name("curl_easy_perform")
+  def easyPerform(handle: Ptr[Byte]): CInt = extern
+```
+
+Four pieces, mirroring the JavaScript facade from Chapter 12:
+
+- **`@link("curl")`** tells the linker to link `libcurl` into the binary —
+  the native equivalent of `npm install`.
+- **`@extern`** marks the object as a set of declarations whose bodies
+  live in that C library.
+- **`@name("curl_easy_init")`** maps a Scala method to the actual C
+  symbol, so your Scala name can be idiomatic while the binding still
+  finds `curl_easy_init`.
+- **`= extern`** is the body you don't write, because C already did.
+
+You declare only the handful of functions you call, exactly as with a JS
+facade. `libcurl` exports hundreds; a working HTTP client needs a dozen.
+
+## C types in Scala
+
+C has its own types, and Scala Native gives you a vocabulary for them
+from `scala.scalanative.unsafe`:
+
+| C | Scala Native |
+|---|--------------|
+| `int` | `CInt` |
+| `char*` (string) | `CString` |
+| `void*` / opaque pointer | `Ptr[Byte]` |
+| `size_t` | `CSize` |
+| a `struct` | `CStruct2[A, B]`, `CStruct3[...]`, … |
+
+A `CString` is a pointer to bytes, not a Scala `String` — the two are
+different worlds, and you convert at the boundary. An opaque C handle
+(like libcurl's `CURL*`) is just a `Ptr[Byte]` you pass back to the
+library; you never look inside it.
+
+## Crossing the string boundary
+
+Two helpers move strings across. `fromCString` reads a C string into a
+Scala `String`. `toCString` does the reverse — but it has to allocate
+memory somewhere, and where decides how long the result lives.
+
+For a string you pass *into* a C call and don't need afterward, allocate
+it in a `Zone`: a scoped arena that frees everything in it when the block
+ends.
+
+```scala
+import scala.scalanative.unsafe.*
+
+Zone.acquire { implicit z =>
+  val handle = curl.easyInit()
+  curl.easySetOpt(handle, CURLOPT_URL, toCString("https://example.com"))
+  curl.easyPerform(handle)
+}   // every toCString allocation in this zone is freed here
+```
+
+Reading a result back out uses `fromCString`:
+
+```scala
+val message: String = fromCString(curl.easyStrError(code))
+```
+
+The `Zone` is the key idea for memory safety at the boundary: temporary C
+allocations get a clear lifetime tied to a block, so they can't leak and
+can't be used after they're freed. (You'll see the one case where `Zone`
+is *wrong* — a value handed back to C that must outlive the call — in
+[Chapter 15](./ch15-00-exposing-native).)
+
+## Why bind C directly?
+
+On the JVM, reaching a C library means JNI: a separate C shim, a build
+step, and a marshaling layer between the JVM and native code. Scala
+Native removes the gap — your Scala compiles to native code already, so
+an `@extern` call is a direct call, with no bridge and no per-call
+overhead.
+
+This is not a toy capability. Uni's Scala Native HTTP client *is* a
+`libcurl` binding written exactly this way — the same `@link` / `@extern`
+/ `Zone` pattern above, in production, behind the same `Http.client` API
+you used on the JVM in [Chapter 8](./ch08-00-http). The cross-platform
+client works on Native because someone wrote this facade once; you can
+wrap any C library the same way.
+
+## What you have, what comes next
+
+You can now call C libraries from Scala Native:
+
+- An **`@extern` object** with **`@link`** and **`@name`** declares the C
+  functions you use — a facade, like Chapter 12's, but for C.
+- **C types** (`CInt`, `CString`, `Ptr`, `CStruct…`) describe the values;
+  a `CString` is not a Scala `String`.
+- **`Zone.acquire`** + **`toCString`** allocate temporary arguments with a
+  scoped lifetime; **`fromCString`** reads results back.
+
+Next, [Chapter 15](./ch15-00-exposing-native) turns the arrow around:
+instead of Scala calling C, you'll expose your Scala Native code *as* a C
+library that Rust, C, and C++ can call.
+
+[← 13. Bundling with Vite](./ch13-00-vite) | [Next → 15. Exposing Scala Native to C and Rust](./ch15-00-exposing-native)

--- a/docs/book/ch15-00-exposing-native.md
+++ b/docs/book/ch15-00-exposing-native.md
@@ -1,0 +1,181 @@
+# 15. Exposing Scala Native to C and Rust
+
+You've written something valuable in Scala — a parser, a query compiler,
+a domain calculation — and now a Rust service and a C++ application both
+want to call it. Porting it twice is the wrong answer. Instead, compile
+your Scala Native code into a **C-ABI library** and let any language that
+speaks C link against it.
+
+This is [Chapter 14](./ch14-00-calling-c) in reverse: there Scala called
+into C; here C, C++, and Rust call into Scala.
+
+## Export a function
+
+Mark a method `@exported` with the C symbol name you want, and Scala
+Native gives it a C calling convention:
+
+```scala
+import scala.scalanative.unsafe.*
+
+object MyLib:
+  @exported("greet")
+  def greet(name: CString): CString =
+    val who = fromCString(name)        // C string → Scala String
+    toCStringHeap(s"Hello, ${who}!")   // Scala String → C string (see below)
+```
+
+`fromCString` reads the incoming `char*` into a Scala `String`, the same
+helper from Chapter 14. The interesting part is the return value.
+
+## Returning data: not in a Zone
+
+In Chapter 14 you allocated temporary C strings in a `Zone`, which frees
+them when the block ends. For a value you *return to C*, that is exactly
+wrong: the `Zone` would free the string the instant `greet` returns, and
+the caller would read freed memory.
+
+A returned value has to outlive the call, so you allocate it on the heap
+with `malloc` and hand ownership across the boundary:
+
+```scala
+import scala.scalanative.unsafe.*
+import scala.scalanative.libc.stdlib
+
+private def toCStringHeap(str: String): CString =
+  val bytes  = str.getBytes("UTF-8")
+  val buffer = stdlib.malloc(bytes.length + 1).asInstanceOf[CString]
+  // copy bytes into buffer and null-terminate...
+  buffer
+```
+
+This is the one genuinely subtle rule of exporting: **arguments use a
+`Zone`, return values use the heap.** Wvlet's real C library uses exactly
+this split — `fromCString` on the way in, a `malloc`-backed `toCString` on
+the way out.
+
+## Build it as a library
+
+By default Scala Native produces an executable. A `nativeConfig` setting
+tells it to produce a library instead — dynamic (`.so` / `.dylib`) or
+static (`.a`):
+
+```scala
+import scala.scalanative.build.BuildTarget
+
+// Dynamic library: libmylib.so / libmylib.dylib
+lazy val mylib = project
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    nativeConfig ~= { _.withBuildTarget(BuildTarget.libraryDynamic) }
+  )
+
+// Static library: libmylib.a (and .withBaseName to set the lib name)
+lazy val mylibStatic = project
+  .enablePlugins(ScalaNativePlugin)
+  .settings(
+    nativeConfig ~= {
+      _.withBuildTarget(BuildTarget.libraryStatic).withBaseName("mylib")
+    }
+  )
+```
+
+`sbt mylib/nativeLink` then emits the shared library, and Scala Native
+also generates a C header declaring your exported functions.
+
+## Call it from Rust
+
+Rust links the library and declares the function in an `extern "C"`
+block:
+
+```rust
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+extern "C" {
+    fn greet(name: *const c_char) -> *const c_char;
+}
+
+fn main() {
+    let name = CString::new("Rust").unwrap();
+    unsafe {
+        let reply = greet(name.as_ptr());
+        // ... read the returned C string ...
+    }
+}
+```
+
+Compile it against the library by pointing the linker at the output
+directory and naming the lib:
+
+```bash
+$ sbt mylib/nativeLink
+$ rustc -L target/scala-3.x -lmylib test.rs -o test
+```
+
+`-L` is the search path (where `libmylib.so` lives) and `-lmylib` is the
+library — the same two flags whatever the consuming language is.
+
+## Call it from C and C++
+
+C and C++ are the same story: declare the function, link the library.
+
+```c
+// test.c
+#include <stdio.h>
+
+const char* greet(const char* name);   // declare the exported function
+
+int main() {
+    printf("%s\n", greet("C"));
+    return 0;
+}
+```
+
+```bash
+$ gcc -L target/scala-3.x -lmylib test.c -o test   # g++ for C++
+```
+
+Wvlet ships its query compiler this way: one Scala Native module exports
+`wvlet_compile_query`, builds to `libwvlet`, and its
+[test suite](https://github.com/wvlet/wvlet/tree/main/wvc-lib) links the
+same `.so` from Rust, C, *and* C++ — three languages, one implementation,
+no ports.
+
+## Why ship Scala as a native library
+
+The usual ways to share logic across languages are a network service (now
+you operate a server and pay serialization on every call) or a rewrite
+(now you maintain the same logic twice and they drift). Exporting a
+C-ABI library is neither: the consumer makes a direct in-process function
+call into your compiled Scala, and there is exactly one implementation to
+maintain.
+
+Because the contract is the C ABI — the lingua franca every systems
+language speaks — you are not committing to Rust or to C++. Anything that
+can call C can call your Scala. You write the logic once, in the language
+you prefer, and hand it to everyone else as a `.so`.
+
+## What you have, what comes next
+
+You can now ship Scala Native code to the systems world:
+
+- **`@exported("name")`** gives a method a C ABI; **`fromCString`** reads
+  arguments.
+- Return values go on the **heap** (`malloc`), never a `Zone` — the one
+  subtle rule.
+- **`BuildTarget.libraryDynamic` / `libraryStatic`** + `nativeLink`
+  produce a `.so` / `.dylib` / `.a` and a C header.
+- **`-L<dir> -l<name>`** links it from Rust, C, or C++ alike.
+
+That closes Part IX — and, with it, Uni's reach into both neighboring
+ecosystems: the JavaScript world through Scala.js
+([Part VIII](./ch12-00-npm-facades)) and the C/Rust world through Scala
+Native. One library, three runtimes, and a door into each runtime's
+native ecosystem.
+
+From here, the appendices collect supporting material:
+[Appendix A](./appendix-a-scala3) on Scala 3 syntax,
+[Appendix B](./appendix-b-airframe) on Uni and Airframe, and
+[Appendix C](./appendix-c-glossary), the glossary.
+
+[← 14. Calling C from Scala Native](./ch14-00-calling-c) | [Next → Appendix A: Scala 3 Syntax Notes](./appendix-a-scala3)

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -66,6 +66,11 @@ are, and the Book links into them when you need depth.
 - [Chapter 12: Calling NPM Modules from Scala.js](./ch12-00-npm-facades)
 - [Chapter 13: Bundling with Vite](./ch13-00-vite)
 
+### Part IX — Scala Native and the C/Rust World
+
+- [Chapter 14: Calling C from Scala Native](./ch14-00-calling-c)
+- [Chapter 15: Exposing Scala Native to C and Rust](./ch15-00-exposing-native)
+
 ### Appendices
 
 - [Appendix A: Scala 3 Syntax Notes for This Book](./appendix-a-scala3)


### PR DESCRIPTION
Adds **Part IX** to [The Uni Book](https://wvlet.org/uni/book/) — the Scala Native mirror of Part VIII (Scala.js/npm), covering native interop in **both directions**.

## Chapters

- **Ch 14 — Calling C from Scala Native** (import direction): `@extern` objects with `@link` / `@name`, the C type vocabulary (`CInt` / `CString` / `Ptr` / `CStruct…`), and `Zone`-scoped `toCString` / `fromCString` at the boundary. Grounded in **Uni's own libcurl bindings** — the Scala Native HTTP client *is* this pattern, behind the same `Http.client` API from Chapter 8.
- **Ch 15 — Exposing Scala Native to C and Rust** (export direction): `@exported` for a C ABI, the one subtle rule (**arguments in a `Zone`, return values on the heap**), building a dynamic/static library with `BuildTarget.libraryDynamic` / `libraryStatic` + `nativeLink`, and linking it from Rust, C, and C++ with `-L` / `-l`.

## Grounded in real code

- Import side verified against Uni's `CurlBindings` / `CurlChannel` (`@link("curl")`, `@extern`, `@name`, `Zone.acquire { implicit z => }`).
- Export side verified against the [`wvc-lib`](https://github.com/wvlet/wvlet/tree/main/wvc-lib) reference you pointed to: `WvcLib.scala` (`@exported`, `fromCString`, malloc-backed return), the `Makefile` (`nativeLink` → `libwvlet`, `-lwvlet`), and the real Rust/C consumers (`test.rs` `extern "C"`, `test.c`). Build targets confirmed against wvlet's `build.sbt` (`BuildTarget.libraryDynamic` / `libraryStatic`).

## Wiring

- New Part IX in the ToC and the `/book/` sidebar.
- Nav re-threaded: ch13 → 14 → 15 → appendices (ch13 closing and Appendix A `prev` updated).
- `pnpm docs:build` passes (dead-link-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)