### PR TITLE
feature: Multi-layer testing foundation — UI (fireEvent) + Electron (ElectronTestbed) test layers

### DIFF
--- a/plans/2026-06-27-multi-layer-testing.md
+++ b/plans/2026-06-27-multi-layer-testing.md
@@ -54,11 +54,17 @@ get it for free:
 - New tests that actually drive interaction (button click increments a counter, typing into
   an input updates reactive state) to prove the toolkit and close the biggest gap.
 
-### PR 2 — Electron integration test harness
-Promote the fake-IPC scaffolding from `ElectronRPCTest` into a reusable
-`wvlet.uni.electron.testing` harness (in-memory IPC pair: server + renderer channel) so apps
-can integration-test their `CounterApi`-style services without a real Electron runtime. Add
-tests to `examples/electron-app` using it.
+### PR 2 — Electron integration test harness  ✅ done (this branch)
+Promoted the fake-IPC scaffolding from `ElectronRPCTest` into a reusable
+`wvlet.uni.electron.testing.ElectronTestbed` (in the published `uni` JS artifact): an
+in-memory `ipcMain` + preload-bridge pair that routes renderer requests to served routers,
+mirroring the renderer→main hop with no Electron runtime. Provides `serve(routers*)`,
+`bridge(channel)`, `channelFactory(channel)`, and `newAsyncClient`. `ElectronRPCTest` now
+dogfoods it; `ElectronTestbedTest` adds a stateful `CounterApi` integration test +
+unserved-channel error case.
+
+Follow-up: wire `ElectronTestbed` into the `examples/electron-app` so the reference app ships
+with an integration test.
 
 ### PR 3 — uni-test layer ergonomics
 Add **test tags** to `UniTest` (e.g. `test("...", tags = Seq("ui"))`) + sbt filtering, so the

--- a/plans/2026-06-27-multi-layer-testing.md
+++ b/plans/2026-06-27-multi-layer-testing.md
@@ -1,0 +1,77 @@
+# Multi-layer testing for rich desktop apps (VSCode-style)
+
+Goal: make Uni a foundation for building rich desktop apps that are testable at every
+layer, mirroring VSCode's testing strategy. Provide first-class support for four layers:
+
+1. **Unit tests** — pure logic, no DOM/Electron, run on JVM/JS/Native.
+2. **UI (component) tests** — render `uni-dom` components in a real browser DOM, simulate
+   user interaction (click/keyboard/input), assert on rendered output.
+3. **Electron (integration) tests** — exercise RPC-over-IPC and main/renderer wiring.
+4. **Plugin tests** — load and test pluggable extensions/contributions in isolation.
+
+## How VSCode does it (reference model)
+
+| VSCode layer        | Tooling                         | What it proves                                  |
+| ------------------- | ------------------------------- | ----------------------------------------------- |
+| Unit                | Mocha, no `vscode` API, no DOM  | individual functions/classes in isolation       |
+| Integration         | `@vscode/test-electron`         | extension API in a real extension-host runtime  |
+| UI / Smoke          | Playwright drives real Electron | full user flows, simulated input, screenshots   |
+| Extension (plugin)  | activated in a test host        | contributions, activation events, commands      |
+
+Key principle: a **testing pyramid** — many fast unit tests, fewer component/UI tests,
+fewest full end-to-end tests. Each layer has ergonomic, purpose-built helpers so authors
+write the *cheapest* test that still proves the behavior.
+
+## Current state in Uni (2026-06-27)
+
+- **Unit** — strong. `wvlet.uni.test.UniTest` (AirSpec-style): assertions, async (`Future`/`Rx`),
+  property checks, lifecycle hooks, flaky handling, nested tests, JUnit-platform IDE integration.
+  Runs on JVM/JS/Native.
+- **UI** — partial. `uni-dom` is a full reactive DOM library; `uni-dom-test` runs in real
+  headless Chromium (Playwright). But tests can only *construct* and `renderTo`, then read
+  `textContent`. **No event simulation** (no click/keyboard/input dispatch), and the mount +
+  cleanup boilerplate is copy-pasted in every test.
+- **Electron** — `wvlet.uni.electron` RPC-over-IPC transport is unit-tested with *fake* IPC
+  objects (`ElectronRPCTest`). The `examples/electron-app` has **zero tests**.
+- **Plugin** — no plugin/extension model exists yet.
+
+Gaps map cleanly onto the layers above: UI needs interaction, Electron needs a reusable
+harness, plugin needs a model + harness first.
+
+## Deliverables (incremental PRs)
+
+### PR 1 — UI test toolkit (this PR)  ✅ in progress
+Ship `wvlet.uni.dom.testing` in the **main** `uni` JS artifact so downstream desktop apps
+get it for free:
+- `mount(element)` → `Mounted` handle: detached container appended to `document.body`,
+  rendered via `DomRenderer`, with `unmount()`/`AutoCloseable` cleanup.
+- `fireEvent` — Testing-Library-style event simulation: `click`, `dblclick`, mouse/pointer,
+  `input(el, value)`, `change`, `keyDown/keyUp/keyPress`, `submit`, `focus`/`blur`, `custom`.
+- Query helpers (`Query` / on `Mounted`): `getByText`/`queryByText`, `getByTestId`,
+  `querySelector(All)` wrappers returning `Option`/`Seq`.
+- `DomTestSession` — framework-agnostic mount-tracker with `cleanupMounted()`.
+- `DomTestSupport` (in `uni-dom-test`) wires `DomTestSession` into `UniTest.after`.
+- New tests that actually drive interaction (button click increments a counter, typing into
+  an input updates reactive state) to prove the toolkit and close the biggest gap.
+
+### PR 2 — Electron integration test harness
+Promote the fake-IPC scaffolding from `ElectronRPCTest` into a reusable
+`wvlet.uni.electron.testing` harness (in-memory IPC pair: server + renderer channel) so apps
+can integration-test their `CounterApi`-style services without a real Electron runtime. Add
+tests to `examples/electron-app` using it.
+
+### PR 3 — uni-test layer ergonomics
+Add **test tags** to `UniTest` (e.g. `test("...", tags = Seq("ui"))`) + sbt filtering, so the
+four layers can be selected/excluded in CI. Optionally per-test timeouts.
+
+### PR 4 — Plugin model + plugin test harness
+Design a minimal plugin/extension contract (activation, contribution registry, isolated
+lifecycle) and a `loadPluginForTest(...)` harness. Largest, designed last.
+
+## Notes / decisions
+- Toolkit ships in main `uni.js` (no dependency on `uni-test`) so it is reusable in any
+  context; only the `UniTest`-coupled `DomTestSupport` mixin lives in test scope.
+- Rx propagation in `uni-dom` is synchronous, so `fireEvent` + assertion can be synchronous
+  for the common case; async helpers (`findBy*`) added only where needed.
+- Follow-up: consider a published `uni-dom-testkit` module so downstream apps can reuse
+  `DomTestSupport` directly instead of re-declaring the 3-line trait.

