### PR TITLE
feature: Compile-check the Book's code examples (and fix 3 doc bugs they caught)

### DIFF
--- a/book-examples/README.md
+++ b/book-examples/README.md
@@ -1,0 +1,22 @@
+# uni-book-examples
+
+Compile-checked code from [The Uni Book](../docs/book/). Each `ChNN*.scala`
+file mirrors the runnable snippets of the corresponding chapter, so CI catches
+API drift in the book as `uni` evolves — the book's authoring guide requires
+every non-illustrative snippet to compile, and this module enforces it.
+
+The examples are compiled, not run (HTTP/RPC servers are configured but never
+started; clients are constructed but never connected). The one exception is
+`Ch04TestingTest`, which is a real `UniTest` suite that also runs.
+
+```bash
+./sbt bookExamples/Test/compile   # compile every example
+./sbt bookExamples/test           # also run the testing-chapter suite
+```
+
+Platform-specific chapters (12–13 Scala.js facades / Vite, 14–15 Scala Native
+FFI) are not represented here — they require the JS and Native toolchains and
+external bundlers/compilers, and are verified against the reference sources they
+were drawn from instead.
+
+This module is not published (`publish / skip := true`).

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch03Design.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch03Design.scala
@@ -1,0 +1,57 @@
+/*
+ * Compile-checked examples from Book Chapter 3 — Wiring with Design.
+ * These mirror the chapter's snippets so CI catches API drift. They are
+ * compiled, not run; bodies that would do I/O are inert.
+ */
+package wvlet.uni.book
+
+import wvlet.uni.design.Design
+
+object Ch03Design:
+  class Database:
+    def query(sql: String): Seq[String] = Seq("alice", "bob")
+
+  class UserService(db: Database):
+    def listUsers(): Seq[String] = db.query("select name from users")
+
+  trait UserRepo
+  class InMemoryUserRepo extends UserRepo
+
+  case class Config(url: String)
+
+  class Server:
+    def start(): Unit = ()
+    def stop(): Unit  = ()
+
+  class FakeDatabase extends Database
+
+  def firstWiring(): Unit =
+    val design = Design.newDesign
+      .bindSingleton[Database]
+      .bindSingleton[UserService]
+    design.build[UserService] { users =>
+      println(users.listUsers())
+    }
+
+  def theFourBindings(): Unit =
+    Design.newDesign.bindSingleton[Database]
+    Design.newDesign.bindInstance[Database](Database())
+    Design.newDesign.bindImpl[UserRepo, InMemoryUserRepo]
+    Design.newDesign
+      .bindInstance[Config](Config("jdbc:db"))
+      .bindProvider[Config, Database] { config => Database() }
+
+  def sessionsAndLifecycle(): Unit =
+    val design = Design.newDesign
+      .bindSingleton[Server]
+      .onStart(_.start())
+      .onShutdown(_.stop())
+    design.build[Server] { server => () }
+
+  def overriding(): Unit =
+    val appDesign = Design.newDesign
+      .bindSingleton[Database]
+      .bindSingleton[UserService]
+    val testDesign = appDesign +
+      Design.newDesign.bindInstance[Database](FakeDatabase())
+    testDesign.build[UserService] { users => () }

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch03Design.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch03Design.scala
@@ -26,9 +26,7 @@ object Ch03Design:
   class FakeDatabase extends Database
 
   def firstWiring(): Unit =
-    val design = Design.newDesign
-      .bindSingleton[Database]
-      .bindSingleton[UserService]
+    val design = Design.newDesign.bindSingleton[Database].bindSingleton[UserService]
     design.build[UserService] { users =>
       println(users.listUsers())
     }
@@ -37,21 +35,24 @@ object Ch03Design:
     Design.newDesign.bindSingleton[Database]
     Design.newDesign.bindInstance[Database](Database())
     Design.newDesign.bindImpl[UserRepo, InMemoryUserRepo]
-    Design.newDesign
+    Design
+      .newDesign
       .bindInstance[Config](Config("jdbc:db"))
-      .bindProvider[Config, Database] { config => Database() }
+      .bindProvider[Config, Database] { config =>
+        Database()
+      }
 
   def sessionsAndLifecycle(): Unit =
-    val design = Design.newDesign
-      .bindSingleton[Server]
-      .onStart(_.start())
-      .onShutdown(_.stop())
-    design.build[Server] { server => () }
+    val design = Design.newDesign.bindSingleton[Server].onStart(_.start()).onShutdown(_.stop())
+    design.build[Server] { server =>
+      ()
+    }
 
   def overriding(): Unit =
