### PR TITLE
feature: Add uniRestart background fork-run to sbt-uni for sbt 2.x

### DIFF
--- a/sbt-uni/src/main/scala/wvlet/uni/sbt/ReStart.scala
+++ b/sbt-uni/src/main/scala/wvlet/uni/sbt/ReStart.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.sbt
+
+import sbt.*
+import sbt.util.{Level, Logger}
+import sbt.internal.util.complete.DefaultParsers.*
+import sbt.internal.util.complete.Parser
+
+import java.io.File
+import java.util.concurrent.atomic.AtomicReference
+import scala.annotation.tailrec
+import scala.collection.immutable.Queue
+import scala.sys.process.Process
+
+/**
+  * Background-process support for `reStart`, ported from sbt-revolver's `reStart`/`reStop` commands
+  * so that sbt 2.x users can fork-run an application without depending on io.spray:sbt-revolver
+  * (which has not been published for sbt 2.x).
+  *
+  * The forked JVM is tracked in a process-global [[GlobalState]] (an `AtomicReference`) rather than
+  * in sbt's `State`, so a running app survives task re-invocations and can be stopped later.
+  */
+
+/**
+  * A handle to an application running in a forked JVM. Watches the process for termination and
+  * installs a JVM shutdown hook so the child is killed if sbt itself exits.
+  */
+final case class AppProcess(projectRef: ProjectRef, consoleColor: String, log: Logger)(
+    process: Process
+):
+  @volatile
+  private var finishState: Option[Int] = None
+
+  private val shutdownHook = Thread(() =>
+    if isRunning then
+      log.info("... killing ...")
+      process.destroy()
+  )
+
+  private val watchThread =
+    val t = Thread(() =>
+      val code = process.exitValue()
+      finishState = Some(code)
+      log.info(s"... finished with exit code ${code}")
+      unregisterShutdownHook()
+      val _ = GlobalState.update(_.removeProcessAndColor(projectRef))
+    )
+    t.setDaemon(true)
+    t.start()
+    t
+
+  registerShutdownHook()
+
+  def projectName: String = projectRef.project
+  def isRunning: Boolean  = finishState.isEmpty
+
+  def stop(): Unit =
+    unregisterShutdownHook()
+    process.destroy()
+    process.exitValue()
+
+  private def registerShutdownHook(): Unit = java
+    .lang
+    .Runtime
+    .getRuntime
+    .addShutdownHook(shutdownHook)
+
+  private def unregisterShutdownHook(): Unit =
+    try
+      java.lang.Runtime.getRuntime.removeShutdownHook(shutdownHook)
+    catch
+      case _: IllegalStateException =>
+        () // JVM is already shutting down
+
+end AppProcess
+
+/**
+  * Immutable snapshot of all running [[AppProcess]]es plus a pool of console colors handed out to
+  * background apps so their interleaved output stays distinguishable.
+  */
+case class ReStartState(
+    processes: Map[ProjectRef, AppProcess],
+    colorPool: Queue[String],
+    seeded: Boolean
+):
+  def addProcess(project: ProjectRef, process: AppProcess): ReStartState = copy(processes =
+    processes + (project -> process)
+  )
+
+  private def removeProcess(project: ProjectRef): ReStartState = copy(processes =
+    processes - project
+  )
+
+  def removeProcessAndColor(project: ProjectRef): ReStartState =
+    getProcess(project) match
+      case Some(p) =>
+        removeProcess(project).offerColor(p.consoleColor)
+      case None =>
+        this
+
+  def runningProjects: Seq[ProjectRef]                    = processes.keys.toSeq
+  def getProcess(project: ProjectRef): Option[AppProcess] = processes.get(project)
+
+  /** Seed the color pool once from the configured color names (formatted as `[NAME]` tags). */
+  def ensureColors(colors: Seq[String]): ReStartState =
+    if seeded then
+      this
+    else
+      copy(colorPool = Queue(colors.map(c => s"[${c.toUpperCase}]")*), seeded = true)
+
+  def takeColor: (ReStartState, String) =
+    colorPool.dequeueOption match
+      case Some((color, rest)) =>
+        (copy(colorPool = rest), color)
+      case None =>
+        (this, "")
+
+  def offerColor(color: String): ReStartState =
+    if color.nonEmpty then
+      copy(colorPool = colorPool.enqueue(color))
+    else
+      this
+
+end ReStartState
+
+object ReStartState:
+  def initial: ReStartState = ReStartState(Map.empty, Queue.empty, seeded = false)
+
+/**
+  * Process-global, lock-free holder of [[ReStartState]]. Not a full STM, so callers must fold all
+  * dependent reads/writes into a single `update`/`updateAndGet` to avoid lost updates.
+  */
+object GlobalState:
+  private val state = AtomicReference(ReStartState.initial)
+
+  @tailrec
+  def update(f: ReStartState => ReStartState): ReStartState =
+    val orig = state.get()
+    val next = f(orig)
+    if !state.compareAndSet(orig, next) then
+      update(f)
+    else
+      next
+
+  @tailrec
+  def updateAndGet[T](f: ReStartState => (ReStartState, T)): T =
+    val orig          = state.get()
+    val (next, value) = f(orig)
+    if !state.compareAndSet(orig, next) then
+      updateAndGet(f)
+    else
+      value
+
+  def get(): ReStartState = state.get()
+
+/**
+  * Minimal ANSI color support. Messages embed `[NAME]` tags (e.g. `[YELLOW]`, `[RESET]`) which are
+  * either expanded to ANSI escape codes or stripped, depending on whether the terminal supports
+  * color. Ported from sbt-revolver's Utilities/SysoutLogger.
+  */
+object ReStartColors:
+  import scala.Console.*
+
+  private val simple: Seq[(String, String)] = Seq(
+    "RED"     -> RED,
+    "GREEN"   -> GREEN,
+    "YELLOW"  -> YELLOW,
+    "BLUE"    -> BLUE,
+    "MAGENTA" -> MAGENTA,
+    "CYAN"    -> CYAN,
+    "WHITE"   -> WHITE
+  )
+
+  private def underlined(c: (String, String)): (String, String) = (s"_${c._1}", c._2 + UNDERLINED)
+
+  private val mapping: Seq[(String, String)] =
+    (Seq("BOLD" -> BOLD, "RESET" -> RESET) ++ simple ++ simple.map(underlined)).map((name, code) =>
+      (s"[${name}]", code)
+    )
+
+  def basicColors: Seq[String]              = Seq("BLUE", "MAGENTA", "CYAN", "YELLOW", "GREEN")
+  def basicColorsAndUnderlined: Seq[String] = basicColors ++ basicColors.map("_" + _)
+
+  def colorize(ansi: Boolean, message: String): String =
+    mapping.foldLeft(message)((m, kv) =>
+      m.replace(
+        kv._1,
+        if ansi then
+          kv._2
+        else
+          ""
+      )
+    )
+
+  /** Wrap a logger so that `[NAME]` color tags in messages are expanded/stripped on the way out. */
+  def colorLogger(base: Logger, ansi: Boolean): Logger =
+    new Logger:
+      def trace(t: => Throwable): Unit                      = base.trace(t)
+      def success(message: => String): Unit                 = base.success(message)
+      def log(level: Level.Value, message: => String): Unit = base.log(
+        level,
+        colorize(ansi, message)
+      )
+
+end ReStartColors
+
+/**
+  * A logger that prints directly with `println`, used to tag the forked app's stdout/stderr with a
+  * per-app colored prefix. Used where no task `streams` logger is available (inside the watch
+  * thread / fork output strategy).
+  */
+class SysoutLogger(appName: String, color: String, ansi: Boolean) extends Logger:
+  def trace(t: => Throwable): Unit = t.printStackTrace()
+
+  def success(message: => String): Unit = println(
+    ReStartColors.colorize(ansi, s"${color}${appName}[RESET] success: ") + message
+  )
+
+  def log(level: Level.Value, message: => String): Unit =
+    val levelStr =
+      level match
+        case Level.Error =>
+          "[ERROR]"
+        case Level.Warn =>
+          "[WARN]"
+        case _ =>
+          ""
+    println(ReStartColors.colorize(ansi, s"${color}${appName}[RESET]${levelStr} ") + message)
+
+end SysoutLogger