--- a/uni-dom-test/src/test/scala/wvlet/uni/dom/testing/DomTestSupport.scala
+++ b/uni-dom-test/src/test/scala/wvlet/uni/dom/testing/DomTestSupport.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom.testing
+
+import wvlet.uni.test.UniTest
+
+/**
+  * Mix into a `UniTest` to render and interact with `uni-dom` components in the headless browser.
+  *
+  * Use `mount(element)` to render; every mounted element is automatically unmounted after each test
+  * via the `after` hook, so tests stay isolated. `fireEvent` and the query helpers are available
+  * through the `wvlet.uni.dom.testing.*` import.
+  *
+  * {{{
+  *   class MyUiTest extends UniTest with DomTestSupport:
+  *     test("clicking +1 increments the counter"):
+  *       val m = mount(Counter())
+  *       fireEvent.click(m.getByText("+1"))
+  *       m.text shouldContain "count=1"
+  * }}}
+  *
+  * This 3-line trait lives in test scope on purpose (it couples `DomTestSession` from the published
+  * `uni` artifact to the `uni-test` framework). Downstream desktop apps can declare the identical
+  * trait, or depend on a future `uni-dom-testkit` module.
+  */
+trait DomTestSupport extends UniTest with DomTestSession:
+  override protected def after: Unit =
+    cleanupMounted()
+    super.after

--- a/uni-dom-test/src/test/scala/wvlet/uni/dom/testing/InteractionTest.scala
+++ b/uni-dom-test/src/test/scala/wvlet/uni/dom/testing/InteractionTest.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom.testing
+
+import wvlet.uni.test.UniTest
+import wvlet.uni.rx.Rx
+import wvlet.uni.dom.RxElement
+import wvlet.uni.dom.all.*
+import wvlet.uni.dom.all.given
+import org.scalajs.dom
+import scala.language.implicitConversions
+
+/**
+  * End-to-end UI interaction tests: render a real `uni-dom` component into a headless Chromium DOM,
+  * dispatch real user events with [[fireEvent]], and assert on the reactively re-rendered output.
+  *
+  * This is the gap the toolkit closes — previously DOM tests could only `renderTo` and read text,
+  * never simulate a click or keystroke.
+  */
+class InteractionTest extends UniTest with DomTestSupport:
+
+  test("clicking a button updates reactive state"):
+    val count = Rx.variable(0)
+
+    class Counter extends RxElement:
+      override def render: RxElement = div(
+        span(cls -> "count", count.map(c => s"count=${c}")),
+        button(
+          cls     -> "inc",
+          onclick -> { () =>
+            count := count.get + 1
+          },
+          "+1"
+        ),
+        button(
+          cls     -> "dec",
+          onclick -> { () =>
+            count := count.get - 1
+          },
+          "-1"
+        )
+      )
+
+    val m = mount(Counter())
+    m.text shouldContain "count=0"
+
+    fireEvent.click(m.getByText("+1"))
+    m.text shouldContain "count=1"
+
+    fireEvent.click(m.getByText("+1"))
+    fireEvent.click(m.getByText("+1"))
+    m.text shouldContain "count=3"
+
+    fireEvent.click(m.getByText("-1"))
+    m.text shouldContain "count=2"
+
+  test("typing into an input drives a two-way bound RxVar"):
+    val name = Rx.variable("")
+
+    class Greeter extends RxElement:
+      override def render: RxElement = div(
+        input(tpe -> "text", value.bind(name)),
+        span(
+          cls -> "greeting",
+          name.map(n =>
+            if n.isEmpty then
+              "Hello, stranger"
+            else
+              s"Hello, ${n}"
+          )
+        )
+      )
+
+    val m = mount(Greeter())
+    m.text shouldContain "Hello, stranger"
+
+    val inputEl = m.query.get("input")
+    fireEvent.input(inputEl, "Uni")
+    name.get shouldBe "Uni"
+    m.text shouldContain "Hello, Uni"
+
+  test("keyboard events reach onkeydown handlers"):
+    val lastKey = Rx.variable("")
+
+    class KeyCapture extends RxElement:
+      override def render: RxElement = div(
+        tabindex  -> "0",
+        onkeydown -> { (e: dom.KeyboardEvent) =>
+          lastKey := e.key
+        },
+        span(cls -> "last", lastKey.map(k => s"key=${k}"))
+      )
+
+    val m    = mount(KeyCapture())
+    val root = m.root.get
+    fireEvent.keyDown(root, key = "Enter")
+    lastKey.get shouldBe "Enter"
+    m.text shouldContain "key=Enter"
+
+  test("getByText returns the deepest matching element, not an ancestor"):
+    class Nested extends RxElement:
+      override def render: RxElement = div(cls -> "outer", span(cls -> "inner", "Save"))
+
+    val m   = mount(Nested())
+    val hit = m.getByText("Save")
+    hit.getAttribute("class") shouldBe "inner"
+
+  test("queryByText returns None when no element matches"):
+    val m = mount(RxElement(div("hello")))
+    m.queryByText("goodbye") shouldBe None
+
+  test("unmount detaches the container and runs cleanup"):
+    val m         = mount(RxElement(div(cls -> "ephemeral", "bye")))
+    val container = m.container
+    (container.parentNode != null) shouldBe true
+    m.unmount()
+    (container.parentNode == null) shouldBe true
+
+end InteractionTest

