### PR TITLE
docs: Use "object wiring" for Design, not "dependency injection"

### DIFF
--- a/docs/core/surface.md
+++ b/docs/core/surface.md
@@ -82,7 +82,7 @@ Zero.of[Map[K, V]]     // Map.empty
 
 ## Use Cases
 
-### Dependency Injection
+### Object Wiring
 
 Surface powers uni's Design system:
 

--- a/docs/core/unitest.md
+++ b/docs/core/unitest.md
@@ -331,7 +331,7 @@ test("platform-specific behavior") {
 
 ## Design Integration
 
-Use Design for dependency injection in tests:
+Use Design for object wiring in tests:
 
 ```scala
 import wvlet.uni.test.UniTest
@@ -619,7 +619,7 @@ Test results are displayed with status symbols:
 ## Best Practices
 
 1. **Avoid mocks** - Use real implementations or in-memory versions
-2. **Use Design for DI** - Leverage dependency injection for test isolation
+2. **Use Design for wiring** - Leverage object wiring for test isolation
 3. **Prefer `shouldMatch`** - Use pattern matching for type checks instead of `asInstanceOf`
 4. **One behavior per test** - Keep tests focused on a single behavior
 5. **Descriptive names** - Test names should describe the expected behavior

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -10,7 +10,7 @@
 Add uni to your `build.sbt`:
 
 ```scala
-// Core utilities (DI, logging, JSON, HTTP, Rx, etc.)
+// Core utilities (object wiring, logging, JSON, HTTP, Rx, etc.)
 libraryDependencies += "org.wvlet.uni" %% "uni" % "__UNI_VERSION__"
 ```
 
@@ -31,7 +31,7 @@ libraryDependencies += "org.wvlet.uni" %%% "uni" % "__UNI_VERSION__"
 Common imports for getting started:
 
 ```scala
-// Dependency injection
+// Object wiring
 import wvlet.uni.design.Design
 
 // Logging

--- a/docs/guide/principles.md
+++ b/docs/guide/principles.md
@@ -27,7 +27,7 @@ Platform-specific code is isolated in `.jvm`, `.js`, and `.native` directories.
 uni leverages Scala 3's type system for compile-time guarantees:
 
 ```scala
-// Dependency injection is type-safe
+// Object wiring is type-safe
 val design = Design.newDesign
   .bindImpl[UserRepository, PostgresUserRepository]
 

--- a/docs/http/router.md
+++ b/docs/http/router.md
@@ -88,7 +88,7 @@ Controllers must have a no-argument constructor.
 
 ### MapControllerProvider
 
-For pre-configured instances (useful for testing or dependency injection):
+For pre-configured instances (useful for testing or object wiring):
 
 ```scala
 import wvlet.uni.http.router.MapControllerProvider


### PR DESCRIPTION
Design is intentionally described as **object wiring**, not dependency injection. The [Introduction](https://wvlet.org/uni/guide/) was already corrected (#593); this applies the same convention to the five remaining reference/guide pages:

- `core/surface.md` — "### Dependency Injection" → "### Object Wiring"
- `guide/principles.md`, `guide/installation.md` — code comments
- `core/unitest.md` — "Use Design for object wiring in tests" (×2)
- `http/router.md` — "useful for testing or object wiring"

`uni-walkthrough.md` still uses the term but is handled in a follow-up that reconciles that page against the Book (and its TOC anchor). `pnpm docs:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)