-    val appDesign = Design.newDesign
-      .bindSingleton[Database]
-      .bindSingleton[UserService]
-    val testDesign = appDesign +
-      Design.newDesign.bindInstance[Database](FakeDatabase())
-    testDesign.build[UserService] { users => () }
+    val appDesign  = Design.newDesign.bindSingleton[Database].bindSingleton[UserService]
+    val testDesign = appDesign + Design.newDesign.bindInstance[Database](FakeDatabase())
+    testDesign.build[UserService] { users =>
+      ()
+    }
+
+end Ch03Design

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch05Logging.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch05Logging.scala
@@ -1,0 +1,26 @@
+/* Compile-checked examples from Book Chapter 5 — Logging That Finds You. */
+package wvlet.uni.book
+
+import wvlet.uni.log.LogSupport
+
+object Ch05Logging:
+  class OrderService extends LogSupport:
+    def placeOrder(id: String): Unit =
+      info(s"Placing order ${id}")
+      debug(s"order details for ${id}")
+
+  def expensiveSnapshot(): String = "state"
+
+  class Diagnostics extends LogSupport:
+    def dump(): Unit =
+      // Unguarded: the message is only built when DEBUG is enabled.
+      debug(s"State dump: ${expensiveSnapshot()}")
+
+  class PaymentService extends LogSupport:
+    private def gatewayCharge(amount: Int): Unit = ()
+    def charge(amount: Int): Unit =
+      try gatewayCharge(amount)
+      catch
+        case e: Exception =>
+          error(s"Charge of ${amount} failed", e)
+          throw e

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch05Logging.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch05Logging.scala
@@ -18,8 +18,9 @@ object Ch05Logging:
 
   class PaymentService extends LogSupport:
     private def gatewayCharge(amount: Int): Unit = ()
-    def charge(amount: Int): Unit =
-      try gatewayCharge(amount)
+    def charge(amount: Int): Unit                =
+      try
+        gatewayCharge(amount)
       catch
         case e: Exception =>
           error(s"Charge of ${amount} failed", e)

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch06Data.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch06Data.scala
@@ -1,0 +1,29 @@
+/* Compile-checked examples from Book Chapter 6 — Data In, Data Out. */
+package wvlet.uni.book
+
+import wvlet.uni.json.*
+import wvlet.uni.weaver.Weaver
+
+object Ch06Data:
+  def navigateJson(): Unit =
+    val doc = JSON.parse("""
+      { "user": { "id": 123, "name": "Alice" },
+        "posts": [ { "title": "Hello" }, { "title": "World" } ] }
+    """)
+    val name  = doc("user")("name").toStringValue
+    val id    = doc("user")("id").toLongValue
+    val first = doc("posts")(0)("title").toStringValue
+    println(s"${name} ${id} ${first}")
+
+  case class User(id: Long, name: String) derives Weaver
+
+  def codec(): Unit =
+    val alice = User(123, "Alice")
+
+    val json: String = Weaver.toJson(alice)
+    val back: User   = Weaver.fromJson[User](json)
+
+    val bytes: Array[Byte] = Weaver.weave(alice)
+    val u: User            = Weaver.unweave[User](bytes)
+
+    println(s"${json} ${back} ${u} ${bytes.length}")

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch07Rx.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch07Rx.scala
@@ -6,7 +6,7 @@ import wvlet.uni.rx.Rx
 object Ch07Rx:
   def aValueThatChanges(): Unit =
     val count = Rx.variable(0)