--- a/uni-dom-test/src/test/scala/wvlet/uni/dom/testing/QueryTest.scala
+++ b/uni-dom-test/src/test/scala/wvlet/uni/dom/testing/QueryTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom.testing
+
+import wvlet.uni.test.UniTest
+import wvlet.uni.dom.RxElement
+import wvlet.uni.dom.all.*
+import wvlet.uni.dom.all.given
+import scala.language.implicitConversions
+
+class QueryTest extends UniTest with DomTestSupport:
+
+  test("getByTestId finds an element by data-testid"):
+    val m = mount(RxElement(div(data("testid") -> "save-button", button("Save"))))
+    m.getByTestId("save-button").textContent shouldBe "Save"
+
+  test("queryByTestId returns None for a missing id"):
+    val m = mount(RxElement(div("x")))
+    m.queryByTestId("nope") shouldBe None
+
+  test("queryAllByTestId returns every match"):
+    val m = mount(
+      RxElement(
+        div(
+          span(data("testid") -> "row", "a"),
+          span(data("testid") -> "row", "b"),
+          span(data("testid") -> "row", "c")
+        )
+      )
+    )
+    m.queryAllByTestId("row").map(_.textContent) shouldBe Seq("a", "b", "c")
+
+  test("getByText accepts a regex matcher"):
+    val m = mount(RxElement(div(span("Order #1234 shipped"))))
+    m.getByText("Order #\\d+ shipped".r).textContent shouldBe "Order #1234 shipped"
+
+  test("queryAll wraps querySelectorAll as a Seq"):
+    val m = mount(RxElement(ul(li("one"), li("two"))))
+    m.queryAll("li").map(_.textContent) shouldBe Seq("one", "two")
+
+  test("get throws ElementNotFoundException for an absent selector"):
+    val m = mount(RxElement(div("x")))
+    intercept[ElementNotFoundException] {
+      m.query.get(".missing")
+    }
+
+  test("getByText trims surrounding whitespace before matching"):
+    val m = mount(RxElement(div(span("   trimmed   "))))
+    m.getByText("trimmed").textContent.trim shouldBe "trimmed"
+
+end QueryTest

--- a/uni/.js/src/main/scala/wvlet/uni/dom/testing/DomTestSession.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/testing/DomTestSession.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom.testing
+
+import wvlet.uni.dom.RxElement
+import scala.collection.mutable.ListBuffer
+
+/**
+  * A framework-agnostic mixin that tracks [[Mounted]] elements so they can be unmounted together.
+  *
+  * Mount through this trait's [[mount]] instead of the top-level one, then call [[cleanupMounted]]
+  * once per test to detach every container and run Rx cleanup — leaving `document.body` clean for
+  * the next test, so tests don't leak DOM into one another.
+  *
+  * It is deliberately decoupled from `UniTest` (which lives in a separate module) so it can be
+  * reused from any test framework. The `uni-dom-test` module provides `DomTestSupport`, which wires
+  * this into `UniTest.after`.
+  */
+trait DomTestSession:
+  private val mountedElements = ListBuffer.empty[Mounted]
+
+  /** Mount an element and register it for automatic cleanup by [[cleanupMounted]]. */
+  def mount(element: RxElement): Mounted =
+    val m = DomTesting.mount(element)
+    mountedElements += m
+    m
+
+  /** Unmount every element mounted through this session, in reverse order. */
+  def cleanupMounted(): Unit =
+    mountedElements
+      .reverseIterator
+      .foreach { m =>
+        try
+          m.unmount()
+        catch
+          case _: Throwable =>
+            () // best-effort cleanup; never fail a test on teardown
+      }
+    mountedElements.clear()