--- a/sbt-uni/src/main/scala/wvlet/uni/sbt/ReStartActions.scala
+++ b/sbt-uni/src/main/scala/wvlet/uni/sbt/ReStartActions.scala
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.sbt
+
+import sbt.*
+import sbt.util.Logger
+import sbt.internal.util.complete.DefaultParsers.*
+import sbt.internal.util.complete.Parser
+
+import java.io.File
+import scala.sys.process.Process
+
+/**
+  * The forking actions behind the `reStart`/`reStop`/`reStatus` tasks. Kept free of sbt task
+  * plumbing so they are easy to read and test; [[UniPlugin]] wires sbt keys to these functions.
+  */
+object ReStartActions:
+
+  /**
+    * Extra command-line arguments parsed from the `reStart` input: app args and (after `---`) JVM
+    * args.
+    */
+  final case class ExtraArgs(jvmArgs: Seq[String], appArgs: Seq[String])
+
+  /**
+    * Parser for `reStart <appArg>* [--- <jvmArg>*]`. Everything before a literal `---` token is
+    * passed to the application; everything after it becomes extra JVM options for the forked JVM.
+    */
+  val startArgsParser: Parser[ExtraArgs] = spaceDelimited("<args> [--- <jvm-args>]").map { args =>
+    args.indexOf("---") match
+      case -1 =>
+        ExtraArgs(jvmArgs = Nil, appArgs = args)
+      case idx =>
+        ExtraArgs(jvmArgs = args.drop(idx + 1), appArgs = args.take(idx))
+  }
+
+  def restartApp(
+      log: Logger,
+      ansi: Boolean,
+      logTag: String,
+      project: ProjectRef,
+      options: ForkOptions,
+      mainClass: Option[String],
+      classpath: Seq[File],
+      defaultArgs: Seq[String],
+      colors: Seq[String],
+      extra: ExtraArgs
+  ): Unit =
+    stopApp(log, ansi, project)
+    startApp(log, ansi, logTag, project, options, mainClass, classpath, defaultArgs, colors, extra)
+
+  def startApp(
+      log: Logger,
+      ansi: Boolean,
+      logTag: String,
+      project: ProjectRef,
+      options: ForkOptions,
+      mainClass: Option[String],
+      classpath: Seq[File],
+      defaultArgs: Seq[String],
+      colors: Seq[String],
+      extra: ExtraArgs
+  ): Unit =
+    val theMainClass = mainClass.getOrElse(
+      sys.error("No main class detected. Set `uniRestart / mainClass := Some(\"...\")`.")
+    )
+    // Seed the color pool from the configured names on first use, then hand out one color.
+    val color  = GlobalState.updateAndGet(_.ensureColors(colors).takeColor)
+    val logger = SysoutLogger(logTag, color, ansi)
+    ReStartColors
+      .colorLogger(log, ansi)
+      .info(
+        s"[YELLOW]Starting application ${formatAppName(
+            project.project,
+            color
+          )} in the background ..."
+      )
+
+    val appProcess =
+      AppProcess(project, color, logger) {
+        forkRun(
+          options,
+          theMainClass,
+          classpath,
+          defaultArgs ++ extra.appArgs,
+          logger,
+          extra.jvmArgs
+        )
+      }
+    registerAppProcess(project, appProcess)
+
+  end startApp
+
+  def stopApp(log: Logger, ansi: Boolean, project: ProjectRef): Unit =
+    val clog = ReStartColors.colorLogger(log, ansi)
+    GlobalState.get().getProcess(project) match
+      case Some(p) =>
+        if p.isRunning then
+          clog.info(s"[YELLOW]Stopping application ${formatApp(p)} (by killing the forked JVM) ...")
+          p.stop()
+      case None =>
+        clog.info(
+          s"[YELLOW]Application ${formatAppName(project.project, "[BOLD]")} not yet started"
+        )
+    GlobalState.update(_.removeProcessAndColor(project))
+
+  def stopApps(log: Logger, ansi: Boolean): Unit = GlobalState
+    .get()
+    .runningProjects
+    .foreach(stopApp(log, ansi, _))
+
+  def showStatus(log: Logger, ansi: Boolean, project: ProjectRef): Unit =
+    val clog = ReStartColors.colorLogger(log, ansi)
+    GlobalState.get().getProcess(project).find(_.isRunning) match
+      case Some(p) =>
+        clog.info(s"[GREEN]Application ${formatApp(p, "[GREEN]")} is currently running")
+      case None =>
+        clog.info(
+          s"[YELLOW]Application ${formatAppName(
+              project.project,
+              "[BOLD]"
+            )} is currently NOT running"
+        )
+
+  private def registerAppProcess(project: ProjectRef, process: AppProcess): Unit = GlobalState
+    .update { state =>
+      // Defensively stop any still-running process before overwriting its slot, so we never leak a
+      // forked JVM if two starts raced.
+      val old = state.getProcess(project)
+      if old.exists(_.isRunning) then
+        old.get.stop()
+      state.addProcess(project, process)
+    }
+
+  private def forkRun(
+      options: ForkOptions,
+      mainClass: String,
+      classpath: Seq[File],
+      args: Seq[String],
+      log: Logger,
+      extraJvmArgs: Seq[String]
+  ): Process =
+    log.info(args.mkString(s"Starting ${mainClass}.main(", ", ", ")"))
+    val cpString     = classpath.map(_.getAbsolutePath).mkString(File.pathSeparator)
+    val javaArgs     = "-classpath" :: cpString :: mainClass :: args.toList
+    val finalOptions = options
+      .withOutputStrategy(options.outputStrategy.getOrElse(OutputStrategy.LoggedOutput(log)))
+      .withRunJVMOptions(options.runJVMOptions ++ extraJvmArgs)
+    Fork.java.fork(finalOptions, javaArgs)
+
+  private def formatAppName(
+      projectName: String,
+      projectColor: String,
+      color: String = "[YELLOW]"
+  ): String = s"[RESET]${projectColor}${projectName}[RESET]${color}"
+
+  private def formatApp(p: AppProcess, color: String = "[YELLOW]"): String = formatAppName(
+    p.projectName,
+    p.consoleColor,
+    color
+  )
+
+end ReStartActions