-    val sub = count.subscribe { v =>
+    val sub   = count.subscribe { v =>
       println(s"count is now ${v}")
     }
     count := 1
@@ -14,11 +14,8 @@ object Ch07Rx:
     sub.cancel
 
   def composing(): Unit =
-    val count = Rx.variable(0)
-    val label: Rx[String] =
-      count
-        .filter(_ % 2 == 0)
-        .map(n => s"even: ${n}")
+    val count             = Rx.variable(0)
+    val label: Rx[String] = count.filter(_ % 2 == 0).map(n => s"even: ${n}")
     label.subscribe(println)
     count := 1
     count := 2

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch07Rx.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch07Rx.scala
@@ -1,0 +1,24 @@
+/* Compile-checked examples from Book Chapter 7 — Rx, the Composable Stream. */
+package wvlet.uni.book
+
+import wvlet.uni.rx.Rx
+
+object Ch07Rx:
+  def aValueThatChanges(): Unit =
+    val count = Rx.variable(0)
+    val sub = count.subscribe { v =>
+      println(s"count is now ${v}")
+    }
+    count := 1
+    count := 2
+    sub.cancel
+
+  def composing(): Unit =
+    val count = Rx.variable(0)
+    val label: Rx[String] =
+      count
+        .filter(_ % 2 == 0)
+        .map(n => s"even: ${n}")
+    label.subscribe(println)
+    count := 1
+    count := 2

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch08Control.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch08Control.scala
@@ -5,7 +5,7 @@ import wvlet.uni.control.{CircuitBreaker, CircuitBreakerOpenException, Control, 
 
 object Ch08Control:
   private def callFlakyService(): String = "ok"
-  private def useFallback(): String       = "fallback"
+  private def useFallback(): String      = "fallback"
 
   class Connection extends AutoCloseable:
     def query(sql: String): String = "rows"
@@ -40,9 +40,13 @@ object Ch08Control:
   def combined(url: String): String =
     val breaker = CircuitBreaker.withConsecutiveFailures(5)
     breaker.run {
-      Retry.withBackOff(maxRetry = 3).run {
-        Control.withResource(openConnection()) { conn =>
-          conn.get(url)
+      Retry
+        .withBackOff(maxRetry = 3)
+        .run {
+          Control.withResource(openConnection()) { conn =>
+            conn.get(url)
+          }
         }
-      }
     }
+
+end Ch08Control

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch08Control.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch08Control.scala
@@ -1,0 +1,48 @@
+/* Compile-checked examples from Book Chapter 8 — Living With Failure. */
+package wvlet.uni.book
+
+import wvlet.uni.control.{CircuitBreaker, CircuitBreakerOpenException, Control, Retry}
+
+object Ch08Control:
+  private def callFlakyService(): String = "ok"
+  private def useFallback(): String       = "fallback"
+
+  class Connection extends AutoCloseable:
+    def query(sql: String): String = "rows"
+    def get(url: String): String   = "body"
+    def close(): Unit              = ()
+
+  private def openConnection(): Connection = Connection()
+
+  def retry(): Unit =
+    val result = Retry
+      .withBackOff(maxRetry = 3)
+      .run {
+        callFlakyService()
+      }
+    println(result)
+
+  def breaker(): Unit =
+    val breaker = CircuitBreaker.withConsecutiveFailures(5)
+    try
+      breaker.run {
+        callFlakyService()
+      }
+    catch
+      case e: CircuitBreakerOpenException =>
+        useFallback()
+
+  def resource(): Unit =
+    Control.withResource(openConnection()) { conn =>
+      conn.query("select 1")
+    }
+
+  def combined(url: String): String =
+    val breaker = CircuitBreaker.withConsecutiveFailures(5)
+    breaker.run {
+      Retry.withBackOff(maxRetry = 3).run {
+        Control.withResource(openConnection()) { conn =>
+          conn.get(url)
+        }
+      }
+    }

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch09Http.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch09Http.scala
@@ -9,22 +9,21 @@ import wvlet.uni.rx.Rx
 
 object Ch09Http:
   def clients(): Unit =
-    val sync     = Http.client.newSyncClient
-    val async    = Http.client.newAsyncClient
-    val tuned    = Http.client
-      .withConnectTimeoutMillis(5000)
-      .withMaxRetry(3)
-      .newSyncClient
+    val sync  = Http.client.newSyncClient
+    val async = Http.client.newAsyncClient
+    val tuned = Http.client.withConnectTimeoutMillis(5000).withMaxRetry(3).newSyncClient
     println(s"${sync} ${async} ${tuned}")
 
-  def buildRequests(): Request =
-    Request.post("https://api.example.com/users").withJsonContent("""{"name":"Alice"}""")
+  def buildRequests(): Request = Request
+    .post("https://api.example.com/users")
+    .withJsonContent("""{"name":"Alice"}""")
 
-  def asyncCompose(): Unit =
-    Http.client.newAsyncClient
-      .send(Request.get("https://httpbin.org/get"))
-      .map(_.contentAsString.getOrElse(""))
-      .subscribe(println)
+  def asyncCompose(): Unit = Http
+    .client
+    .newAsyncClient
+    .send(Request.get("https://httpbin.org/get"))
+    .map(_.contentAsString.getOrElse(""))
+    .subscribe(println)
 
   class UserController:
     @Endpoint(HttpMethod.GET, "/users/:id")
@@ -33,15 +32,14 @@ object Ch09Http:
     @Endpoint(HttpMethod.GET, "/users")
     def listUsers(): Seq[String] = Seq("alice", "bob")
 
-  def functionalServerConfig =
-    NettyServer
-      .withPort(8080)
-      .withRxHandler { (request: Request) =>
-        Rx.single(Response.ok(s"You asked for ${request.path}"))
-      }
+  def functionalServerConfig = NettyServer
+    .withPort(8080)
+    .withRxHandler { (request: Request) =>
+      Rx.single(Response.ok(s"You asked for ${request.path}"))
+    }
 
   def routedServerConfig =
     val router = Router.of[UserController]
-    NettyServer
-      .withPort(8080)
-      .withRxHandler(RouterHandler(router))
+    NettyServer.withPort(8080).withRxHandler(RouterHandler(router))
+
+end Ch09Http

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch09Http.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch09Http.scala
@@ -1,0 +1,47 @@
+/* Compile-checked examples from Book Chapter 9 — HTTP Clients and Servers.
+ * Clients/servers are constructed but never connected/started here. */
+package wvlet.uni.book
+
+import wvlet.uni.http.{Http, HttpMethod, Request, Response}
+import wvlet.uni.http.router.{Endpoint, Router}
+import wvlet.uni.http.netty.{NettyServer, RouterHandler}
+import wvlet.uni.rx.Rx
+
+object Ch09Http:
+  def clients(): Unit =
+    val sync     = Http.client.newSyncClient
+    val async    = Http.client.newAsyncClient
+    val tuned    = Http.client
+      .withConnectTimeoutMillis(5000)
+      .withMaxRetry(3)
+      .newSyncClient
+    println(s"${sync} ${async} ${tuned}")
+
+  def buildRequests(): Request =
+    Request.post("https://api.example.com/users").withJsonContent("""{"name":"Alice"}""")
+
+  def asyncCompose(): Unit =
+    Http.client.newAsyncClient
+      .send(Request.get("https://httpbin.org/get"))
+      .map(_.contentAsString.getOrElse(""))
+      .subscribe(println)
+
+  class UserController:
+    @Endpoint(HttpMethod.GET, "/users/:id")
+    def getUser(id: String): String = s"""{"id":"${id}"}"""
+
+    @Endpoint(HttpMethod.GET, "/users")
+    def listUsers(): Seq[String] = Seq("alice", "bob")
+
+  def functionalServerConfig =
+    NettyServer
+      .withPort(8080)
+      .withRxHandler { (request: Request) =>
+        Rx.single(Response.ok(s"You asked for ${request.path}"))
+      }
+
+  def routedServerConfig =
+    val router = Router.of[UserController]
+    NettyServer
+      .withPort(8080)
+      .withRxHandler(RouterHandler(router))

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch10Rpc.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch10Rpc.scala
@@ -14,13 +14,9 @@ object Ch10Rpc:
     def createUser(name: String, email: String): User
 
   class UserServiceImpl extends UserService:
-    def getUser(id: Long): User =
-      User(id, "Alice", "alice@example.com")
-    def createUser(name: String, email: String): User =
-      User(1L, name, email)
+    def getUser(id: Long): User                       = User(id, "Alice", "alice@example.com")
+    def createUser(name: String, email: String): User = User(1L, name, email)
 
   def serverConfig =
     val router = RPCRouter.of[UserService](UserServiceImpl())
-    NettyServer
-      .withPort(8080)
-      .withRxHandler(RPCHandler(router))
+    NettyServer.withPort(8080).withRxHandler(RPCHandler(router))

--- a/book-examples/src/main/scala/wvlet/uni/book/Ch10Rpc.scala
+++ b/book-examples/src/main/scala/wvlet/uni/book/Ch10Rpc.scala
@@ -1,0 +1,26 @@
+/* Compile-checked examples from Book Chapter 10 — Typed RPC.
+ * The router/handler are built but no server is started. */
+package wvlet.uni.book
+
+import wvlet.uni.weaver.Weaver
+import wvlet.uni.http.rpc.RPCRouter
+import wvlet.uni.http.netty.{NettyServer, RPCHandler}
+
+object Ch10Rpc:
+  case class User(id: Long, name: String, email: String) derives Weaver
+
+  trait UserService:
+    def getUser(id: Long): User
+    def createUser(name: String, email: String): User
+
+  class UserServiceImpl extends UserService:
+    def getUser(id: Long): User =
+      User(id, "Alice", "alice@example.com")
+    def createUser(name: String, email: String): User =
+      User(1L, name, email)
+
+  def serverConfig =
+    val router = RPCRouter.of[UserService](UserServiceImpl())
+    NettyServer
+      .withPort(8080)
+      .withRxHandler(RPCHandler(router))

--- a/book-examples/src/test/scala/wvlet/uni/book/Ch04TestingTest.scala
+++ b/book-examples/src/test/scala/wvlet/uni/book/Ch04TestingTest.scala
@@ -1,0 +1,37 @@
+/* Compile-checked (and run) examples from Book Chapter 4 — Testing with UniTest.
+ * This is a real UniTest suite, so it both compiles and runs in CI. */
+package wvlet.uni.book
+
+import wvlet.uni.design.Design
+import wvlet.uni.test.UniTest
+
+class Ch04TestingTest extends UniTest:
+  test("adds two numbers") {
+    val result = 2 + 3
+    result shouldBe 5
+  }
+
+  test("a list contains a value") {
+    Seq("a", "b", "c") shouldContain "b"
+  }
+
+  // Substitute, don't mock: take the real wiring and override one binding.
+  class Database:
+    def lookup(id: String): Option[String] = None
+  class FakeDatabase extends Database:
+    override def lookup(id: String): Option[String] = Some("Alice")
+  class UserService(db: Database):
+    def findUser(id: String): Option[String] = db.lookup(id)
+
+  test("looks up a user via a Design override") {
+    val appDesign = Design.newDesign
+      .bindSingleton[Database]
+      .bindSingleton[UserService]
+
+    val testDesign = appDesign +
+      Design.newDesign.bindInstance[Database](FakeDatabase())
+
+    testDesign.build[UserService] { users =>
+      users.findUser("123") shouldBe Some("Alice")
+    }
+  }

--- a/book-examples/src/test/scala/wvlet/uni/book/Ch04TestingTest.scala
+++ b/book-examples/src/test/scala/wvlet/uni/book/Ch04TestingTest.scala
@@ -18,18 +18,17 @@ class Ch04TestingTest extends UniTest:
   // Substitute, don't mock: take the real wiring and override one binding.
   class Database:
     def lookup(id: String): Option[String] = None
+
   class FakeDatabase extends Database:
     override def lookup(id: String): Option[String] = Some("Alice")
+
   class UserService(db: Database):
     def findUser(id: String): Option[String] = db.lookup(id)
 
   test("looks up a user via a Design override") {
-    val appDesign = Design.newDesign
-      .bindSingleton[Database]
-      .bindSingleton[UserService]
+    val appDesign = Design.newDesign.bindSingleton[Database].bindSingleton[UserService]
 
-    val testDesign = appDesign +
-      Design.newDesign.bindInstance[Database](FakeDatabase())
+    val testDesign = appDesign + Design.newDesign.bindInstance[Database](FakeDatabase())
 
     testDesign.build[UserService] { users =>
       users.findUser("123") shouldBe Some("Alice")

--- a/build.sbt
+++ b/build.sbt
@@ -124,13 +124,7 @@ lazy val root = project
   .settings(buildSettings, name := "uni", publish / skip := true)
   .aggregate((jvmProjects ++ jsProjects ++ nativeProjects): _*)
 
-lazy val jvmProjects: Seq[ProjectReference] = Seq(
-  core.jvm,
-  uni.jvm,
-  netty,
-  bookExamples,
-  test.jvm
-)
+lazy val jvmProjects: Seq[ProjectReference] = Seq(core.jvm, uni.jvm, netty, bookExamples, test.jvm)
 
 lazy val jsProjects: Seq[ProjectReference]     = Seq(core.js, uni.js, domTest, test.js)
 lazy val nativeProjects: Seq[ProjectReference] = Seq(core.native, uni.native, test.native)

--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,7 @@ lazy val jvmProjects: Seq[ProjectReference] = Seq(
   core.jvm,
   uni.jvm,
   netty,
+  bookExamples,
   test.jvm
 )
 
@@ -234,6 +235,18 @@ lazy val netty = project
       )
   )
   .dependsOn(uni.jvm, test.jvm % Test)
+
+// Compile-checked code examples from The Uni Book (docs/book). Not published;
+// exists so CI catches API drift in the book's runnable snippets.
+lazy val bookExamples = project
+  .in(file("book-examples"))
+  .settings(
+    buildSettings,
+    noPublish,
+    name        := "uni-book-examples",
+    description := "Compile-checked code examples from The Uni Book"
+  )
+  .dependsOn(uni.jvm, netty, test.jvm % Test)
 
 // uni-dom-test - Tests for uni-dom using JSDOM environment
 lazy val domTest = project

--- a/docs/book/ch06-00-data.md
+++ b/docs/book/ch06-00-data.md
@@ -17,7 +17,7 @@ There are two situations, and Uni has a tool for each:
 `JSON.parse` turns text into a navigable tree:
 
 ```scala
-import wvlet.uni.json.JSON
+import wvlet.uni.json.*
 
 val doc = JSON.parse("""
   { "user": { "id": 123, "name": "Alice" },

--- a/docs/book/ch08-00-control.md
+++ b/docs/book/ch08-00-control.md
@@ -10,7 +10,7 @@ depending on the failure:
 - The call failed and left a connection open. **Clean it up anyway.**
 
 Uni gives you one primitive for each: `Retry`, `CircuitBreaker`, and
-`Resource`.
+`Control.withResource`.
 
 ## Retry a transient failure
 
@@ -89,12 +89,12 @@ and recovery policy.
 
 Both tools above can fail the call. When they do, anything the call
 opened — a file, a socket, a connection — still needs to close.
-`Resource.withResource` guarantees it:
+`Control.withResource` guarantees it:
 
 ```scala
-import wvlet.uni.control.Resource
+import wvlet.uni.control.Control
 
-Resource.withResource(openConnection()) { conn =>
+Control.withResource(openConnection()) { conn =>
   conn.query("select 1")
 }   // conn.close() runs here — even if query threw
 ```
@@ -106,26 +106,26 @@ you never wrote it.
 
 If that mechanism feels familiar, it should — it is the same guarantee
 `Design`'s `onShutdown` gives a whole session
-([Chapter 3](./ch03-00-design)). `Resource` is the local, block-scoped
+([Chapter 3](./ch03-00-design)). `Control.withResource` is the local, block-scoped
 version; `Design` is the application-scoped version. Reach for
-`Resource` when a resource lives for one operation, and for a `Design`
+`Control.withResource` when a resource lives for one operation, and for a `Design`
 lifecycle hook when it lives for the program.
 
 ## Putting them together
 
 A hardened call to a flaky dependency uses all three at once: a
-`Resource` for the connection, a `CircuitBreaker` to fail fast when the
+`Control.withResource` for the connection, a `CircuitBreaker` to fail fast when the
 dependency is down, and `Retry` to ride out the blips that get through:
 
 ```scala
-import wvlet.uni.control.{CircuitBreaker, Resource, Retry}
+import wvlet.uni.control.{CircuitBreaker, Control, Retry}
 
 val breaker = CircuitBreaker.withConsecutiveFailures(5)
 
 def fetch(url: String): String =
   breaker.run {
     Retry.withBackOff(maxRetry = 3).run {
-      Resource.withResource(openConnection()) { conn =>
+      Control.withResource(openConnection()) { conn =>
         conn.get(url)
       }
     }
@@ -146,7 +146,7 @@ You can now write code that survives the network:
   *only for idempotent operations*.
 - **`CircuitBreaker.run { }`** fails fast when a backend is down, so you
   stop making it worse.
-- **`Resource.withResource(r) { }`** closes resources on every path, the
+- **`Control.withResource(r) { }`** closes resources on every path, the
   block-scoped cousin of `Design`'s `onShutdown`.
 
 That closes Part IV: your services can react ([Rx](./ch07-00-rx)) and

--- a/docs/control/resource.md
+++ b/docs/control/resource.md
@@ -5,9 +5,9 @@ Safely acquire and release resources with automatic cleanup.
 ## Basic Usage
 
 ```scala
-import wvlet.uni.control.Resource
+import wvlet.uni.control.Control
 
-Resource.withResource(openFile("data.txt")) { file =>
+Control.withResource(openFile("data.txt")) { file =>
   processFile(file)
 } // File is automatically closed
 ```
@@ -15,7 +15,7 @@ Resource.withResource(openFile("data.txt")) { file =>
 ## Multiple Resources
 
 ```scala
-Resource.withResources(
+Control.withResources(
   openDatabase(),
   openFile("config.txt")
 ) { (db, file) =>
@@ -30,7 +30,7 @@ Works with any `AutoCloseable`:
 ```scala
 import java.io.{BufferedReader, FileReader}
 
-Resource.withResource(BufferedReader(FileReader("data.txt"))) { reader =>
+Control.withResource(BufferedReader(FileReader("data.txt"))) { reader =>
   reader.lines().forEach(println)
 }
 ```
@@ -38,9 +38,9 @@ Resource.withResource(BufferedReader(FileReader("data.txt"))) { reader =>
 ## Nested Resources
 
 ```scala
-Resource.withResource(openConnection()) { conn =>
-  Resource.withResource(conn.createStatement()) { stmt =>
-    Resource.withResource(stmt.executeQuery(sql)) { rs =>
+Control.withResource(openConnection()) { conn =>
+  Control.withResource(conn.createStatement()) { stmt =>
+    Control.withResource(stmt.executeQuery(sql)) { rs =>
       processResultSet(rs)
     }
   }
@@ -53,7 +53,7 @@ Resources are closed even if an exception occurs:
 
 ```scala
 try
-  Resource.withResource(openFile("data.txt")) { file =>
+  Control.withResource(openFile("data.txt")) { file =>
     if someCondition then
       throw RuntimeException("Processing failed")
     processFile(file)
@@ -78,7 +78,7 @@ class DatabasePool extends AutoCloseable:
     // Release all connections
     connections.foreach(_.close())
 
-Resource.withResource(DatabasePool()) { pool =>
+Control.withResource(DatabasePool()) { pool =>
   val conn = pool.getConnection()
   // Use connection
 }
@@ -93,7 +93,7 @@ import wvlet.uni.rx.Rx
 
 def readLines(path: String): Rx[String] =
   Rx.single {
-    Resource.withResource(scala.io.Source.fromFile(path)) { source =>
+    Control.withResource(scala.io.Source.fromFile(path)) { source =>
       source.getLines().toList
     }
   }.flatMap(lines => Rx.fromSeq(lines))
@@ -105,7 +105,7 @@ The `withResource` method implements the loan pattern:
 
 ```scala
 def withDatabase[T](f: Database => T): T =
-  Resource.withResource(Database.connect()) { db =>
+  Control.withResource(Database.connect()) { db =>
     f(db)
   }
 

--- a/docs/core/json.md
+++ b/docs/core/json.md
@@ -5,7 +5,7 @@ uni includes a pure Scala JSON parser with a convenient DSL for querying and man
 ## Parsing JSON
 
 ```scala
-import wvlet.uni.json.JSON
+import wvlet.uni.json.*
 
 val jsonString = """
 {


### PR DESCRIPTION
The Book's authoring guide says every non-illustrative snippet must compile against the current `uni` — but nothing enforced it, so the examples could silently drift as the API evolves. This adds a **`book-examples`** module that makes the book self-verifying, and fixes the drift that compiling immediately surfaced.

## The module

A JVM-only `book-examples` project (mirrors the existing `netty` project pattern; `publish / skip`, aggregated into the JVM build so CI compiles it). One source file per JVM-runnable chapter — Design, Logging, Data, Rx, Control, HTTP, RPC — using the same APIs as the chapter's snippets. Examples are compiled, not run (servers configured but not started); `Ch04TestingTest` is a real `UniTest` suite that also runs.

```
./sbt bookExamples/Test/compile   # compiles every example
./sbt bookExamples/test           # 3/3 pass
```

(Chapters 12–15 — Scala.js/Vite and Scala Native FFI — need the JS/Native toolchains and external bundlers, so they're verified against their reference sources instead, as the README notes.)

## Doc bugs it caught — all fixed here

1. **`Resource.withResource` does not exist.** The real API is **`Control.withResource`** / `Control.withResources`. Fixed in the book (ch08) and `control/resource.md` (was wrong in 10 places).
2. **The JSON access DSL needs `import wvlet.uni.json.*`.** `json("user")("name").toStringValue` and `json / "k"` are implicit-class extensions in `package object json`; `import wvlet.uni.json.JSON` doesn't bring them into scope. Fixed in the book (ch06) and `core/json.md`.

These are exactly the kind of copy-paste-breaking errors the module now prevents.

`pnpm docs:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)