--- a/uni/.js/src/main/scala/wvlet/uni/dom/testing/DomTesting.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/testing/DomTesting.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom.testing
+
+import org.scalajs.dom
+import wvlet.uni.dom.{DomRenderer, RxElement}
+
+/**
+  * UI (component) testing toolkit for `uni-dom` — the second layer of Uni's testing pyramid (unit →
+  * UI → Electron → plugin).
+  *
+  * Renders reactive elements into a real browser DOM, simulates user interaction via [[fireEvent]],
+  * and queries the result via [[Query]] helpers. Designed to run in a real headless browser
+  * (Chromium via Playwright), which is also the Electron renderer, so the same tests cover web and
+  * desktop UI.
+  *
+  * {{{
+  *   import wvlet.uni.dom.all.*
+  *   import wvlet.uni.dom.testing.*
+  *
+  *   val m = mount(MyCounter())
+  *   fireEvent.click(m.getByText("+1"))
+  *   m.text shouldContain "count=1"
+  *   m.unmount()
+  * }}}
+  *
+  * In a `UniTest`, mix in `wvlet.uni.dom.testing.DomTestSupport` (in `uni-dom-test`) so mounted
+  * elements are cleaned up automatically after each test.
+  */
+object DomTesting:
+
+  /**
+    * Render a reactive element into a fresh container in `document.body` and return a [[Mounted]]
+    * handle for querying and interacting with it. Remember to [[Mounted.unmount]] when done (or use
+    * [[DomTestSession]] / `DomTestSupport` for automatic cleanup).
+    */
+  def mount(element: RxElement): Mounted =
+    val container = dom.document.createElement("div")
+    container.setAttribute("data-uni-test-container", "true")
+    dom.document.body.appendChild(container)
+    val cancelable = DomRenderer.renderTo(container, element)
+    Mounted(container, cancelable)
+
+end DomTesting
+
+/** Convenience top-level `mount` so `import wvlet.uni.dom.testing.*` exposes it directly. */
+def mount(element: RxElement): Mounted = DomTesting.mount(element)

--- a/uni/.js/src/main/scala/wvlet/uni/dom/testing/Mounted.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/testing/Mounted.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom.testing
+
+import org.scalajs.dom
+import wvlet.uni.rx.Cancelable
+
+/**
+  * A handle to a `uni-dom` element rendered into a live (headless-browser) DOM for testing.
+  *
+  * The element is rendered into a fresh `<div>` container appended to `document.body`, so queries
+  * and events behave exactly as they would in a running app. Call [[unmount]] (or use it as an
+  * `AutoCloseable`) to detach the container and run Rx cleanup; [[DomTestSession]] does this
+  * automatically after each test.
+  *
+  * Query methods are delegated from [[Query]], so `mounted.getByText("Save")` works directly.
+  */
+class Mounted(val container: dom.Element, private val cancelable: Cancelable) extends AutoCloseable:
+
+  private val q: Query = Query(container)
+
+  /** The first rendered element (the root of the mounted component), if any. */
+  def root: Option[dom.Element] = Option(container.firstElementChild)
+
+  /** The concatenated text content of the rendered subtree. */
+  def text: String = container.textContent
+
+  /** The inner HTML of the container (useful for debugging failed assertions). */
+  def html: String = container.innerHTML
+
+  /** Query helpers scoped to this mounted subtree. */
+  def query: Query = q
+
+  // Expose Query's getBy/queryBy methods directly on the handle.
+  export q.{
+    queryAll,
+    query as querySelector,
+    get,
+    queryAllByTestId,
+    queryByTestId,
+    getByTestId,
+    queryAllByText,
+    queryByText,
+    getByText
+  }
+
+  /** Detach the container from the DOM and cancel all Rx subscriptions. Idempotent. */
+  def unmount(): Unit =
+    cancelable.cancel
+    if container.parentNode != null then
+      container.parentNode.removeChild(container)
+
+  override def close(): Unit = unmount()
+
+end Mounted