--- a/sbt-uni/src/main/scala/wvlet/uni/sbt/UniPlugin.scala
+++ b/sbt-uni/src/main/scala/wvlet/uni/sbt/UniPlugin.scala
@@ -15,8 +15,10 @@ package wvlet.uni.sbt
 
 import sbt.*
 import sbt.Keys.*
+import sbt.internal.util.ConsoleAppender
 import xsbti.FileConverter
 import wvlet.uni.http.codegen.{HttpCodeGenerator, ServiceScanner}
+import scala.annotation.nowarn
 
 /**
   * sbt 2.x plugin for generating HTTP/RPC client code from Scala 3 traits.
@@ -24,6 +26,10 @@ import wvlet.uni.http.codegen.{HttpCodeGenerator, ServiceScanner}
   * Unlike sbt-airframe (which forks a JVM for code generation), this plugin runs the codegen
   * in-process. This is possible because sbt 2.x uses Scala 3 for the metabuild, so the plugin can
   * directly call uni's codegen as a library.
+  *
+  * It also provides a `uniRestart` task (ported from sbt-revolver's `reStart`, which has not been
+  * released for sbt 2.x) to fork-run an application in the background. Combine it with sbt's file
+  * watch (`~uniRestart`) to relaunch the process on every code change. See [[ReStartActions]].
   *
   * Usage in build.sbt:
   * {{{
@@ -33,6 +39,15 @@ import wvlet.uni.http.codegen.{HttpCodeGenerator, ServiceScanner}
   *     uniHttpClients := Seq("com.example.api.UserService:rpc")
   *   )
   *   .dependsOn(api) // project containing the service trait
+  *   .settings(
+  *     // optional: start the forked process from a directory other than the project root
+  *     uniRestart / baseDirectory := baseDirectory.value / "server"
+  *   )
+  *
+  * // run the app in a forked JVM and relaunch it whenever sources change:
+  * //   sbt> ~app/uniRestart arg1 arg2 --- -Xmx512m
+  * //   sbt> app/uniStop
+  * //   sbt> app/uniStatus
   * }}}
   */
 object UniPlugin extends AutoPlugin:
@@ -47,47 +62,137 @@ object UniPlugin extends AutoPlugin:
 
     val uniHttpCodegenOutDir = settingKey[File]("Output directory for generated code")
 
+    // --- uniRestart (background fork-run), ported from sbt-revolver's reStart ---
+
+    val uniRestart = inputKey[Unit](
+      "(Re)start the application in a forked JVM in the background. Stops the previous run first, " +
+        "so `~uniRestart` relaunches it on every code change. " +
+        "Usage: uniRestart <app-args>* [--- <jvm-args>*]"
+    )
+
+    val uniStop   = taskKey[Unit]("Stop the application started by uniRestart")
+    val uniStatus = taskKey[Unit]("Show whether the uniRestart application is currently running")
+
+    val uniRestartArgs = settingKey[Seq[String]](
+      "Default arguments passed to the application on uniRestart"
+    )
+
+    @transient
+    val uniRestartForkOptions = taskKey[ForkOptions](
+      "Fork options (java home, JVM opts, env) used by uniRestart"
+    )
+
+    val uniRestartLogTag = settingKey[String](
+      "Prefix used to tag the forked application's console output"
+    )
+
+    val uniRestartColors = settingKey[Seq[String]](
+      "Console color names assigned to background apps to distinguish output"
+    )
+
+  end autoImport
+
   import autoImport.*
 
   override def requires: Plugins = sbt.plugins.JvmPlugin
   override def trigger           = noTrigger
 
