### PR TITLE
chore: Re-add sbt-scalafmt to the sbt 2.x plugin builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
         working-directory: sbt-uni
         run: |
           echo "Using UNI_VERSION=${{ steps.publish.outputs.UNI_VERSION }}"
-          UNI_VERSION=${{ steps.publish.outputs.UNI_VERSION }} sbt "publishLocal; scripted"
+          UNI_VERSION=${{ steps.publish.outputs.UNI_VERSION }} sbt "scalafmtCheckAll; publishLocal; scripted"
   test_sbt_uni_playwright:
     name: sbt-uni-playwright scripted test
     needs: changes
@@ -194,4 +194,4 @@ jobs:
         run: pnpm dlx playwright@1.49.0 install --with-deps chromium
       - name: Build and scripted-test the plugin (runs Scala.js tests in headless Chromium)
         working-directory: sbt-uni-playwright
-        run: sbt "publishLocal; scripted"
+        run: sbt "scalafmtCheckAll; publishLocal; scripted"

--- a/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/BrowserSession.scala
+++ b/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/BrowserSession.scala
@@ -15,7 +15,7 @@ package wvlet.uni.jsenv.playwright
 
 import com.microsoft.playwright.{Browser, BrowserContext, BrowserType, Page, Playwright, Tracing}
 
-import java.util.{List as JList}
+import java.util.List as JList
 import scala.jdk.CollectionConverters.*
 import scala.util.control.NonFatal
 
@@ -33,14 +33,16 @@ private[playwright] class BrowserSession(
 ):
   /** Save the current page as a screenshot (best-effort). */
   def screenshot(path: java.nio.file.Path): Unit =
-    try page.screenshot(Page.ScreenshotOptions().setPath(path).setFullPage(true))
+    try
+      page.screenshot(Page.ScreenshotOptions().setPath(path).setFullPage(true))
     catch
       case NonFatal(_) =>
 
   /** Stop tracing and write the trace zip if tracing was enabled (best-effort). */
   def stopTracing(path: java.nio.file.Path): Unit =
     if tracingEnabled then
-      try context.tracing().stop(Tracing.StopOptions().setPath(path))
+      try
+        context.tracing().stop(Tracing.StopOptions().setPath(path))
       catch
         case NonFatal(_) =>
 
@@ -55,30 +57,38 @@ end BrowserSession
 private[playwright] object BrowserSession:
 
   // Flags that let Chromium load ES modules and sibling files over file://.
-  private val chromiumArgs =
-    List(
-      "--disable-extensions",
-      "--disable-web-security",
-      "--allow-running-insecure-content",
-      "--disable-site-isolation-trials",
-      "--allow-file-access-from-files",
-      "--disable-gpu"
-    )
+  private val chromiumArgs = List(
+    "--disable-extensions",
+    "--disable-web-security",
+    "--allow-running-insecure-content",
+    "--disable-site-isolation-trials",
+    "--allow-file-access-from-files",
+    "--disable-gpu"
+  )
+
   private val firefoxArgs = List("--disable-web-security")
   private val webkitArgs  = chromiumArgs.filterNot(_ == "--disable-gpu")
 
-  /** Resolve a browser name to its Playwright type and default launch flags (single source of truth). */
+  /**
+    * Resolve a browser name to its Playwright type and default launch flags (single source of
+    * truth).
+    */
   private def resolve(playwright: Playwright, browserName: String): (BrowserType, List[String]) =
     browserName.toLowerCase match
-      case "chromium" | "chrome" => (playwright.chromium(), chromiumArgs)
-      case "firefox"             => (playwright.firefox(), firefoxArgs)
-      case "webkit"              => (playwright.webkit(), webkitArgs)
-      case other => throw IllegalArgumentException(s"Unknown Playwright browser: ${other}")
+      case "chromium" | "chrome" =>
+        (playwright.chromium(), chromiumArgs)
+      case "firefox" =>
+        (playwright.firefox(), firefoxArgs)
+      case "webkit" =>
+        (playwright.webkit(), webkitArgs)
+      case other =>
+        throw IllegalArgumentException(s"Unknown Playwright browser: ${other}")
 
   /** Close an AutoCloseable, swallowing errors and nulls. */
   private def closeQuietly(c: AutoCloseable): Unit =
     if c != null then
-      try c.close()
+      try
+        c.close()
       catch
         case NonFatal(_) =>
 