--- a/uni/.js/src/main/scala/wvlet/uni/dom/testing/Query.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/testing/Query.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom.testing
+
+import org.scalajs.dom
+
+/**
+  * Query a rendered DOM subtree for elements, modeled on Testing Library's queries.
+  *
+  * Two flavors per selector:
+  *   - `queryBy...` returns `Option`/`Seq` (absence is not an error)
+  *   - `getBy...` returns the element or throws [[ElementNotFoundException]] (use in assertions
+  *     where the element must exist)
+  */
+class Query(val root: dom.Element):
+
+  // --- Raw CSS selectors ---
+
+  def queryAll(selector: String): Seq[dom.Element] =
+    val nodes = root.querySelectorAll(selector)
+    (0 until nodes.length).map(i => nodes(i).asInstanceOf[dom.Element])
+
+  def query(selector: String): Option[dom.Element] = Option(root.querySelector(selector))
+
+  def get(selector: String): dom.Element = query(selector).getOrElse(
+    throw ElementNotFoundException(s"No element matches selector: ${selector}")
+  )
+
+  // --- data-testid ---
+
+  def queryAllByTestId(testId: String): Seq[dom.Element] = queryAll(s"[data-testid='${testId}']")
+
+  def queryByTestId(testId: String): Option[dom.Element] = queryAllByTestId(testId).headOption
+
+  def getByTestId(testId: String): dom.Element = queryByTestId(testId).getOrElse(
+    throw ElementNotFoundException(s"No element with data-testid='${testId}'")
+  )
+
+  // --- text content ---
+
+  /**
+    * All elements whose trimmed text matches and that have no descendant element with the same
+    * matching text (i.e. the deepest/most-specific matches), so `getByText("Save")` returns the
+    * `<button>` rather than an enclosing `<div>`.
+    */
+  def queryAllByText(matcher: TextMatcher): Seq[dom.Element] =
+    val all = queryAll("*").filter(e => matcher.matches(e.textContent))
+    all.filterNot(e => all.exists(other => (other ne e) && e.contains(other)))
+
+  def queryByText(matcher: TextMatcher): Option[dom.Element] = queryAllByText(matcher).headOption
+
+  def getByText(matcher: TextMatcher): dom.Element = queryByText(matcher).getOrElse(
+    throw ElementNotFoundException(s"No element with text matching: ${matcher}")
+  )
+
+end Query
+
+/** A matcher for element text, accepting an exact `String` or a `Regex`. */
+trait TextMatcher:
+  def matches(text: String): Boolean
+
+object TextMatcher:
+  import scala.language.implicitConversions
+
+  /** Exact match against the element's trimmed text content. */
+  given fromString: Conversion[String, TextMatcher] with
+    def apply(expected: String): TextMatcher =
+      new TextMatcher:
+        def matches(text: String): Boolean = text.trim == expected
+        override def toString: String      = s"\"${expected}\""
+
+  /** Regex match against the element's trimmed text content. */
+  given fromRegex: Conversion[scala.util.matching.Regex, TextMatcher] with
+    def apply(re: scala.util.matching.Regex): TextMatcher =
+      new TextMatcher:
+        def matches(text: String): Boolean = re.findFirstIn(text.trim).isDefined
+        override def toString: String      = s"/${re}/"
+
+/** Thrown by `getBy...` queries when no matching element is found. */
+class ElementNotFoundException(message: String) extends RuntimeException(message)

