### PR TITLE
docs: Use sequence diagrams for the Electron IPC flow

### DIFF
--- a/docs/http/electron-tutorial.md
+++ b/docs/http/electron-tutorial.md
@@ -14,20 +14,15 @@ to the main process. For the API reference behind each piece, see [Desktop Apps
 Electron runs three contexts; Uni occupies two and a tiny hand-written script bridges the third:
 
 ```mermaid
-flowchart LR
-  subgraph R["Renderer · Chromium"]
-    A["RendererApp · Scala.js<br/>ElectronRenderer.install<br/>Http.client.newAsyncClient"]
-  end
-  subgraph PL["Preload"]
-    B["contextBridge<br/>window.uniRPC.request"]
-  end
-  subgraph M["Main · Node.js"]
-    C["MainProcess · Scala.js<br/>ElectronRPCServer.serve ipcMain<br/>CounterApiImpl"]
-  end
-  A -- "request payload" --> B
-  B -- "ipcRenderer.invoke uni-rpc" --> C
-  C -. "response payload" .-> B
-  B -. "Promise" .-> A
+sequenceDiagram
+    participant R as Renderer · Scala.js
+    participant P as Preload bridge
+    participant M as Main · Scala.js
+    R->>P: window.uniRPC.request(payload)
+    P->>M: ipcRenderer.invoke('uni-rpc', payload)
+    Note over M: ElectronRPCServer.serve(ipcMain)<br/>RPCRouter.of CounterApi → CounterApiImpl
+    M-->>P: response payload
+    P-->>R: Promise resolves
 ```
 
 ## Prerequisites

--- a/docs/http/electron.md
+++ b/docs/http/electron.md
@@ -18,20 +18,16 @@ directory. This page is the API reference for what the tutorial wires together.
 Electron runs three contexts. Uni occupies two of them; the third is a tiny hand-written bridge:
 
 ```mermaid
-flowchart LR
-  subgraph R["Renderer · Chromium"]
-    A["RPC client<br/>Http.client.newAsyncClient<br/>ElectronRenderer.install"]
-  end
-  subgraph PL["Preload"]
-    B["contextBridge<br/>window.uniRPC.request"]
-  end
-  subgraph M["Main · Node.js"]
-    C["ElectronRPCServer.serve ipcMain<br/>RPCDispatcher → RPCRouter<br/>your service impl"]
-  end
-  A -- "request payload" --> B
-  B -- "ipcRenderer.invoke uni-rpc" --> C
-  C -. "response payload" .-> B
-  B -. "Promise" .-> A
+sequenceDiagram
+    participant R as Renderer · Chromium
+    participant P as Preload bridge
+    participant M as Main · Node.js
+    Note over R: ElectronRenderer.install()<br/>Http.client.newAsyncClient
+    R->>P: window.uniRPC.request(payload)
+    P->>M: ipcRenderer.invoke('uni-rpc', payload)
+    Note over M: RPCDispatcher → RPCRouter<br/>your service impl
+    M-->>P: response payload
+    P-->>R: Promise resolves
 ```
 
 - **Renderer** serializes each RPC request to a plain object and calls the preload bridge.

--- a/examples/electron-app/README.md
+++ b/examples/electron-app/README.md
@@ -5,20 +5,15 @@ A minimal [Electron](https://www.electronjs.org/) desktop app built with **Uni +
 no HTTP server, no open ports.
 
 ```mermaid
-flowchart LR
-  subgraph R["Renderer · Chromium"]
-    A["RendererApp · Scala.js<br/>ElectronRenderer.install<br/>Http.client.newAsyncClient"]
-  end
-  subgraph PL["Preload · contextBridge"]
-    B["window.uniRPC.request"]
-  end
-  subgraph M["Main · Node.js"]
-    C["MainProcess · Scala.js<br/>ElectronRPCServer.serve<br/>RPCRouter.of CounterApi → CounterApiImpl"]
-  end
-  A -- "request payload" --> B
-  B -- "ipcRenderer.invoke uni-rpc" --> C
-  C -. "response payload" .-> B
-  B -. "Promise" .-> A
+sequenceDiagram
+    participant R as Renderer · Scala.js
+    participant P as Preload · contextBridge
+    participant M as Main · Scala.js
+    R->>P: window.uniRPC.request(payload)
+    P->>M: ipcRenderer.invoke('uni-rpc', payload)
+    Note over M: ElectronRPCServer.serve<br/>RPCRouter.of CounterApi → CounterApiImpl
+    M-->>P: response payload
+    P-->>R: Promise resolves
 ```
 
 The same `CounterApi` trait (in `api/`) is shared by both sides: the main process *implements* it,


### PR DESCRIPTION
## Summary

Follow-up to #610. The horizontal Mermaid flowcharts rendered **too small** in VitePress's width-limited content column.

The renderer↔preload↔main exchange is really a **request/response sequence**, so this switches the three diagrams to `sequenceDiagram`:
- Lays out **vertically** → fits the narrow content column (docs have plenty of vertical space).
- Reads top-to-bottom in call order, making the IPC round-trip explicit (request → `ipcRenderer.invoke` → dispatch → response → Promise).

No site-wide changes (no column widening, no zoom plugin) — the fix is just the right diagram type for the content.

Applied to:
- `docs/http/electron.md` (reference)
- `docs/http/electron-tutorial.md` (tutorial)
- `examples/electron-app/README.md` (GitHub renders it natively)

## Verification

`pnpm docs:build` passes; `sequenceDiagram` and the (URL-encoded) message text are bundled into the page chunks for client-side rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)