### PR TITLE
chore: Bump sbt-uni and sbt-uni-playwright to sbt 2.0.1

### DIFF
--- a/sbt-uni-playwright/plugin/src/sbt-test/playwright/basic/project/build.properties
+++ b/sbt-uni-playwright/plugin/src/sbt-test/playwright/basic/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC10
+sbt.version=2.0.1

--- a/sbt-uni-playwright/project/build.properties
+++ b/sbt-uni-playwright/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC10
+sbt.version=2.0.1

--- a/sbt-uni-playwright/project/plugin.sbt
+++ b/sbt-uni-playwright/project/plugin.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.github.sbt" % "sbt-pgp"    % "2.3.1")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
-// Note: sbt-scalafmt requires sbt 2.0.0-RC11+; re-add it once this build moves off RC10. The
-// repo-root .scalafmt.conf style is mirrored here so formatting stays consistent meanwhile.
+// Note: sbt-scalafmt (which needs sbt 2.0.0-RC11+) can now be re-added, since this build is on
+// sbt 2.0.1 — left as a follow-up. The repo-root .scalafmt.conf style is mirrored here so
+// formatting stays consistent meanwhile.
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/sbt-uni/project/build.properties
+++ b/sbt-uni/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC10
+sbt.version=2.0.1

--- a/sbt-uni/src/sbt-test/codegen/rpc-client-with-provider/project/build.properties
+++ b/sbt-uni/src/sbt-test/codegen/rpc-client-with-provider/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC10
+sbt.version=2.0.1

--- a/sbt-uni/src/sbt-test/codegen/rpc-client/project/build.properties
+++ b/sbt-uni/src/sbt-test/codegen/rpc-client/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC10
+sbt.version=2.0.1

--- a/sbt-uni/src/sbt-test/restart/basic/project/build.properties
+++ b/sbt-uni/src/sbt-test/restart/basic/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC10
+sbt.version=2.0.1

--- a/sbt-uni/src/sbt-test/restart/workdir/project/build.properties
+++ b/sbt-uni/src/sbt-test/restart/workdir/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.0-RC10
+sbt.version=2.0.1


### PR DESCRIPTION
## Why

The `sbt-uni` and `sbt-uni-playwright` sbt 2.x plugin builds were pinned to `2.0.0-RC10`. **sbt 2.0.1** (final) is now available, so move them to it. (Follow-up to #623, which uses 2.0.1 for the new `sbt-uni-crossproject` plugin.)

## What

- Bump `sbt.version` to `2.0.1` in all seven `build.properties` across both builds (plugin metabuilds + their `sbt-test` projects).
- Refresh the now-stale `sbt-scalafmt` note in `sbt-uni-playwright/project/plugin.sbt`: its "needs RC11+" blocker no longer applies on 2.0.1, so re-adding scalafmt is now possible (left as a follow-up to keep this change focused).

## Validation

Both builds compile on 2.0.1:
- `sbt-uni-playwright` (`uni-jsenv-playwright` + plugin) — clean.
- `sbt-uni` — compiles against a locally published `uni`; only the two pre-existing `thisProjectRef`-excluded-from-cache lint warnings remain (not introduced by this bump).

The full scripted suites for both run in CI (`test_sbt_plugin`, `test_sbt_uni_playwright`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)