--- a/uni/.js/src/main/scala/wvlet/uni/dom/testing/fireEvent.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/dom/testing/fireEvent.scala
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.dom.testing
+
+import org.scalajs.dom
+import scala.scalajs.js
+
+/**
+  * Simulate DOM events for UI testing, modeled on Testing Library's `fireEvent`.
+  *
+  * Events are dispatched with `bubbles = true` and `cancelable = true` so they propagate to
+  * delegated handlers the way real user input does. Each method returns the boolean result of
+  * `dispatchEvent` (false if a handler called `preventDefault`).
+  *
+  * Example:
+  * {{{
+  *   import wvlet.uni.dom.testing.*
+  *   val m = mount(MyCounter())
+  *   fireEvent.click(m.getByText("+1"))
+  *   m.text shouldContain "count=1"
+  * }}}
+  */
+object fireEvent:
+
+  /** Dispatch an already-constructed event to the target. */
+  def dispatch(target: dom.EventTarget, event: dom.Event): Boolean = target.dispatchEvent(event)
+
+  // --- Mouse / pointer ---
+
+  def click(target: dom.EventTarget): Boolean       = dispatch(target, mouseEvent("click"))
+  def dblclick(target: dom.EventTarget): Boolean    = dispatch(target, mouseEvent("dblclick"))
+  def mouseDown(target: dom.EventTarget): Boolean   = dispatch(target, mouseEvent("mousedown"))
+  def mouseUp(target: dom.EventTarget): Boolean     = dispatch(target, mouseEvent("mouseup"))
+  def mouseOver(target: dom.EventTarget): Boolean   = dispatch(target, mouseEvent("mouseover"))
+  def mouseOut(target: dom.EventTarget): Boolean    = dispatch(target, mouseEvent("mouseout"))
+  def mouseMove(target: dom.EventTarget): Boolean   = dispatch(target, mouseEvent("mousemove"))
+  def contextMenu(target: dom.EventTarget): Boolean = dispatch(target, mouseEvent("contextmenu"))
+
+  private def mouseEvent(eventType: String): dom.MouseEvent =
+    val init = js
+      .Dynamic
+      .literal(bubbles = true, cancelable = true)
+      .asInstanceOf[dom.MouseEventInit]
+    new dom.MouseEvent(eventType, init)
+
+  // --- Form input ---
+
+  /**
+    * Set the `value` of an input/textarea/select and dispatch an `input` event, mirroring a user
+    * typing into the field. Use this for elements bound with `value <-> rxVar` two-way bindings.
+    */
+  def input(target: dom.Element, value: String): Boolean =
+    setValue(target, value)
+    dispatch(target, simpleEvent("input"))
+
+  /**
+    * Set the `value` and dispatch a `change` event (fired by `<select>` and on blur for text
+    * inputs).
+    */
+  def change(target: dom.Element, value: String): Boolean =
+    setValue(target, value)
+    dispatch(target, simpleEvent("change"))
+
+  /** Toggle a checkbox/radio `checked` state and dispatch `input`+`change`. */
+  def setChecked(target: dom.Element, checked: Boolean): Boolean =
+    target match
+      case in: dom.html.Input =>
+        in.checked = checked
+      case _ =>
+    dispatch(target, simpleEvent("input"))
+    dispatch(target, simpleEvent("change"))
+
+  def submit(target: dom.EventTarget): Boolean = dispatch(target, simpleEvent("submit"))
+
+  private def setValue(target: dom.Element, value: String): Unit =
+    target match
+      case in: dom.html.Input =>
+        in.value = value
+      case ta: dom.html.TextArea =>
+        ta.value = value
+      case se: dom.html.Select =>
+        se.value = value
+      case _ =>
+        target.asInstanceOf[js.Dynamic].value = value
+
+  // --- Focus ---
+
+  def focus(target: dom.EventTarget): Boolean = dispatch(target, focusEvent("focus"))
+  def blur(target: dom.EventTarget): Boolean  = dispatch(target, focusEvent("blur"))
+
+  private def focusEvent(eventType: String): dom.FocusEvent =
+    // FocusEvent does not bubble per the spec, but focusin/focusout do. Keep bubbles=false here so
+    // tests reflect real focus semantics; handlers registered with `onfocus` still fire.
+    val init = js
+      .Dynamic
+      .literal(bubbles = false, cancelable = false)
+      .asInstanceOf[dom.FocusEventInit]
+    new dom.FocusEvent(eventType, init)
+
+  // --- Keyboard ---
+
+  def keyDown(
+      target: dom.EventTarget,
+      key: String,
+      code: String = "",
+      ctrlKey: Boolean = false,
+      shiftKey: Boolean = false,
+      altKey: Boolean = false,
+      metaKey: Boolean = false
+  ): Boolean = dispatch(
+    target,
+    keyboardEvent("keydown", key, code, ctrlKey, shiftKey, altKey, metaKey)
+  )
+
+  def keyUp(
+      target: dom.EventTarget,
+      key: String,
+      code: String = "",
+      ctrlKey: Boolean = false,
+      shiftKey: Boolean = false,
+      altKey: Boolean = false,
+      metaKey: Boolean = false
+  ): Boolean = dispatch(
+    target,
+    keyboardEvent("keyup", key, code, ctrlKey, shiftKey, altKey, metaKey)
+  )
+
+  def keyPress(
+      target: dom.EventTarget,
+      key: String,
+      code: String = "",
+      ctrlKey: Boolean = false,
+      shiftKey: Boolean = false,
+      altKey: Boolean = false,
+      metaKey: Boolean = false
+  ): Boolean = dispatch(
+    target,
+    keyboardEvent("keypress", key, code, ctrlKey, shiftKey, altKey, metaKey)
+  )
+
+  private def keyboardEvent(
+      eventType: String,
+      key: String,
+      code: String,
+      ctrlKey: Boolean,
+      shiftKey: Boolean,
+      altKey: Boolean,
+      metaKey: Boolean
+  ): dom.KeyboardEvent =
+    val init = js
+      .Dynamic
+      .literal(
+        bubbles = true,
+        cancelable = true,
+        key = key,
+        code =
+          if code.isEmpty then
+            key
+          else
+            code
+        ,
+        ctrlKey = ctrlKey,
+        shiftKey = shiftKey,
+        altKey = altKey,
+        metaKey = metaKey
+      )
+      .asInstanceOf[dom.KeyboardEventInit]
+    new dom.KeyboardEvent(eventType, init)
+
+  // --- Generic / custom ---
+
+  /** Dispatch a bubbling, cancelable `dom.Event` of the given type. */
+  def custom(target: dom.EventTarget, eventType: String): Boolean = dispatch(
+    target,
+    simpleEvent(eventType)
+  )
+
+  private def simpleEvent(eventType: String): dom.Event =
+    val init = js.Dynamic.literal(bubbles = true, cancelable = true).asInstanceOf[dom.EventInit]
+    new dom.Event(eventType, init)
+
+end fireEvent

