### PR TITLE
docs(book): Add diagrams for the trickiest mental models (dependency-free)

### DIFF
--- a/docs/book/ch03-00-design.md
+++ b/docs/book/ch03-00-design.md
@@ -161,6 +161,18 @@ same mechanism. For a type that is already `AutoCloseable`, Design can
 call `close()` for you; the [lifecycle reference](/core/design#lifecycle-management)
 lists every hook and the order they fire in.
 
+```text
+design.build[App] { app => … }
+   │
+   ├─ construct the graph (dependencies first)
+   ├─ onStart hooks run
+   │
+   ├──▶  your block runs            (the body of build { })
+   │
+   ├─ onShutdown hooks run          (even if the block threw)
+   └─ session closed
+```
+
 When you need the session itself — to open short-lived **child
 sessions**, say, one per web request, while singletons live for the whole
 process — use `design.withSession { session => … }` instead of `build`.

--- a/docs/book/ch10-00-rpc.md
+++ b/docs/book/ch10-00-rpc.md
@@ -55,6 +55,16 @@ Each method becomes a `POST /UserService/{methodName}` endpoint. You
 never chose those paths — they fall out of the trait, which is the point:
 there is no path for the client and server to disagree about.
 
+```text
+                  trait UserService          ← the one contract
+                 ╱                 ╲
+     RPCRouter.of[T](impl)      generated client
+         (server side)            (caller side)
+                 ╲                 ╱
+            POST /UserService/getUser
+             (MessagePack on the wire)
+```
+
 ## Call it like a local method
 
 On the client side, the `sbt-uni` plugin generates a typed client from

--- a/docs/book/ch11-00-cross-platform.md
+++ b/docs/book/ch11-00-cross-platform.md
@@ -45,6 +45,16 @@ three times. The `.jvm` / `.js` / `.native` folders hold only the code
 that *must* differ per platform. If you never need them, you never create
 them — and most application logic never does.
 
+```text
+                src/main/scala/      ← shared logic, compiled 3×
+                       │
+      ┌────────────────┼────────────────┐
+    + .jvm/          + .js/           + .native/   ← platform-only code
+      ▼                ▼                ▼
+     JVM            Scala.js        Scala Native
+  (Netty, JDK)   (browser, Node)   (native binary)
+```
+
 ## Why most code doesn't care
 
 The reason the shared folder stays large is that Uni already wraps the


### PR DESCRIPTION
Adds diagrams where a picture clarifies a *flow* the prose can only walk through linearly:

- **Ch 3** — the Design **session lifecycle** (build → `onStart` → your block → `onShutdown` → close).
- **Ch 10** — one RPC **trait as the shared contract** feeding both the server (`RPCRouter.of`) and the generated client.
- **Ch 11** — one **source set fanning out** to three platform builds.

## Why ASCII, not Mermaid

I tried `vitepress-plugin-mermaid` first, but it only declares support for VitePress **1.x** and the site runs VitePress **2.0-alpha** (unmet peer dependency). Adding it would risk the `--frozen-lockfile` CI build for no compatibility guarantee, so these are fenced `text` blocks instead — they render everywhere with **zero new dependencies**. If the site later moves to a Mermaid-compatible VitePress, these are easy to upgrade.

`pnpm docs:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)