--- a/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/JsBridge.scala
+++ b/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/JsBridge.scala
@@ -26,7 +26,9 @@ import java.net.URL
   */
 private[playwright] object JsBridge:
 
-  /** Name of the control object the Java side polls (must match the calls in [[PlaywrightEngine]]). */
+  /**
+    * Name of the control object the Java side polls (must match the calls in [[PlaywrightEngine]]).
+    */
   val controlInterface: String = "globalThis.__uniPlaywrightControl"
 
   /**
@@ -128,8 +130,10 @@ private[playwright] object JsBridge:
 
   private def scriptTag(input: Input): String =
     input match
-      case Input.Script(path)         => classicTag(path)
-      case Input.CommonJSModule(path) => classicTag(path)
+      case Input.Script(path) =>
+        classicTag(path)
+      case Input.CommonJSModule(path) =>
+        classicTag(path)
       case Input.ESModule(path) =>
         s"""<script defer type="module" src="${srcOf(path)}"></script>"""
       case other =>

--- a/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/Materializer.scala
+++ b/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/Materializer.scala
@@ -20,13 +20,16 @@ import scala.util.control.NonFatal
 
 /**
   * Writes generated content (the JS shim, the launcher HTML) to real temp files so the browser can
-  * load them over `file://`, and deletes them on [[close]]. Linked Scala.js inputs are referenced in
-  * place (their own paths), so only generated files are tracked here.
+  * load them over `file://`, and deletes them on [[close]]. Linked Scala.js inputs are referenced
+  * in place (their own paths), so only generated files are tracked here.
   */
 private[playwright] class Materializer extends AutoCloseable:
   private var tmpFiles: List[Path] = Nil
 
-  /** Write `content` to a fresh temp file ending in `suffix` (e.g. ".js", ".html") and return its URL. */
+  /**
+    * Write `content` to a fresh temp file ending in `suffix` (e.g. ".js", ".html") and return its
+    * URL.
+    */
   def write(suffix: String, content: String): URL =
     val tmp = Files.createTempFile("uni-playwright-", suffix)
     // Track before writing so a write failure still leaves the temp file scheduled for cleanup.
@@ -37,14 +40,14 @@ private[playwright] class Materializer extends AutoCloseable:
     tmp.toUri.toURL
 
   override def close(): Unit =
-    val files =
-      synchronized {
-        val fs = tmpFiles
-        tmpFiles = Nil
-        fs
-      }
+    val files = synchronized {
+      val fs = tmpFiles
+      tmpFiles = Nil
+      fs
+    }
     files.foreach { f =>
-      try Files.deleteIfExists(f)
+      try
+        Files.deleteIfExists(f)
       catch
         case NonFatal(_) => // best-effort cleanup
     }

--- a/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/PlaywrightBrowsers.scala
+++ b/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/PlaywrightBrowsers.scala
@@ -27,7 +27,12 @@ object PlaywrightBrowsers:
     *   the resolved Chromium/Firefox/WebKit version string, for logging.
     */
   def install(browserName: String): String =
-    val session = BrowserSession.launch(browserName, headless = true, extraArgs = Nil, tracingEnabled = false)
+    val session = BrowserSession.launch(
+      browserName,
+      headless = true,
+      extraArgs = Nil,
+      tracingEnabled = false
+    )
     try session.browser.version()
     finally session.close()
 

--- a/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/PlaywrightEngine.scala
+++ b/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/PlaywrightEngine.scala
@@ -26,9 +26,9 @@ import scala.util.control.NonFatal
 /**
   * Drives a single Scala.js run in a real browser on one worker thread.
   *
-  *   - It serves the linked inputs (plus the [[JsBridge]] shim) to a Playwright page, then polls the
-  *     page every `pollIntervalMs` for console output, errors, and com-messages, and pushes queued
-  *     outbound messages back in.
+  *   - It serves the linked inputs (plus the [[JsBridge]] shim) to a Playwright page, then polls
+  *     the page every `pollIntervalMs` for console output, errors, and com-messages, and pushes
+  *     queued outbound messages back in.
   *   - `send` and `close` are safe to call from other threads (they only touch a concurrent queue
   *     and an atomic flag); all Playwright calls stay on the worker thread.
   *   - On an uncaught JS error (or any failure), it captures a screenshot and (if enabled) a trace
@@ -66,7 +66,7 @@ private[playwright] final class PlaywrightEngine(
   def close(): Unit = wantToClose.set(true)
 
   private def runLoop(): Unit =
-    val materializer        = Materializer()
+    val materializer            = Materializer()
     var session: BrowserSession = null
     var streams: RunStreams     = null
     try
@@ -95,17 +95,21 @@ private[playwright] final class PlaywrightEngine(
         promise.tryFailure(t)
         captureArtifacts(session)
     finally
-      if streams != null then streams.close()
+      if streams != null then
+        streams.close()
       // Close the browser before deleting the temp files it loaded.
-      if session != null then session.close()
+      if session != null then
+        session.close()
       materializer.close()
+    end try
   end runLoop
 
   /** Wait until the page's control interface is installed. Returns false if close() came first. */
   private def awaitReady(session: BrowserSession): Boolean =
     val deadline = System.currentTimeMillis() + readyTimeoutMs
     while !wantToClose.get() do