--- a/uni/.js/src/main/scala/wvlet/uni/electron/testing/ElectronTestbed.scala
+++ b/uni/.js/src/main/scala/wvlet/uni/electron/testing/ElectronTestbed.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.electron.testing
+
+import wvlet.uni.electron.{ElectronChannelFactory, ElectronIPC, ElectronRPCServer}
+import wvlet.uni.http.{Http, HttpAsyncClient}
+import wvlet.uni.http.rpc.RPCRouter
+
+import scala.collection.mutable
+import scala.scalajs.js
+
+/**
+  * In-memory Electron IPC harness for **integration-testing RPC-over-IPC services without a real
+  * Electron runtime** — the third layer of Uni's testing pyramid (unit → UI → Electron → plugin).
+  *
+  * A testbed plays both sides of the Electron IPC boundary:
+  *   - [[ipcMain]] is a fake `ipcMain` you hand to [[ElectronRPCServer.serve]] (the main process).
+  *   - [[bridge]] is a fake preload bridge an [[ElectronChannelFactory]] calls (the renderer).
+  *
+  * Requests forwarded through [[bridge]] are routed to the handler that `serve` registered on the
+  * matching channel, exactly mirroring the renderer→main hop, so the full marshalling +
+  * `RPCDispatcher` path is exercised in a plain headless-browser/Node test.
+  *
+  * {{{
+  *   val testbed = ElectronTestbed.serve(RPCRouter.of[CounterApi](CounterApiImpl()))
+  *   val client  = testbed.newAsyncClient
+  *   rpcClient.callAsync[CounterState](client, "increment", Seq.empty).map { st =>
+  *     st.value shouldBe 1
+  *   }
+  * }}}
+  *
+  * Ships in the published `uni` JS artifact (no test-framework dependency) so Electron apps can
+  * reuse it directly.
+  */
+class ElectronTestbed:
+
+  private val handlers = mutable
+    .Map
+    .empty[String, js.Function2[js.Any, js.Any, js.Promise[js.Object]]]
+
+  /**
+    * A fake `ipcMain` to pass to [[ElectronRPCServer.serve]]. Its `handle(channel, fn)` records the
+    * handler per channel so [[bridge]] can dispatch to it.
+    */
+  val ipcMain: js.Dynamic = js
+    .Dynamic
+    .literal(handle =
+      (
+          (channel: js.Any, fn: js.Any) =>
+            handlers(channel.asInstanceOf[String]) = fn.asInstanceOf[
+              js.Function2[js.Any, js.Any, js.Promise[js.Object]]
+            ]
+      ): js.Function2[js.Any, js.Any, Unit]
+    )
+
+  /**
+    * A fake preload bridge for the given channel. Forwards `request(payload)` to the served handler
+    * and returns its `Promise`, just like `ipcRenderer.invoke(channel, payload)` would.
+    *
+    * @param channel
+    *   the IPC channel name; defaults to [[ElectronIPC.DefaultChannel]] (what `serve` uses by
+    *   default).
+    */
+  def bridge(channel: String = ElectronIPC.DefaultChannel): js.Dynamic = js
+    .Dynamic
+    .literal(request =
+      (
+          (payload: js.Any) =>
+            handlers.get(channel) match
+              case Some(fn) =>
+                fn(js.undefined.asInstanceOf[js.Any], payload)
+              case None =>
+                js.Promise
+                  .reject(js.Error(s"No Electron RPC handler registered on channel '${channel}'"))
+      ): js.Function1[js.Any, js.Promise[js.Object]]
+    )
+
+  /** An [[ElectronChannelFactory]] wired to this testbed's [[bridge]]. */
+  def channelFactory(channel: String = ElectronIPC.DefaultChannel): ElectronChannelFactory =
+    ElectronChannelFactory(bridge(channel))
+
+  /** A ready-to-use async HTTP client whose requests are tunneled through this testbed's IPC. */
+  def newAsyncClient: HttpAsyncClient =
+    Http.client.withChannelFactory(channelFactory()).newAsyncClient
+
+end ElectronTestbed
+
+object ElectronTestbed:
+
+  /** Create a testbed and serve the given routers on the default channel. */
+  def serve(routers: RPCRouter*): ElectronTestbed =
+    val testbed = ElectronTestbed()
+    ElectronRPCServer.serve(testbed.ipcMain, routers*)
+    testbed
+
+  /** Create a testbed and serve the given routers on an explicit channel. */
+  def serve(channel: String, routers: RPCRouter*): ElectronTestbed =
+    val testbed = ElectronTestbed()
+    ElectronRPCServer.serve(testbed.ipcMain, channel, routers*)
+    testbed

--- a/uni/.js/src/test/scala/wvlet/uni/electron/ElectronRPCTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/electron/ElectronRPCTest.scala
@@ -13,6 +13,7 @@
  */
 package wvlet.uni.electron
 
+import wvlet.uni.electron.testing.ElectronTestbed
 import wvlet.uni.http.Http
 import wvlet.uni.http.rpc.{RPCClient, RPCRouter}
 import wvlet.uni.rx.Rx
@@ -39,27 +40,10 @@ class GreetingServiceImpl extends GreetingService:
 class ElectronRPCTest extends UniTest:
 
   /**
-    * Wire a server router to a renderer-facing bridge through fake Electron IPC objects. Returns
-    * the bridge the renderer channel would call.
+    * Wire a server router to a renderer-facing bridge through the in-memory [[ElectronTestbed]]
+    * harness. Returns the bridge the renderer channel would call.
     */
