### PR TITLE
docs(book): Move Testing into Part III (Ch4) + link cross-platform to ecosystem Parts

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -104,45 +104,40 @@ export default defineConfig<UniThemeConfig>({
           text: 'Part III — Core Concepts',
           items: [
             { text: '3. Wiring with Design', link: '/book/ch03-00-design' },
-            { text: '4. Logging That Finds You', link: '/book/ch04-00-logging' },
-            { text: '5. JSON & MessagePack', link: '/book/ch05-00-data' }
+            { text: '4. Testing with UniTest', link: '/book/ch04-00-testing' },
+            { text: '5. Logging That Finds You', link: '/book/ch05-00-logging' },
+            { text: '6. JSON & MessagePack', link: '/book/ch06-00-data' }
           ]
         },
         {
           text: 'Part IV — Async & Control Flow',
           items: [
-            { text: '6. Rx, the Composable Stream', link: '/book/ch06-00-rx' },
-            { text: '7. Retry, Circuit Breakers, Resources', link: '/book/ch07-00-control' }
+            { text: '7. Rx, the Composable Stream', link: '/book/ch07-00-rx' },
+            { text: '8. Retry, Circuit Breakers, Resources', link: '/book/ch08-00-control' }
           ]
         },
         {
           text: 'Part V — HTTP & RPC',
           items: [
-            { text: '8. HTTP Clients and Servers', link: '/book/ch08-00-http' },
-            { text: '9. Typed RPC', link: '/book/ch09-00-rpc' }
+            { text: '9. HTTP Clients and Servers', link: '/book/ch09-00-http' },
+            { text: '10. Typed RPC', link: '/book/ch10-00-rpc' }
           ]
         },
         {
           text: 'Part VI — Cross-Platform',
           items: [
-            { text: '10. One Codebase, Three Runtimes', link: '/book/ch10-00-cross-platform' }
+            { text: '11. One Codebase, Three Runtimes', link: '/book/ch11-00-cross-platform' }
           ]
         },
         {
-          text: 'Part VII — Testing',
-          items: [
-            { text: '11. Testing with UniTest', link: '/book/ch11-00-testing' }
-          ]
-        },
-        {
-          text: 'Part VIII — Scala.js & the JS Ecosystem',
+          text: 'Part VII — Scala.js & the JS Ecosystem',
           items: [
             { text: '12. Calling NPM Modules', link: '/book/ch12-00-npm-facades' },
             { text: '13. Bundling with Vite', link: '/book/ch13-00-vite' }
           ]
         },
         {
-          text: 'Part IX — Scala Native & the C/Rust World',
+          text: 'Part VIII — Scala Native & the C/Rust World',
           items: [
             { text: '14. Calling C from Scala Native', link: '/book/ch14-00-calling-c' },
             { text: '15. Exposing Scala Native to C & Rust', link: '/book/ch15-00-exposing-native' }

--- a/docs/book/appendix-a-scala3.md
+++ b/docs/book/appendix-a-scala3.md
@@ -49,7 +49,7 @@ def toJson[A](a: A)(using weaver: Weaver[A]): String = weaver.toJson(a)
 toJson(user)   // the Weaver[User] given is found and passed for you
 ```
 
-This is how [Weaver](./ch05-00-data) codecs and other typeclass-style
+This is how [Weaver](./ch06-00-data) codecs and other typeclass-style
 values travel through the code without cluttering every signature. A
 `derives` clause (`case class User(...) derives Weaver`) generates the
 `given` for you.
@@ -85,7 +85,7 @@ extension (s: String)
 ```
 
 Several Uni APIs read fluently because of extensions — the `shouldBe` in
-[Chapter 11](./ch11-00-testing)'s tests is an extension method on any
+[Chapter 4](./ch04-00-testing)'s tests is an extension method on any
 value.
 
 ## Why `new` is almost never needed

--- a/docs/book/appendix-c-glossary.md
+++ b/docs/book/appendix-c-glossary.md
@@ -11,20 +11,20 @@ a value of some type. Created with `bindSingleton`, `bindInstance`,
 **Cancelable** — The handle returned by `Rx.subscribe` / `Rx.run`. Calling
 `cancel` tears down the subscription and stops further values. Holding and
 releasing it is how `Rx` avoids leaked streams. See
-[Chapter 6](./ch06-00-rx).
+[Chapter 7](./ch07-00-rx).
 
 **Circuit breaker** — A control-flow primitive that stops calling a
 backend once its failure rate crosses a threshold, "opening" to fail fast
-until the backend recovers. See [Chapter 7](./ch07-00-control).
+until the backend recovers. See [Chapter 8](./ch08-00-control).
 
 **Codec** — A bidirectional translator between bytes (JSON or MessagePack)
 and Scala values. In Uni the codec is a [Weaver](#weaver). See
-[Chapter 5](./ch05-00-data).
+[Chapter 6](./ch06-00-data).
 
 **Cross-project** — An sbt module declared once with `crossProject` and
 compiled for the JVM, Scala.js, and Scala Native. Shared code lives in
 `src/`; platform-specific code in `.jvm` / `.js` / `.native`. See
-[Chapter 10](./ch10-00-cross-platform).
+[Chapter 11](./ch11-00-cross-platform).
 
 **Design** — An immutable description of how types are wired together —
 which implementations satisfy which dependencies, and which values live as
@@ -38,28 +38,28 @@ plain case class from `Array[String]` using `@option` and `@argument`. See
 **LogSupport** — The trait a class mixes in to get `trace` / `debug` /
 `info` / `warn` / `error` methods and a logger named after the class. Log
 messages carry their source `(file:line)`, captured at compile time. See
-[Chapter 4](./ch04-00-logging).
+[Chapter 5](./ch05-00-logging).
 
 **Resource** — A control primitive (`Resource.withResource`) that lends
 you a resource for a block and closes it on exit, on both the normal and
-exception paths — the loan pattern. See [Chapter 7](./ch07-00-control).
+exception paths — the loan pattern. See [Chapter 8](./ch08-00-control).
 
 **Retry** — A policy (`Retry.withBackOff`) that re-runs a failing
 operation with increasing delays. Safe only for idempotent operations. See
-[Chapter 7](./ch07-00-control).
+[Chapter 8](./ch08-00-control).
 
 **RPC** — Calling a remote service through a shared Scala trait, so the
 client and server are checked against one contract by the compiler. See
-[Chapter 9](./ch09-00-rpc).
+[Chapter 10](./ch10-00-rpc).
 
 **Rx** — Uni's abstraction for a value that arrives later or changes over
 time: a lazy description of zero or more values that you compose with
 `map` / `flatMap` / `filter` and consume with `subscribe`. See
-[Chapter 6](./ch06-00-rx).
+[Chapter 7](./ch07-00-rx).
 
 **RxVar** — A mutable `Rx` you can watch: created with `Rx.variable`,
 updated with `:=`, and observed by subscribers. See
-[Chapter 6](./ch06-00-rx).
+[Chapter 7](./ch07-00-rx).
 
 **Session** — The runtime context `Design.build` (or `withSession`) opens:
 it owns the singletons it constructs and runs their `onStart` / `onShutdown`
@@ -69,10 +69,10 @@ down. See [Chapter 3](./ch03-00-design).
 **Surface** — Compile-time type reflection. It captures a type's structure
 (fields, parameters, type arguments) for the codec layer to use, without
 runtime reflection — which is what lets derivation work on Scala.js and
-Native. See [Chapter 5](./ch05-00-data).
+Native. See [Chapter 6](./ch06-00-data).
 
 **Weaver** — Uni's derivation-based codec. One `Weaver[A]` serializes a
 type to JSON *or* MessagePack; you get it with `derives Weaver`. See
-[Chapter 5](./ch05-00-data).
+[Chapter 6](./ch06-00-data).
 
 [← Appendix B: Uni and Airframe](./appendix-b-airframe) | [Back to the Book](./)

--- a/docs/book/ch01-01-installation.md
+++ b/docs/book/ch01-01-installation.md
@@ -159,13 +159,13 @@ everyone shares lives at the module root under `src/main/scala` and
 > `.<platform>/src/main/scala` folders stay empty unless you reach for
 > a genuinely platform-only dependency — a JVM-only Java library, a
 > browser DOM API, a native syscall. You will see examples of that in
-> Chapter 10.
+> Chapter 11.
 
 The `%%%` operator tells sbt: *pick the version of `uni` that was built
 for whichever platform I am compiling for right now*. Your Scala source
 does not change between platforms; only the build setting does.
 
-We will build a real cross-platform codebase in Chapter 10. For now
+We will build a real cross-platform codebase in Chapter 11. For now
 know that it is one cross-plugin, one `CrossType.Pure`, and a `%%%`
 away — and that everything you write goes in `src/main/scala`.
 

--- a/docs/book/ch02-00-cli-app.md
+++ b/docs/book/ch02-00-cli-app.md
@@ -115,7 +115,7 @@ produces a client with sensible defaults: connection pooling, JSON
 content negotiation, and — importantly — a retry policy. If
 `httpbin.org` returns a 5xx or the TCP connection flakes, the client
 retries with exponential backoff before giving up. We lean on that in
-Chapter 7.
+Chapter 8.
 
 `response.status` is a typed `HttpStatus` (not a number), so you can
 pattern-match on it without digging through strings.
@@ -250,7 +250,7 @@ way.
 
 For testing `UrlFetcher` itself *without* the network, we would
 replace its HTTP client with a stand-in via a test-only `Design`. We
-will do exactly that in Chapter 11 once we have met `Design`'s
+will do exactly that in Chapter 4 once we have met `Design`'s
 override mechanism.
 
 ## What you have, what comes next

--- a/docs/book/ch03-00-design.md
+++ b/docs/book/ch03-00-design.md
@@ -190,7 +190,7 @@ testDesign.build[UserService] { users =>
 
 `UserService` does not know or care that its `Database` was replaced —
 it asked for a `Database`, and it got one. This is the override
-mechanism Chapter 11 builds on to test services without their real
+mechanism Chapter 4 builds on to test services without their real
 dependencies. See [Testing with Design](/core/design#testing) for the
 patterns.
 
@@ -207,8 +207,8 @@ You can now read and write a `Design`:
 - **`+`** overrides a design, which is how tests swap real dependencies
   for fakes.
 
-Next, [Chapter 4](./ch04-00-logging) adds the first thing every one of
-these services wants — logging that tells you not just *what* happened
-but *where*.
+Next, [Chapter 4](./ch04-00-testing) puts that override seam to work
+immediately: now that you can wire a program, you can *test* it — swapping
+a real dependency for a fake without touching the code under test.
 
-[← 2. A URL Fetcher](./ch02-00-cli-app) | [Next → 4. Logging That Finds You](./ch04-00-logging)
+[← 2. A URL Fetcher](./ch02-00-cli-app) | [Next → 4. Testing with UniTest](./ch04-00-testing)

--- a/docs/book/ch04-00-testing.md
+++ b/docs/book/ch04-00-testing.md
@@ -1,4 +1,4 @@
-# 11. Testing with UniTest
+# 4. Testing with UniTest
 
 A service under test needs a database, a payment gateway, and the current
 time. The reflex is to mock all three. Uni pushes you the other way: run
@@ -86,7 +86,7 @@ from one. The tool you need is `Design` override, which you already have.
 
 Because `UniTest` is itself cross-platform, a test you write once runs
 under the JVM, Scala.js, and Scala Native — the same `sbt test` story as
-[Chapter 10](./ch10-00-cross-platform), now for your tests. A suite over
+[Chapter 11](./ch11-00-cross-platform), now for your tests. A suite over
 shared logic verifies all three builds at once, so "compiles on Native"
 becomes "*passes* on Native" without a second test to write.
 
@@ -111,15 +111,14 @@ You can now test a Uni application the way it's meant to be tested:
 - One suite runs on **all three platforms**, and stays **fast** because
   it's in-process.
 
-That completes the book's core path. You have built, wired, logged,
-serialized, reacted, recovered, served, connected, ported, and tested a
-Uni application — the full arc from `Design.build` to a green test suite
-on three runtimes.
+Testing comes this early in the book on purpose. With `Design` from
+[Chapter 3](./ch03-00-design) in one hand and `UniTest` in the other, you
+can now *prove* a service works — before you've even met logging. Every
+feature the rest of the book introduces is something you can immediately
+write a fast, dependency-free test for.
 
-Next, [Part VIII](./ch12-00-npm-facades) follows the Scala.js thread out
-into the wider JavaScript world: calling npm packages from Scala through
-small hand-written facades, and bundling the result with Vite. After that,
-the appendices collect supporting material — Scala 3 syntax, the Airframe
-relationship, and a glossary.
+Next, [Chapter 5](./ch05-00-logging) adds the other thing every service
+wants from the start: logging that tells you not just *what* happened but
+*where*.
 
-[← 10. One Codebase, Three Runtimes](./ch10-00-cross-platform) | [Next → 12. Calling NPM Modules](./ch12-00-npm-facades)
+[← 3. Wiring with Design](./ch03-00-design) | [Next → 5. Logging That Finds You](./ch05-00-logging)

--- a/docs/book/ch05-00-logging.md
+++ b/docs/book/ch05-00-logging.md
@@ -1,4 +1,4 @@
-# 4. Logging That Finds You
+# 5. Logging That Finds You
 
 A log line that reads `save failed` is almost useless if your codebase
 has twenty `save` methods. The first question you ask is always the same:
@@ -136,8 +136,8 @@ Logging is now a one-line, zero-ceremony tool:
 - Logs are **human context** by design; `error(msg, e)` keeps the cause
   attached.
 
-Next, [Chapter 5](./ch05-00-data) turns to data crossing your program's
+Next, [Chapter 6](./ch06-00-data) turns to data crossing your program's
 edges — parsing JSON, writing MessagePack, and deriving both from your
 case classes with one line.
 
-[← 3. Wiring with Design](./ch03-00-design) | [Next → 5. Data In, Data Out](./ch05-00-data)
+[← 4. Testing with UniTest](./ch04-00-testing) | [Next → 6. Data In, Data Out](./ch06-00-data)

--- a/docs/book/ch06-00-data.md
+++ b/docs/book/ch06-00-data.md
@@ -1,4 +1,4 @@
-# 5. Data In, Data Out — JSON & MessagePack
+# 6. Data In, Data Out — JSON & MessagePack
 
 Every service eats and produces data. A request arrives as a JSON body;
 a cache stores a MessagePack frame; a config file is a blob of text. This
@@ -104,7 +104,7 @@ the two formats cannot drift apart, because they are the same `Weaver`.
 That is what lets the identical codec run on the JVM, in the browser
 (Scala.js), and as a native binary. A reflection-based serializer would
 not survive the trip to Scala.js or Native; a derived one does. We return
-to this theme in [Chapter 10](./ch10-00-cross-platform).
+to this theme in [Chapter 11](./ch11-00-cross-platform).
 :::
 
 ## What you have, what comes next
@@ -120,8 +120,8 @@ You can now move data across your program's edges:
 - Derivation is compile-time, so the codec is cross-platform.
 
 That closes Part III: you can wire a program ([Design](./ch03-00-design)),
-see what it does ([Logging](./ch04-00-logging)), and move data through it.
-Next, [Part IV](./ch06-00-rx) makes those services *react* — `Rx`, Uni's
+see what it does ([Logging](./ch05-00-logging)), and move data through it.
+Next, [Part IV](./ch07-00-rx) makes those services *react* — `Rx`, Uni's
 composable stream, for values that change over time.
 
-[← 4. Logging That Finds You](./ch04-00-logging) | [Next → 6. Rx, the Composable Stream](./ch06-00-rx)
+[← 5. Logging That Finds You](./ch05-00-logging) | [Next → 7. Rx, the Composable Stream](./ch07-00-rx)

--- a/docs/book/ch07-00-rx.md
+++ b/docs/book/ch07-00-rx.md
@@ -1,4 +1,4 @@
-# 6. Rx, the Composable Stream
+# 7. Rx, the Composable Stream
 
 Two things in your program refuse to sit still. An async HTTP call does
 not return a `Response` — it returns one *later*. A configuration value
@@ -149,8 +149,8 @@ with one tool:
 - The **async HTTP client** returns `Rx[HttpResponse]`, so async and
   reactive code share one model.
 
-Next, [Chapter 7](./ch07-00-control) is about what happens when those
+Next, [Chapter 8](./ch08-00-control) is about what happens when those
 calls *fail* — retries, circuit breakers, and resource lifetimes that
 clean up after themselves.
 
-[← 5. Data In, Data Out](./ch05-00-data) | [Next → 7. Living With Failure](./ch07-00-control)
+[← 6. Data In, Data Out](./ch06-00-data) | [Next → 8. Living With Failure](./ch08-00-control)

--- a/docs/book/ch08-00-control.md
+++ b/docs/book/ch08-00-control.md
@@ -1,4 +1,4 @@
-# 7. Living With Failure — Retry, Circuit Breakers, Resources
+# 8. Living With Failure — Retry, Circuit Breakers, Resources
 
 A call across a network will fail. Not *if* — *when*. The interesting
 question is what you do about it, and there are three different answers
@@ -149,9 +149,9 @@ You can now write code that survives the network:
 - **`Resource.withResource(r) { }`** closes resources on every path, the
   block-scoped cousin of `Design`'s `onShutdown`.
 
-That closes Part IV: your services can react ([Rx](./ch06-00-rx)) and
-recover (this chapter). Next, [Part V](./ch08-00-http) puts them on the
+That closes Part IV: your services can react ([Rx](./ch07-00-rx)) and
+recover (this chapter). Next, [Part V](./ch09-00-http) puts them on the
 network for real — building HTTP clients and servers, then typed RPC on
 top.
 
-[← 6. Rx, the Composable Stream](./ch06-00-rx) | [Next → 8. HTTP Clients and Servers](./ch08-00-http)
+[← 7. Rx, the Composable Stream](./ch07-00-rx) | [Next → 9. HTTP Clients and Servers](./ch09-00-http)

--- a/docs/book/ch09-00-http.md
+++ b/docs/book/ch09-00-http.md
@@ -1,4 +1,4 @@
-# 8. HTTP Clients and Servers
+# 9. HTTP Clients and Servers
 
 Chapter 2 made a single HTTP call to get a CLI tool working. This chapter
 takes HTTP seriously from both sides: the **client** that calls out, and
@@ -32,7 +32,7 @@ concurrency.
 ## The client, asynchronously
 
 The async client returns the value-over-time version of the response — an
-`Rx[HttpResponse]`, exactly the shape from [Chapter 6](./ch06-00-rx):
+`Rx[HttpResponse]`, exactly the shape from [Chapter 7](./ch07-00-rx):
 
 ```scala
 import wvlet.uni.http.{Http, Request}
@@ -50,7 +50,7 @@ instead of blocking. The same operators you learned for streams work
 here — async HTTP is not a separate world.
 
 Both clients come configured with sensible defaults, including the retry
-policy from [Chapter 7](./ch07-00-control). Tune them with `withXxx`
+policy from [Chapter 8](./ch08-00-control). Tune them with `withXxx`
 setters before creating the client:
 
 ```scala
@@ -114,7 +114,7 @@ NettyServer
 `Router.of[UserController]` reads the annotations at compile time and
 builds the route table; path parameters like `:id` bind to method
 parameters by name, and a returned `Seq` or case class is serialized to
-JSON for you (via the [Weaver](./ch05-00-data) machinery from Chapter 5).
+JSON for you (via the [Weaver](./ch06-00-data) machinery from Chapter 6).
 The [server reference](/http/server) covers query parameters, filters,
 and combining controllers.
 
@@ -132,7 +132,7 @@ the JVM, in the browser and Node.js (Scala.js), and as a native binary —
 because `Http.client` resolves to the right transport for each runtime
 (`java.net.http`, the Fetch API, or libcurl). You write the request once.
 The one constraint worth knowing: browsers have no synchronous HTTP, so
-in browser code use `newAsyncClient`. [Chapter 10](./ch10-00-cross-platform)
+in browser code use `newAsyncClient`. [Chapter 11](./ch11-00-cross-platform)
 is about this property in general; the [client reference](/http/client)
 has the per-platform backend table.
 
@@ -149,8 +149,8 @@ You can now build both ends of an HTTP exchange:
   **annotation router** (`@Endpoint` + `Router.of`, JVM).
 - The same client source runs on JVM, Scala.js, and Native.
 
-Next, [Chapter 9](./ch09-00-rpc) removes the hand-written URLs and JSON
+Next, [Chapter 10](./ch10-00-rpc) removes the hand-written URLs and JSON
 entirely: define a trait once and get a typed client and server that
 speak it.
 
-[← 7. Living With Failure](./ch07-00-control) | [Next → 9. Typed RPC](./ch09-00-rpc)
+[← 8. Living With Failure](./ch08-00-control) | [Next → 10. Typed RPC](./ch10-00-rpc)

--- a/docs/book/ch10-00-cross-platform.md
+++ b/docs/book/ch10-00-cross-platform.md
@@ -100,6 +100,25 @@ only exists on one platform, keep the code that uses it in that platform's
 folder.
 :::
 
+## Reaching into a platform's ecosystem
+
+A platform folder isn't only for the JDK or a syscall — it's the door to
+that runtime's whole *foreign* ecosystem. The `.js` folder is where you
+call JavaScript packages from npm; the `.native` folder is where you call
+C, C++, and Rust. Both use the same idea as the `Clock` above — a typed
+Scala declaration of the foreign code you use, kept in the platform folder
+that has it — and each gets a dedicated Part later in this book:
+
+- **[Part VIII](./ch12-00-npm-facades)** — wiring Scala.js to npm modules
+  with hand-written facades, bundled by Vite.
+- **[Part IX](./ch14-00-calling-c)** — calling C libraries from Scala
+  Native, and exposing your Scala Native code *as* a library that C, C++,
+  and Rust can call.
+
+So the shared folder holds your portable logic, and each platform folder
+can reach as deep into that platform's native world as you need — without
+either concern leaking into the other.
+
 ## What you have, what comes next
 
 You can now ship one codebase to three runtimes:
@@ -113,8 +132,11 @@ You can now ship one codebase to three runtimes:
 - Unshareable primitives hide behind a **shared interface with a
   per-platform implementation**, and missing platforms fail at compile
   time.
+- Each platform folder is also the door to that runtime's ecosystem — npm
+  ([Part VIII](./ch12-00-npm-facades)) from `.js`, C/Rust
+  ([Part IX](./ch14-00-calling-c)) from `.native`.
 
-Next, the final chapter, [Chapter 11](./ch11-00-testing), tests all of
-this — and the same suite runs on all three runtimes.
+Next, [Chapter 11](./ch11-00-testing) tests all of this — and the same
+suite runs on all three runtimes.
 
 [← 9. Typed RPC](./ch09-00-rpc) | [Next → 11. Testing with UniTest](./ch11-00-testing)

--- a/docs/book/ch10-00-rpc.md
+++ b/docs/book/ch10-00-rpc.md
@@ -1,6 +1,6 @@
-# 9. Typed RPC
+# 10. Typed RPC
 
-In Chapter 8 both ends of the call wrote out the contract by hand: the
+In Chapter 9 both ends of the call wrote out the contract by hand: the
 server picked the path `/users/:id` and shaped the JSON; the client typed
 the same path and parsed the same JSON back. Nothing connects those two
 copies. Rename a field on the server and the client keeps compiling — and
@@ -82,8 +82,8 @@ error.
 
 ## What crosses the wire
 
-Arguments and return values are serialized with [Weaver](./ch05-00-data),
-the same derivation you met in Chapter 5 — which is why `User` has
+Arguments and return values are serialized with [Weaver](./ch06-00-data),
+the same derivation you met in Chapter 6 — which is why `User` has
 `derives Weaver`. Over the wire RPC uses MessagePack by default: it is
 compact and fast, and since both ends were generated from one trait,
 there is no human reading the bytes who would prefer JSON. The encoding
@@ -104,7 +104,7 @@ trait is a feature: it keeps them in lockstep.
 It is the *wrong* tool when the other end is not yours to recompile. A
 public API consumed by third parties, a webhook, anything that must speak
 a stable, language-neutral contract — that wants plain
-[HTTP/REST](./ch08-00-http), where the wire format *is* the interface and
+[HTTP/REST](./ch09-00-http), where the wire format *is* the interface and
 no client needs your trait. Use RPC inside your system; use REST at its
 public edge.
 
@@ -120,9 +120,9 @@ You can now connect two services without hand-written glue:
   **`RPCStatus`**.
 - Reach for RPC when you own both ends, REST at the public edge.
 
-That closes Part V. Next, [Part VI](./ch10-00-cross-platform) steps back
+That closes Part V. Next, [Part VI](./ch11-00-cross-platform) steps back
 to the property that has been quietly true this whole time: nearly
 everything you've written runs on three different runtimes from one
 codebase.
 
-[← 8. HTTP Clients and Servers](./ch08-00-http) | [Next → 10. One Codebase, Three Runtimes](./ch10-00-cross-platform)
+[← 9. HTTP Clients and Servers](./ch09-00-http) | [Next → 11. One Codebase, Three Runtimes](./ch11-00-cross-platform)

--- a/docs/book/ch11-00-cross-platform.md
+++ b/docs/book/ch11-00-cross-platform.md
@@ -1,4 +1,4 @@
-# 10. One Codebase, Three Runtimes
+# 11. One Codebase, Three Runtimes
 
 Here is something that has been quietly true for the whole book: almost
 every snippet you've written — `Design`, `Rx`, `Weaver`, the HTTP client —
@@ -53,7 +53,7 @@ platform-specific pieces behind cross-platform APIs:
 - File I/O goes through the [FileSystem](/core/filesystem) abstraction
   (`IOPath`), not `java.nio.file.Path` — so reading a file is the same
   call everywhere.
-- The [HTTP client](./ch08-00-http) resolves to `java.net.http`, the
+- The [HTTP client](./ch09-00-http) resolves to `java.net.http`, the
   Fetch API, or libcurl depending on the runtime, behind one
   `Http.client`.
 - `Rx`, `Design`, and `Weaver` are pure Scala with no platform
@@ -109,9 +109,9 @@ C, C++, and Rust. Both use the same idea as the `Clock` above — a typed
 Scala declaration of the foreign code you use, kept in the platform folder
 that has it — and each gets a dedicated Part later in this book:
 
-- **[Part VIII](./ch12-00-npm-facades)** — wiring Scala.js to npm modules
+- **[Part VII](./ch12-00-npm-facades)** — wiring Scala.js to npm modules
   with hand-written facades, bundled by Vite.
-- **[Part IX](./ch14-00-calling-c)** — calling C libraries from Scala
+- **[Part VIII](./ch14-00-calling-c)** — calling C libraries from Scala
   Native, and exposing your Scala Native code *as* a library that C, C++,
   and Rust can call.
 
@@ -133,10 +133,12 @@ You can now ship one codebase to three runtimes:
   per-platform implementation**, and missing platforms fail at compile
   time.
 - Each platform folder is also the door to that runtime's ecosystem — npm
-  ([Part VIII](./ch12-00-npm-facades)) from `.js`, C/Rust
-  ([Part IX](./ch14-00-calling-c)) from `.native`.
+  ([Part VII](./ch12-00-npm-facades)) from `.js`, C/Rust
+  ([Part VIII](./ch14-00-calling-c)) from `.native`.
 
-Next, [Chapter 11](./ch11-00-testing) tests all of this — and the same
-suite runs on all three runtimes.
+Next, [Part VII](./ch12-00-npm-facades) follows the Scala.js side of this
+story out into the JavaScript ecosystem — calling npm packages from Scala
+— and [Part VIII](./ch14-00-calling-c) does the same for Scala Native and
+the C/Rust world.
 
-[← 9. Typed RPC](./ch09-00-rpc) | [Next → 11. Testing with UniTest](./ch11-00-testing)
+[← 10. Typed RPC](./ch10-00-rpc) | [Next → 12. Calling NPM Modules from Scala.js](./ch12-00-npm-facades)

--- a/docs/book/ch12-00-npm-facades.md
+++ b/docs/book/ch12-00-npm-facades.md
@@ -1,6 +1,6 @@
 # 12. Calling NPM Modules from Scala.js
 
-You're building a browser app with Uni ([Chapter 10](./ch10-00-cross-platform)),
+You're building a browser app with Uni ([Chapter 11](./ch11-00-cross-platform)),
 and you need something the JavaScript world already solved: a Markdown
 renderer, a charting library, a date picker. It's on npm, written in
 JavaScript, with no Scala types. How do you call it from Scala 3 without
@@ -137,4 +137,4 @@ nothing has *installed* `marked` or resolved that import for the browser.
 That is the bundler's job. Next, [Chapter 13](./ch13-00-vite) wires it all
 together with Vite.
 
-[← 11. Testing with UniTest](./ch11-00-testing) | [Next → 13. Bundling with Vite](./ch13-00-vite)
+[← 11. One Codebase, Three Runtimes](./ch11-00-cross-platform) | [Next → 13. Bundling with Vite](./ch13-00-vite)

--- a/docs/book/ch13-00-vite.md
+++ b/docs/book/ch13-00-vite.md
@@ -163,11 +163,11 @@ You can now ship a Scala.js app that uses the npm ecosystem:
 - **`@JSGlobal` + `window`** bridges stubborn modules, and
   **`resolve.alias`** swaps out browser-hostile dependencies.
 
-That completes Part VIII — Scala.js is now a full participant in the
+That completes Part VII — Scala.js is now a full participant in the
 JavaScript ecosystem, with types on your side of the boundary and npm on
 the other.
 
-Next, [Part IX](./ch14-00-calling-c) does the mirror image for the other
+Next, [Part VIII](./ch14-00-calling-c) does the mirror image for the other
 end of the platform spectrum: Scala Native and the C/Rust world — calling
 C libraries from Scala, and exposing your Scala as a library that C, C++,
 and Rust can call.

--- a/docs/book/ch14-00-calling-c.md
+++ b/docs/book/ch14-00-calling-c.md
@@ -1,6 +1,6 @@
 # 14. Calling C from Scala Native
 
-Compile a Uni app with Scala Native ([Chapter 10](./ch10-00-cross-platform))
+Compile a Uni app with Scala Native ([Chapter 11](./ch11-00-cross-platform))
 and you get a real native binary — and with it, direct access to the
 entire C ecosystem: `libcurl`, `sqlite`, `openssl`, anything with a C
 ABI. No JNI, no subprocess, no serialization across a boundary. You call
@@ -107,7 +107,7 @@ overhead.
 This is not a toy capability. Uni's Scala Native HTTP client *is* a
 `libcurl` binding written exactly this way — the same `@link` / `@extern`
 / `Zone` pattern above, in production, behind the same `Http.client` API
-you used on the JVM in [Chapter 8](./ch08-00-http). The cross-platform
+you used on the JVM in [Chapter 9](./ch09-00-http). The cross-platform
 client works on Native because someone wrote this facade once; you can
 wrap any C library the same way.
 

--- a/docs/book/ch15-00-exposing-native.md
+++ b/docs/book/ch15-00-exposing-native.md
@@ -167,9 +167,9 @@ You can now ship Scala Native code to the systems world:
   produce a `.so` / `.dylib` / `.a` and a C header.
 - **`-L<dir> -l<name>`** links it from Rust, C, or C++ alike.
 
-That closes Part IX — and, with it, Uni's reach into both neighboring
+That closes Part VIII — and, with it, Uni's reach into both neighboring
 ecosystems: the JavaScript world through Scala.js
-([Part VIII](./ch12-00-npm-facades)) and the C/Rust world through Scala
+([Part VII](./ch12-00-npm-facades)) and the C/Rust world through Scala
 Native. One library, three runtimes, and a door into each runtime's
 native ecosystem.
 

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -40,33 +40,30 @@ are, and the Book links into them when you need depth.
 ### Part III — Core Concepts
 
 - [Chapter 3: Wiring with Design](./ch03-00-design)
-- [Chapter 4: Logging That Finds You](./ch04-00-logging)
-- [Chapter 5: Data In, Data Out — JSON & MessagePack](./ch05-00-data)
+- [Chapter 4: Testing with UniTest](./ch04-00-testing)
+- [Chapter 5: Logging That Finds You](./ch05-00-logging)
+- [Chapter 6: Data In, Data Out — JSON & MessagePack](./ch06-00-data)
 
 ### Part IV — Async & Control Flow
 
-- [Chapter 6: Rx, the Composable Stream](./ch06-00-rx)
-- [Chapter 7: Living With Failure — Retry, Circuit Breakers, Resources](./ch07-00-control)
+- [Chapter 7: Rx, the Composable Stream](./ch07-00-rx)
+- [Chapter 8: Living With Failure — Retry, Circuit Breakers, Resources](./ch08-00-control)
 
 ### Part V — HTTP & RPC
 
-- [Chapter 8: HTTP Clients and Servers](./ch08-00-http)
-- [Chapter 9: Typed RPC](./ch09-00-rpc)
+- [Chapter 9: HTTP Clients and Servers](./ch09-00-http)
+- [Chapter 10: Typed RPC](./ch10-00-rpc)
 
 ### Part VI — Cross-Platform Development
 
-- [Chapter 10: One Codebase, Three Runtimes](./ch10-00-cross-platform)
+- [Chapter 11: One Codebase, Three Runtimes](./ch11-00-cross-platform)
 
-### Part VII — Testing
-
-- [Chapter 11: Testing with UniTest](./ch11-00-testing)
-
-### Part VIII — Scala.js in the JavaScript Ecosystem
+### Part VII — Scala.js in the JavaScript Ecosystem
 
 - [Chapter 12: Calling NPM Modules from Scala.js](./ch12-00-npm-facades)
 - [Chapter 13: Bundling with Vite](./ch13-00-vite)
 
-### Part IX — Scala Native and the C/Rust World
+### Part VIII — Scala Native and the C/Rust World
 
 - [Chapter 14: Calling C from Scala Native](./ch14-00-calling-c)
 - [Chapter 15: Exposing Scala Native to C and Rust](./ch15-00-exposing-native)


### PR DESCRIPTION
Reorganizes [The Uni Book](https://wvlet.org/uni/book/) so **UniTest comes early**, where a reader can actually use it, instead of at Chapter 11 (Part VII of IX).

## The move

Testing becomes **Chapter 4**, right after Design — so Part III now reads *"wire it (Design 3), prove it (Testing 4), observe it (Logging 5), move data through it (Data 6)."* Testing's core lesson is `Design` override, so the Design→Testing adjacency is natural.

Everything from old Chapter 6 onward shifts up by one:

| Was | Now |
|-----|-----|
| 11 Testing | **4** |
| 4 Logging → 5 · 5 Data → 6 · 6 Rx → 7 · 7 Control → 8 | 5 · 6 · 7 · 8 |
| 8 HTTP → 9 · 9 RPC → 10 · 10 Cross-platform → 11 | 9 · 10 · 11 |
| 12–15 (ecosystem chapters) | unchanged |

Parts: Testing folds into **Part III**; the ecosystem Parts renumber to **VII** (Scala.js) and **VIII** (Scala Native).

## What was updated

- File renames via `git mv` (history preserved).
- Every nav footer (the chain now reads cleanly 3 → 15 → appendices), every inline `Chapter N` / `Part N` cross-reference, the ToC, and the `/book/` sidebar.
- Rewrote the recaps whose role changed: **Design** now points forward to Testing; **Testing** is no longer the book's finale (it hands off to Logging and notes *why* it's early); **Cross-platform** now leads into Part VII.
- Folds in the earlier change linking the cross-platform chapter to the npm / C-Rust ecosystem Parts (**supersedes #597**, which I'll close).

`pnpm docs:build` passes (dead-link-clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)