-  override def projectSettings: Seq[Setting[?]] = Seq(
-    uniHttpClients        := Seq.empty,
-    uniHttpCodegenOutDir  := (Compile / sourceManaged).value,
-    uniHttpGenerateClient := {
-      given FileConverter = fileConverter.value
-      val log             = streams.value.log
-      val outDir          = uniHttpCodegenOutDir.value
-      val clients         = uniHttpClients.value
+  override def projectSettings: Seq[Setting[?]] =
+    Seq(
+      uniHttpClients        := Seq.empty,
+      uniHttpCodegenOutDir  := (Compile / sourceManaged).value,
+      uniHttpGenerateClient := {
+        given FileConverter = fileConverter.value
+        val log             = streams.value.log
+        val outDir          = uniHttpCodegenOutDir.value
+        val clients         = uniHttpClients.value
 
-      if clients.isEmpty then
-        log.debug("uniHttpClients is empty, skipping code generation")
-        Seq.empty
-      else
-        // Compile dependent projects first to produce .class files
-        val _ = (Compile / compile).all(dependentProjects).value
+        if clients.isEmpty then
+          log.debug("uniHttpClients is empty, skipping code generation")
+          Seq.empty
+        else
+          // Compile dependent projects first to produce .class files
+          val _ = (Compile / compile).all(dependentProjects).value
 
-        // Build a classloader from dependent project class dirs + dependency JARs
-        val depClassDirs: Seq[java.io.File] = (Compile / classDirectory)
-          .all(dependentProjects)
-          .value
-        val depClasspath: Seq[java.nio.file.Path] = (Compile / dependencyClasspath).value.files
-        val allUrls = (depClassDirs.map(_.toURI.toURL) ++ depClasspath.map(_.toUri.toURL)).toArray
-        val classLoader = java.net.URLClassLoader(allUrls, getClass.getClassLoader)
+          // Build a classloader from dependent project class dirs + dependency JARs
+          val depClassDirs: Seq[java.io.File] = (Compile / classDirectory)
+            .all(dependentProjects)
+            .value
+          val depClasspath: Seq[java.nio.file.Path] = (Compile / dependencyClasspath).value.files
+          val allUrls = (depClassDirs.map(_.toURI.toURL) ++ depClasspath.map(_.toUri.toURL)).toArray
+          val classLoader = java.net.URLClassLoader(allUrls, getClass.getClassLoader)
 
-        val generated = clients.flatMap { spec =>
-          val config    = HttpCodeGenerator.parseConfig(spec)
-          val className = config.apiClassName
-          log.info(s"Generating client for ${className}")
-          val service = ServiceScanner.scan(className, classLoader)
-          HttpCodeGenerator.generateAndWrite(service, config, outDir)
-        }
-        generated
+          val generated = clients.flatMap { spec =>
+            val config    = HttpCodeGenerator.parseConfig(spec)
+            val className = config.apiClassName
+            log.info(s"Generating client for ${className}")
+            val service = ServiceScanner.scan(className, classLoader)
+            HttpCodeGenerator.generateAndWrite(service, config, outDir)
+          }
+          generated
+      },
+      // Hook into source generation so generated code is compiled with user code
+      Compile / sourceGenerators += uniHttpGenerateClient
+    ) ++ uniRestartSettings
+
+  /** uniRestart/uniStop/uniStatus settings, ported from sbt-revolver's reStart. */
+  private def uniRestartSettings: Seq[Setting[?]] = Seq(
+    uniRestart / mainClass     := (Compile / run / mainClass).value,
+    uniRestart / fullClasspath := Def.uncached((Runtime / fullClasspath).value),
+    // Working directory of the forked JVM. Defaults to the project root; override when the app must
+    // start from elsewhere, e.g. `uniRestart / baseDirectory := baseDirectory.value / "server"`.
+    uniRestart / baseDirectory := baseDirectory.value,
+    // javaOptions / envVars are left unscoped: `uniRestart / <key>` delegates to the project value,
+    // while still letting users override them specifically for uniRestart.
+    uniRestartArgs        := Seq.empty,
+    uniRestartLogTag      := thisProjectRef.value.project,
+    uniRestartColors      := ReStartColors.basicColorsAndUnderlined,
+    uniRestartForkOptions := {
+      // Touch the temp dir so it is created before the forked JVM may rely on it.
+      val _ = taskTemporaryDirectory.value
+      ForkOptions()
+        .withJavaHome(javaHome.value)
+        .withOutputStrategy(outputStrategy.value)
+        .withWorkingDirectory((uniRestart / baseDirectory).value)
+        .withRunJVMOptions((uniRestart / javaOptions).value.toVector)
+        .withConnectInput(false)
+        .withEnvVars((uniRestart / envVars).value)
     },
-    // Hook into source generation so generated code is compiled with user code
-    Compile / sourceGenerators += uniHttpGenerateClient
+    uniRestart := {
+      val extra = ReStartActions.startArgsParser.parsed
+      // Ensure this project's classes are compiled before forking.
+      val _               = (Compile / products).value
+      given FileConverter = fileConverter.value
+      val classpath       = (uniRestart / fullClasspath).value.files.map(_.toFile)
+      ReStartActions.restartApp(
+        log = streams.value.log,
+        ansi = ansiEnabled,
+        logTag = uniRestartLogTag.value,
+        project = thisProjectRef.value,
+        options = uniRestartForkOptions.value,
+        mainClass = (uniRestart / mainClass).value,
+        classpath = classpath,
+        defaultArgs = uniRestartArgs.value,
+        colors = uniRestartColors.value,
+        extra = extra
+      )
+    },
+    uniStop   := ReStartActions.stopApp(streams.value.log, ansiEnabled, thisProjectRef.value),
+    uniStatus := ReStartActions.showStatus(streams.value.log, ansiEnabled, thisProjectRef.value)
   )
+
+  // Stop any background apps when the build is reloaded, so we never leak a forked JVM.
+  override def globalSettings: Seq[Setting[?]] = Seq(
+    onUnload ~= { previous => (state: State) =>
+      ReStartActions.stopApps(state.log, ansiEnabled)
+      previous(state)
+    }
+  )
+
+  // Whether ANSI color is enabled in the current environment. The public Terminal accessors are
+  // `private[sbt]`, so we fall back to the (deprecated but accessible) env-level flag.
+  @nowarn("cat=deprecation")
+  private def ansiEnabled: Boolean = ConsoleAppender.formatEnabledInEnv
 
   private def dependentProjects: ScopeFilter = ScopeFilter(
     inDependencies(ThisProject, transitive = true, includeRoot = false)

--- a/sbt-uni/src/sbt-test/restart/basic/app/src/main/scala/example/Main.scala
+++ b/sbt-uni/src/sbt-test/restart/basic/app/src/main/scala/example/Main.scala
@@ -1,0 +1,20 @@
+package example
+
+import java.nio.file.{Files, Paths}
+
+/**
+  * Test app for `uniRestart`. Writes a marker file named after its first program argument, but only
+  * when the system property `uni.test.enabled=true` is set. This lets the scripted test assert that
+  * BOTH program args (the file name) AND JVM args after `---` (the system property) are forwarded
+  * to the forked JVM. It then stays alive so the test can observe a running background process and
+  * later stop it.
+  */
+object Main:
+  def main(args: Array[String]): Unit =
+    val name = args.headOption.getOrElse("default")
+    if sys.props.get("uni.test.enabled").contains("true") then
+      val target = Paths.get("target")
+      Files.createDirectories(target)
+      Files.write(target.resolve(s"${name}.txt"), "started".getBytes)
+    // Stay running so uniStatus/uniStop have a live process to act on.
+    Thread.sleep(120000)

--- a/sbt-uni/src/sbt-test/restart/basic/build.sbt
+++ b/sbt-uni/src/sbt-test/restart/basic/build.sbt
@@ -1,0 +1,6 @@
+lazy val app = project
+  .in(file("app"))
+  .enablePlugins(UniPlugin)
+  .settings(
+    scalaVersion := "3.8.3"
+  )

--- a/sbt-uni/src/sbt-test/restart/basic/project/build.properties
+++ b/sbt-uni/src/sbt-test/restart/basic/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.0-RC10

--- a/sbt-uni/src/sbt-test/restart/basic/project/plugins.sbt
+++ b/sbt-uni/src/sbt-test/restart/basic/project/plugins.sbt
@@ -1,0 +1,7 @@
+sys.props.get("plugin.version") match {
+  case Some(v) =>
+    addSbtPlugin("org.wvlet.uni" % "sbt-uni" % v)
+  case _ =>
+    sys.error("""|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/sbt-uni/src/sbt-test/restart/basic/test
+++ b/sbt-uni/src/sbt-test/restart/basic/test
@@ -1,0 +1,20 @@
+# Start the app in a background forked JVM.
+# Program arg "first" => marker file name; JVM arg "-Duni.test.enabled=true" (after ---) gates the write,
+# so the marker appearing proves both arg channels reach the forked JVM.
+> app/uniRestart first --- -Duni.test.enabled=true
+$ sleep 8000
+$ exists app/target/first.txt
+
+# uniStatus must succeed while the app is running.
+> app/uniStatus
+
+# Restart while still running: this should stop the "first" process and start a "second" one.
+> app/uniRestart second --- -Duni.test.enabled=true
+$ sleep 8000
+$ exists app/target/second.txt
+
+# Stop the background app.
+> app/uniStop
+
+# uniStatus must still succeed after the app has stopped.
+> app/uniStatus

--- a/sbt-uni/src/sbt-test/restart/workdir/app/src/main/scala/example/Main.scala
+++ b/sbt-uni/src/sbt-test/restart/workdir/app/src/main/scala/example/Main.scala
@@ -1,0 +1,20 @@
+package example
+
+import java.nio.file.{Files, Paths}
+
+/**
+  * Test app for `uniRestart`. Writes a marker file named after its first program argument, but only
+  * when the system property `uni.test.enabled=true` is set. This lets the scripted test assert that
+  * BOTH program args (the file name) AND JVM args after `---` (the system property) are forwarded to
+  * the forked JVM. It then stays alive so the test can observe a running background process and
+  * later stop it.
+  */
+object Main:
+  def main(args: Array[String]): Unit =
+    val name = args.headOption.getOrElse("default")
+    if sys.props.get("uni.test.enabled").contains("true") then
+      val target = Paths.get("target")
+      Files.createDirectories(target)
+      Files.write(target.resolve(s"${name}.txt"), "started".getBytes)
+    // Stay running so uniStatus/uniStop have a live process to act on.
+    Thread.sleep(120000)

--- a/sbt-uni/src/sbt-test/restart/workdir/build.sbt
+++ b/sbt-uni/src/sbt-test/restart/workdir/build.sbt
@@ -1,0 +1,8 @@
+lazy val app = project
+  .in(file("app"))
+  .enablePlugins(UniPlugin)
+  .settings(
+    scalaVersion := "3.8.3",
+    // Start the forked process from a subdirectory instead of the project root.
+    uniRestart / baseDirectory := baseDirectory.value / "run-dir"
+  )

--- a/sbt-uni/src/sbt-test/restart/workdir/project/build.properties
+++ b/sbt-uni/src/sbt-test/restart/workdir/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.0-RC10

--- a/sbt-uni/src/sbt-test/restart/workdir/project/plugins.sbt
+++ b/sbt-uni/src/sbt-test/restart/workdir/project/plugins.sbt
@@ -1,0 +1,7 @@
+sys.props.get("plugin.version") match {
+  case Some(v) =>
+    addSbtPlugin("org.wvlet.uni" % "sbt-uni" % v)
+  case _ =>
+    sys.error("""|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/sbt-uni/src/sbt-test/restart/workdir/test
+++ b/sbt-uni/src/sbt-test/restart/workdir/test
@@ -1,0 +1,9 @@
+# The app writes its marker to "target/<name>.txt" relative to the forked JVM's working directory.
+# With `uniRestart / baseDirectory := baseDirectory.value / "run-dir"`, the working directory is the
+# run-dir subdirectory, so the marker must appear under app/run-dir/target (not app/target).
+$ mkdir app/run-dir
+> app/uniRestart marker --- -Duni.test.enabled=true
+$ sleep 8000
+$ exists app/run-dir/target/marker.txt
+$ absent app/target/marker.txt
+> app/uniStop


### PR DESCRIPTION
## Why

While migrating to sbt 2.0, the only thing `io.spray:sbt-revolver` was still pulling its weight for is `reStart` — and sbt-revolver has no sbt 2.x release. This ports that capability into **sbt-uni**, so sbt 2.0 users get background fork-run (and `~uniRestart` to relaunch on every code change) without the extra plugin.

## What

New tasks (uni-prefixed to avoid clashing with sbt-revolver's `reStart`/`reStop`/`reStatus` if both are on a build during migration):

- **`uniRestart`** — (re)start the app in a forked JVM in the background; stops the previous run first, so `~uniRestart` relaunches on code change. Usage: `uniRestart <app-args>* [--- <jvm-args>*]`.
- `uniStop` / `uniStatus` — stop / report status.

The forked process working directory is exposed via **`uniRestart / baseDirectory`** (defaults to the project root) for apps that must not start from the project root:

```scala
uniRestart / baseDirectory := baseDirectory.value / "server"
```

Supporting settings: `uniRestartArgs`, `uniRestartForkOptions`, `uniRestartLogTag`, `uniRestartColors`.

## sbt 2.x port notes (vs sbt 1.x revolver)

- Parser moved to `sbt.internal.util.complete.DefaultParsers`.
- `Logger.ansiCodesSupported` is gone and `Terminal.*` is `private[sbt]`, so color detection uses `ConsoleAppender.formatEnabledInEnv` (the only accessible flag).
- sbt 2.x task-result caching: `@transient` on the `ForkOptions` key, `Def.uncached(...)` for the classpath.
- `Runtime` resolves to sbt's `Runtime` config → used `java.lang.Runtime`.
- Running process is tracked in a process-global `AtomicReference`, not sbt `State`, so it survives task re-invocations; a JVM shutdown hook + `onUnload` hook prevent leaking the forked JVM on exit/reload.

## Tests

Scripted tests (run by CI's existing `scripted` step in `sbt-uni`):

- `restart/basic` — start → `uniStatus` running → restart-while-running (old JVM killed) → `uniStop` → `uniStatus` stopped; also asserts both program args and `---` JVM args reach the fork.
- `restart/workdir` — marker lands under the overridden `baseDirectory` and is absent at the default location.

Both pass locally, plus a clean `compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)