-      if isReady(session) then return true
+      if isReady(session) then
+        return true
       if System.currentTimeMillis() > deadline then
         throw RuntimeException(
           s"Timed out after ${readyTimeoutMs}ms waiting for the Playwright page to load the Scala.js bridge"
@@ -115,8 +119,10 @@ private[playwright] final class PlaywrightEngine(
 
   private def isReady(session: BrowserSession): Boolean =
     session.page.evaluate(readyExpr) match
-      case b: java.lang.Boolean => b.booleanValue()
-      case _                    => false
+      case b: java.lang.Boolean =>
+        b.booleanValue()
+      case _ =>
+        false
 
   /** One poll cycle: push outbound messages, drain console/errors/inbound messages. */
   private def pump(session: BrowserSession, streams: RunStreams): Unit =
@@ -132,8 +138,10 @@ private[playwright] final class PlaywrightEngine(
     // JS -> JVM
     val resp =
       session.page.evaluate(fetchExpr) match
-        case m: java.util.Map[?, ?] => m.asInstanceOf[java.util.Map[String, Object]]
-        case _                      => java.util.Collections.emptyMap[String, Object]()
+        case m: java.util.Map[?, ?] =>
+          m.asInstanceOf[java.util.Map[String, Object]]
+        case _ =>
+          java.util.Collections.emptyMap[String, Object]()
 
     strings(resp, "consoleLog").foreach(streams.out.println)
     strings(resp, "consoleError").foreach(streams.err.println)
@@ -146,8 +154,10 @@ private[playwright] final class PlaywrightEngine(
 
   private def strings(resp: java.util.Map[String, Object], key: String): List[String] =
     resp.get(key) match
-      case l: java.util.List[?] => l.asScala.iterator.map(String.valueOf).toList
-      case _                    => Nil
+      case l: java.util.List[?] =>
+        l.asScala.iterator.map(String.valueOf).toList
+      case _ =>
+        Nil
 
   private def captureArtifacts(session: BrowserSession): Unit =
     if config.captureArtifactsOnFailure && session != null then
@@ -174,7 +184,11 @@ end PlaywrightEngine
   * streams (`onOutputStream`), we hand it the read end of a pipe; otherwise we inherit the JVM's
   * stdout/stderr (without owning them, so closing never closes the real streams).
   */
-private[playwright] class RunStreams(val out: PrintStream, val err: PrintStream, closer: () => Unit):
+private[playwright] class RunStreams(
+    val out: PrintStream,
+    val err: PrintStream,
+    closer: () => Unit
+):
   def close(): Unit = closer()
 
 private[playwright] object RunStreams:
@@ -189,30 +203,46 @@ private[playwright] object RunStreams:
   def prepare(runConfig: RunConfig): RunStreams =
     // Only create a pipe when there is a consumer (onOutputStream) to read its other end.
     val capture = runConfig.onOutputStream.isDefined
-    val outPipe = if capture && !runConfig.inheritOutput then Some(pipe()) else None
-    val errPipe = if capture && !runConfig.inheritError then Some(pipe()) else None
+    val outPipe =
+      if capture && !runConfig.inheritOutput then
+        Some(pipe())
+      else
+        None
+    val errPipe =
+      if capture && !runConfig.inheritError then
+        Some(pipe())
+      else
+        None
     try
-      runConfig
-        .onOutputStream
-        .foreach(f => f(outPipe.map(_._1), errPipe.map(_._1)))
+      runConfig.onOutputStream.foreach(f => f(outPipe.map(_._1), errPipe.map(_._1)))
 
       val out = printStream(runConfig.inheritOutput, outPipe, System.out)
       val err = printStream(runConfig.inheritError, errPipe, System.err)
-      RunStreams(out, err, () => { out.close(); err.close() })
+      RunStreams(
+        out,
+        err,
+        () =>
+          out.close();
+          err.close()
+      )
     catch
       case t: Throwable =>
         // The pipes aren't owned by a RunStreams yet, so close them here if setup fails.
-        List(outPipe, errPipe).flatten.foreach { (in, w) =>
-          closeQuietly(in)
-          closeQuietly(w)
-        }
+        List(outPipe, errPipe)
+          .flatten
+          .foreach { (in, w) =>
+            closeQuietly(in)
+            closeQuietly(w)
+          }
         throw t
 
+  end prepare
+
   private def closeQuietly(c: AutoCloseable): Unit =
-    try c.close()
+    try
+      c.close()
     catch
       case NonFatal(_) =>
-
 
   // autoFlush so console output appears incrementally rather than only at close.
   private def printStream(
@@ -220,12 +250,15 @@ private[playwright] object RunStreams:
       pipe: Option[(PipedInputStream, PipedOutputStream)],
       inherited: OutputStream
   ): PrintStream =
-    if inherit then PrintStream(Unowned(inherited), true)
+    if inherit then
+      PrintStream(Unowned(inherited), true)
     else
       pipe match
-        case Some((_, w)) => PrintStream(w, true)
+        case Some((_, w)) =>
+          PrintStream(w, true)
         // Neither inherited nor captured: discard, so an unread pipe can never block the worker.
-        case None => PrintStream(OutputStream.nullOutputStream(), true)
+        case None =>
+          PrintStream(OutputStream.nullOutputStream(), true)
 
   private def pipe(): (PipedInputStream, PipedOutputStream) =
     // 64 KiB buffer (vs the 1 KiB default) to reduce writer backpressure on bursty console output.

--- a/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/PlaywrightJSEnv.scala
+++ b/sbt-uni-playwright/jsenv/src/main/scala/wvlet/uni/jsenv/playwright/PlaywrightJSEnv.scala
@@ -39,13 +39,14 @@ case class PlaywrightConfig(
     artifactDir: Path = Paths.get("target", "uni-playwright"),
     launchArgs: List[String] = Nil
 ):
-  def withBrowserName(name: String): PlaywrightConfig = copy(browserName = name)
+  def withBrowserName(name: String): PlaywrightConfig  = copy(browserName = name)
   def withHeadless(enabled: Boolean): PlaywrightConfig = copy(headless = enabled)
 
-  def withCaptureArtifactsOnFailure(enabled: Boolean): PlaywrightConfig =
-    copy(captureArtifactsOnFailure = enabled)
+  def withCaptureArtifactsOnFailure(enabled: Boolean): PlaywrightConfig = copy(
+    captureArtifactsOnFailure = enabled
+  )
 
-  def withArtifactDir(dir: Path): PlaywrightConfig = copy(artifactDir = dir)
+  def withArtifactDir(dir: Path): PlaywrightConfig         = copy(artifactDir = dir)
   def withLaunchArgs(args: List[String]): PlaywrightConfig = copy(launchArgs = args)
   def noArtifactCapture: PlaywrightConfig                  = copy(captureArtifactsOnFailure = false)
 
@@ -54,8 +55,8 @@ end PlaywrightConfig
 /**
   * A Scala.js `org.scalajs.jsenv.JSEnv` that runs tests in a real browser via the Java Playwright
   * runtime. Unlike jsdom it supports ES modules and a faithful DOM, and Chromium matches the
-  * Electron renderer. Java Playwright bundles its own driver and downloads browsers on demand, so no
-  * Node.js or npm package is required.
+  * Electron renderer. Java Playwright bundles its own driver and downloads browsers on demand, so
+  * no Node.js or npm package is required.
   *
   * Usage in build.sbt (with the dependency added to `project/plugins.sbt`):
   * {{{
@@ -66,8 +67,9 @@ class PlaywrightJSEnv(val config: PlaywrightConfig) extends JSEnv:
 
   def this() = this(PlaywrightConfig())
 
-  def this(browserName: String, headless: Boolean) =
-    this(PlaywrightConfig(browserName = browserName, headless = headless))
+  def this(browserName: String, headless: Boolean) = this(
+    PlaywrightConfig(browserName = browserName, headless = headless)
+  )
 
   /** Human-readable environment name (shown in sbt's test output). */
   override val name: String = s"PlaywrightJSEnv(${config.browserName})"
@@ -90,14 +92,11 @@ class PlaywrightJSEnv(val config: PlaywrightConfig) extends JSEnv:
 
 end PlaywrightJSEnv
 
-private final class PlaywrightRun(
-    config: PlaywrightConfig,
-    input: Seq[Input],
-    runConfig: RunConfig
-) extends JSRun:
+private final class PlaywrightRun(config: PlaywrightConfig, input: Seq[Input], runConfig: RunConfig)
+    extends JSRun:
   private val engine = PlaywrightEngine(config, input, runConfig, enableCom = false, _ => ())
   override def future: Future[Unit] = engine.future
-  override def close(): Unit         = engine.close()
+  override def close(): Unit        = engine.close()
 
 private final class PlaywrightComRun(
     config: PlaywrightConfig,
@@ -106,6 +105,6 @@ private final class PlaywrightComRun(
     onMessage: String => Unit
 ) extends JSComRun:
   private val engine = PlaywrightEngine(config, input, runConfig, enableCom = true, onMessage)
-  override def future: Future[Unit]  = engine.future
-  override def close(): Unit          = engine.close()
+  override def future: Future[Unit]    = engine.future
+  override def close(): Unit           = engine.close()
   override def send(msg: String): Unit = engine.send(msg)

--- a/sbt-uni-playwright/plugin/src/main/scala/wvlet/uni/sbt/playwright/UniPlaywrightPlugin.scala
+++ b/sbt-uni-playwright/plugin/src/main/scala/wvlet/uni/sbt/playwright/UniPlaywrightPlugin.scala
@@ -23,8 +23,8 @@ import wvlet.uni.jsenv.playwright.{PlaywrightBrowsers, PlaywrightConfig, Playwri
   * sbt 2.x plugin for running Scala.js tests in a real browser via Playwright.
   *
   * It wires `Test / jsEnv` to a [[wvlet.uni.jsenv.playwright.PlaywrightJSEnv]] (configured via the
-  * `uniPlaywrightBrowser` / `uniPlaywrightHeadless` settings) and adds a `uniPlaywrightInstall` task
-  * to pre-download and pin the browser binaries. Java Playwright bundles its own driver and
+  * `uniPlaywrightBrowser` / `uniPlaywrightHeadless` settings) and adds a `uniPlaywrightInstall`
+  * task to pre-download and pin the browser binaries. Java Playwright bundles its own driver and
   * downloads browsers on demand, so no Node.js or npm package is required.
   *
   * Usage in build.sbt:
@@ -45,30 +45,34 @@ object UniPlaywrightPlugin extends AutoPlugin:
 
   object autoImport:
     // Re-exported so consumers can reference the JSEnv with only this plugin on the classpath.
-    type PlaywrightJSEnv = wvlet.uni.jsenv.playwright.PlaywrightJSEnv
+    type PlaywrightJSEnv  = wvlet.uni.jsenv.playwright.PlaywrightJSEnv
     type PlaywrightConfig = wvlet.uni.jsenv.playwright.PlaywrightConfig
     val PlaywrightConfig: wvlet.uni.jsenv.playwright.PlaywrightConfig.type =
       wvlet.uni.jsenv.playwright.PlaywrightConfig
 
-    val uniPlaywrightBrowser =
-      settingKey[String]("Browser for Test/jsEnv: chromium (default), firefox, or webkit")
+    val uniPlaywrightBrowser = settingKey[String](
+      "Browser for Test/jsEnv: chromium (default), firefox, or webkit"
+    )
+
     val uniPlaywrightHeadless = settingKey[Boolean]("Run the browser headless (default true)")
 
-    val uniPlaywrightBrowsers =
-      settingKey[Seq[String]]("Browsers to install via uniPlaywrightInstall")
+    val uniPlaywrightBrowsers = settingKey[Seq[String]](
+      "Browsers to install via uniPlaywrightInstall"
+    )
 
-    val uniPlaywrightInstall =
-      taskKey[Unit]("Download and pin the configured Playwright browser binaries")
+    val uniPlaywrightInstall = taskKey[Unit](
+      "Download and pin the configured Playwright browser binaries"
+    )
 
   import autoImport.*
 
-  override lazy val projectSettings: Seq[Setting[?]] =
-    Seq(
-      uniPlaywrightBrowser  := "chromium",
-      uniPlaywrightHeadless := true,
-      uniPlaywrightBrowsers := Seq(uniPlaywrightBrowser.value),
-      // A JSEnv is not serializable, so opt out of sbt 2.x's setting-value caching.
-      Test / jsEnv := Def.uncached(
+  override lazy val projectSettings: Seq[Setting[?]] = Seq(
+    uniPlaywrightBrowser  := "chromium",
+    uniPlaywrightHeadless := true,
+    uniPlaywrightBrowsers := Seq(uniPlaywrightBrowser.value),
+    // A JSEnv is not serializable, so opt out of sbt 2.x's setting-value caching.
+    Test / jsEnv :=
+      Def.uncached(
         PlaywrightJSEnv(
           PlaywrightConfig(
             browserName = uniPlaywrightBrowser.value,
@@ -76,14 +80,16 @@ object UniPlaywrightPlugin extends AutoPlugin:
           )
         )
       ),
-      uniPlaywrightInstall := {
-        val log = streams.value.log
-        uniPlaywrightBrowsers.value.foreach { browser =>
+    uniPlaywrightInstall := {
+      val log = streams.value.log
+      uniPlaywrightBrowsers
+        .value
+        .foreach { browser =>
           log.info(s"Installing Playwright browser: ${browser} ...")
           val version = PlaywrightBrowsers.install(browser)
           log.info(s"Installed ${browser} ${version}")
         }
-      }
-    )
+    }
+  )
 
 end UniPlaywrightPlugin

--- a/sbt-uni-playwright/project/plugin.sbt
+++ b/sbt-uni-playwright/project/plugin.sbt
@@ -1,7 +1,5 @@
-addSbtPlugin("com.github.sbt" % "sbt-pgp"    % "2.3.1")
-addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
-// Note: sbt-scalafmt (which needs sbt 2.0.0-RC11+) can now be re-added, since this build is on
-// sbt 2.0.1 — left as a follow-up. The repo-root .scalafmt.conf style is mirrored here so
-// formatting stays consistent meanwhile.
+addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-dynver"   % "5.1.1")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt" % "2.6.1")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/sbt-uni/.scalafmt.conf
+++ b/sbt-uni/.scalafmt.conf
@@ -1,0 +1,16 @@
+version = 3.11.1
+project.layout = StandardConvention
+runner.dialect = scala3
+maxColumn = 100
+style = defaultWithAlign
+docstrings.blankFirstLine = yes
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.removeOptionalBraces = yes
+rewrite.scala3.insertEndMarkerMinLines = 30
+# Add a new line before case class
+newlines.topLevelStatementBlankLines = [
+  {
+    blanks { after = 1 }
+  }
+]
+newlines.source = unfold

--- a/sbt-uni/project/plugin.sbt
+++ b/sbt-uni/project/plugin.sbt
@@ -1,4 +1,5 @@
-addSbtPlugin("com.github.sbt" % "sbt-pgp"    % "2.3.1")
-addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-dynver"   % "5.1.1")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt" % "2.6.1")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
## Why

While `sbt-uni` and `sbt-uni-playwright` were pinned to sbt `2.0.0-RC10`, `sbt-scalafmt` (which needs ≥ `2.0.0-RC11`) had to be left out. Now that #624 moves them to **sbt 2.0.1**, the formatter can be re-added — restoring the same `scalafmtCheckAll` enforcement the main build already has.

> **Stacked on #624** (base = `chore/bump-sibling-sbt-201`). Review/merge that first; this diff is scalafmt-only on top of it.

## What

- Add `addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")` (the version the main build uses) to `sbt-uni` and `sbt-uni-playwright` metabuilds.
- Add a local `.scalafmt.conf` to `sbt-uni` (it had none — its sources happened to already conform to the mirrored repo-root style).
- Reformat the 7 existing `sbt-uni-playwright` sources to that style (they were written before the formatter was available; **formatting-only**, still compiles).
- **Enforce in CI**: the `test_sbt_plugin` and `test_sbt_uni_playwright` jobs now run `scalafmtCheckAll` before `scripted`.

## Validation

`scalafmtCheckAll` passes for both builds on sbt 2.0.1, and both still `compile`.

Follow-up: `sbt-uni-crossproject` (added in #623) gets the same treatment in that PR, so all three sbt 2.x builds end up consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)