-  private def fakeBridge(routers: RPCRouter*): js.Dynamic =
-    var captured: js.Function2[js.Any, js.Any, js.Promise[js.Object]] = null
-    val ipcMain                                                       = js
-      .Dynamic
-      .literal(handle =
-        (
-            (_channel: js.Any, fn: js.Any) =>
-              captured = fn.asInstanceOf[js.Function2[js.Any, js.Any, js.Promise[js.Object]]]
-        ): js.Function2[js.Any, js.Any, Unit]
-      )
-    ElectronRPCServer.serve(ipcMain, routers*)
-    js.Dynamic
-      .literal(request =
-        ((payload: js.Any) => captured(js.undefined.asInstanceOf[js.Any], payload)): js.Function1[
-          js.Any,
-          js.Promise[js.Object]
-        ]
-      )
+  private def fakeBridge(routers: RPCRouter*): js.Dynamic = ElectronTestbed.serve(routers*).bridge()
 
   private def rpcClient: RPCClient = RPCClient.build(
     Surface.of[GreetingService],

--- a/uni/.js/src/test/scala/wvlet/uni/electron/testing/ElectronTestbedTest.scala
+++ b/uni/.js/src/test/scala/wvlet/uni/electron/testing/ElectronTestbedTest.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package wvlet.uni.electron.testing
+
+import wvlet.uni.http.rpc.{RPCClient, RPCRouter}
+import wvlet.uni.surface.Surface
+import wvlet.uni.test.UniTest
+
+/** Shared counter state, mirroring the `examples/electron-app` reference service. */
+case class CounterState(value: Int)
+
+trait CounterApi:
+  def get(): CounterState
+  def increment(): CounterState
+  def add(delta: Int): CounterState
+
+class CounterApiImpl extends CounterApi:
+  private var current                    = 0
+  override def get(): CounterState       = CounterState(current)
+  override def increment(): CounterState =
+    current += 1;
+    CounterState(current)
+
+  override def add(delta: Int): CounterState =
+    current += delta;
+    CounterState(current)
+
+/**
+  * Integration test for an Electron RPC service the way a desktop app would write it: serve the
+  * real router in an [[ElectronTestbed]] and drive it through the renderer-side RPC client, with no
+  * Electron runtime in sight.
+  */
+class ElectronTestbedTest extends UniTest:
+
+  private def rpcClient: RPCClient = RPCClient.build(
+    Surface.of[CounterApi],
+    Surface.methodsOf[CounterApi]
+  )
+
+  test("a stateful service keeps state across IPC calls") {
+    val testbed = ElectronTestbed.serve(RPCRouter.of[CounterApi](CounterApiImpl()))
+    val client  = testbed.newAsyncClient
+    val rpc     = rpcClient
+    for
+      s0 <- rpc.callAsync[CounterState](client, "get", Seq.empty)
+      s1 <- rpc.callAsync[CounterState](client, "increment", Seq.empty)
+      s2 <- rpc.callAsync[CounterState](client, "increment", Seq.empty)
+      s3 <- rpc.callAsync[CounterState](client, "add", Seq(10))
+    yield
+      s0.value shouldBe 0
+      s1.value shouldBe 1
+      s2.value shouldBe 2
+      s3.value shouldBe 12
+  }
+
+  test("requesting an unserved channel rejects with a clear error") {
+    val testbed = ElectronTestbed.serve(RPCRouter.of[CounterApi](CounterApiImpl()))
+    val client  =
+      wvlet
+        .uni
+        .http
+        .Http
+        .client
+        .withChannelFactory(testbed.channelFactory("nonexistent-channel"))
+        .newAsyncClient
+    rpcClient
+      .callAsync[CounterState](client, "get", Seq.empty)
+      .transform {
+        case scala.util.Failure(e) =>
+          e.getMessage shouldContain "No Electron RPC handler"
+        case scala.util.Success(v) =>
+          fail(s"Expected a failure for an unserved channel, but got ${v}")
+      }
+  }
+
+end ElectronTestbedTest


### PR DESCRIPTION
## Why

Goal: make Uni a foundation for building **rich desktop apps testable at every layer**, mirroring VSCode's testing strategy (unit → integration → UI/smoke → extension). Full roadmap: `plans/2026-06-27-multi-layer-testing.md`.

This branch delivers the **two missing middle layers** of that pyramid. Unit testing (`UniTest`) was already strong; this adds UI-interaction testing and Electron integration testing.

## Layer 1 — UI (component) test toolkit  `wvlet.uni.dom.testing`

Previously `uni-dom` tests could only `renderTo` and read `textContent` — no way to dispatch a click, keystroke, or input event. New, shipped in the published `uni` JS artifact:

- **`fireEvent`** — Testing-Library-style event simulation: `click`/`dblclick`/mouse, `input`/`change`/`setChecked`, `keyDown`/`keyUp`/`keyPress` (with modifiers), `focus`/`blur`, `submit`, `custom`.
- **`Query` / `TextMatcher`** — `getBy`/`queryBy`/`queryAll` for CSS selectors, `data-testid`, and element text (`String` or `Regex`); text queries return the deepest match.
- **`mount` / `Mounted`** — render an `RxElement` into a fresh container, query/interact via the handle, `unmount()` / `AutoCloseable` cleanup.
- **`DomTestSession`** + **`DomTestSupport`** (test scope) for automatic per-test cleanup via `UniTest.after`.

Tests run in **real headless Chromium** (Playwright): `InteractionTest` (clicks/typing/keyboard drive Rx state), `QueryTest` (query helpers). Full `domTest` suite green: **387 passed**.

## Layer 2 — Electron integration harness  `wvlet.uni.electron.testing.ElectronTestbed`

In-memory Electron IPC harness so apps can integration-test RPC-over-IPC services **without a real Electron runtime**. Plays both sides of the IPC boundary (fake `ipcMain` + fake preload `bridge`), routing renderer requests to served routers through the full marshalling + `RPCDispatcher` path.

- API: `ElectronTestbed.serve(routers*)`, `.bridge(channel)`, `.channelFactory(channel)`, `.newAsyncClient`.
- `ElectronRPCTest` now dogfoods it (hand-rolled `fakeBridge` removed).
- `ElectronTestbedTest` — stateful `CounterApi` integration test + unserved-channel error case. **7 electron tests passed.**

Both toolkits ship in the published `uni` artifact (no test-framework dependency) so downstream desktop apps reuse them directly; only the `UniTest`-coupled `DomTestSupport` mixin is test-scope.

## Roadmap (follow-up PRs)

1. UI test toolkit ✅ (this PR)
2. Electron integration harness ✅ (this PR)
3. `UniTest` test tags — select/exclude layers (`unit`/`ui`/`electron`) in CI
4. Plugin model + plugin test harness (needs design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)