### PR TITLE
chore: Migrate the main build to sbt 2.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,9 @@
 - **uni**: Main library collection (logging, DI, JSON/MessagePack, RPC/HTTP)
 - **uni-test**: Unit testing framework
 
-Cross-platform: JVM, Scala.js, Scala Native via sbt-crossproject. Platform-specific code in `.jvm`, `.js`, `.native` folders.
+The build runs on **sbt 2.x** (Scala 3 metabuild). Cross-platform — JVM, Scala.js, Scala Native — via uni's own [`sbt-uni-crossproject`](sbt-uni-crossproject/) plugin (`crossProject`, `CrossType.Pure`), which replaced the unported portable-scala plugins. Platform-specific code in `.jvm`, `.js`, `.native` folders.
+
+Note (sbt 2.x): use `%%` (not the old `%%%`) for Scala.js/Native deps, and wrap a non-serializable `Test / jsEnv` in `Def.uncached(...)`.
 
 ## Commands
 
@@ -76,3 +78,4 @@ Gemini reviews PRs. Address feedback before merging.
 - [`adr/2026-06-26-esmodule-dom-tests-playwright.md`](adr/2026-06-26-esmodule-dom-tests-playwright.md) — `uni-dom-test` runs in headless Chromium via Playwright (`scala-js-env-playwright`), replacing jsdom so DOM tests run under `ModuleKind.ESModule` like the rest of the JS build. Read before touching the `domTest` jsEnv or the Playwright CI step; covers the Java-Playwright-bundles-its-own-driver (no Node needed) point and the CI `playwright@<ver>` pin that must match the transitive `com.microsoft.playwright` version.
 - [`adr/2026-06-26-uni-jsenv-playwright.md`](adr/2026-06-26-uni-jsenv-playwright.md) — the `sbt-uni-playwright/` build: a uni-owned, cats-effect-free Playwright `JSEnv` (`uni-jsenv-playwright`) + an sbt 2.x plugin (`sbt-uni-playwright`), replacing the unmaintained Scala-2.12-only third-party env for sbt 2.x consumers. Read before touching that build; covers the polling com mechanism, the sbt-2.x `%%`/`Def.uncached` changes, and the Playwright driver thread-context-classloader fix in `BrowserSession`.
 - [`adr/2026-06-30-sbt-uni-crossproject.md`](adr/2026-06-30-sbt-uni-crossproject.md) — the `sbt-uni-crossproject/` build: a minimal, uni-owned sbt 2.x re-implementation of `portable-scala/sbt-crossproject` (which isn't ported to sbt 2.x), supporting only the `CrossType.Pure` layout uni uses. Read before touching that build; covers the single-plugin-for-all-three-platforms choice, the Scala 3 val-name macro replicating sbt's `KeyMacro.definingValName`, why internal materialization needs `new CrossProject(...)`, and the `given Conversion[Builder, CrossProject]` build trigger.
+- [`adr/2026-06-30-sbt2-main-build-migration.md`](adr/2026-06-30-sbt2-main-build-migration.md) — migrating the **main build** to sbt 2.x: swaps the unported third-party plugins for the uni-owned ones (`sbt-uni-crossproject`, `uni-jsenv-playwright`, `sbt-uni` for `sbt-revolver`). Read before touching `build.sbt` / `project/plugin.sbt`; covers the output-dir name collision (root → `uni-root`), `%%%`→`%%` and the `scalajs-test-interface_2.13` single-`%` exception, `Def.uncached` for `jsEnv`, and the `implicitConversions` import.

--- a/adr/2026-06-30-sbt2-main-build-migration.md
+++ b/adr/2026-06-30-sbt2-main-build-migration.md
@@ -1,0 +1,61 @@
+# 2026-06-30: Migrate the main uni build to sbt 2.x
+
+## Context
+
+The main build ran on **sbt 1.x** (Scala 2.12 metabuild). The blocker for sbt 2.x was that several
+plugins had no sbt 2.x release — chiefly `sbt-crossproject` (JVM/JS/Native cross-building) and the
+third-party Playwright `JSEnv`. Those are now replaced by uni-owned sbt 2.x plugins
+(`sbt-uni-crossproject`, `uni-jsenv-playwright`, see their ADRs), and the only other gap —
+`sbt-revolver` — is unused in the build and replaced by `sbt-uni`'s `uniRestart`/`uniStop`/
+`uniStatus`. So the migration became possible.
+
+## Decision
+
+Move `project/build.properties` to **sbt 2.0.1** and swap the metabuild plugins:
+
+| Removed (no sbt 2.x build / superseded) | Replacement |
+| --- | --- |
+| `sbt-scalajs-crossproject` + `sbt-scala-native-crossproject` | `org.wvlet.uni:sbt-uni-crossproject` |
+| `io.github.gmkumar2005:scala-js-env-playwright` | `org.wvlet.uni:uni-jsenv-playwright` |
+| `sbt-revolver` | `org.wvlet.uni:sbt-uni` |
+| `sbt-buildinfo` (was unused), `addDependencyTreePlugin` (built into sbt 2.x) | — |
+
+`sbt-pack` bumped `0.23` → `1.0.0`. Kept (already on sbt 2.x): `sbt-pgp`, `sbt-scalafmt`,
+`sbt-ide-settings`, `sbt-scalajs`, `sbt-scala-native`, `sbt-dynver`, `scalajs-env-nodejs`.
+
+Because `sbt-uni-crossproject` reproduces the exact `crossProject` / `CrossType.Pure` API, the
+`build.sbt` project definitions were unchanged — only sbt-2.x source-level adjustments were needed.
+
+## The non-obvious migration traps (each cost a compile/load cycle)
+
+1. **Output-directory collision.** sbt 2.x derives each project's output dir from its **name**
+   (`target/out/<platform>/<scala>/<name>`), not its id. The root project and the `uni` library
+   project were both `name := "uni"` → *"Overlapping output directories"* at load. Fixed by naming
+   the root `uni-root`. (Per-platform crossproject projects don't collide — different platform dir.)
+
+2. **`%%%` is gone; `%%` is now platform-aware.** On sbt 2.x `%%` already encodes the platform
+   suffix (`_sjs1` / `_native0.5`), so every old `%%%` becomes `%%`. Conversely, a dependency that
+   must stay platform-less needs care — `scalajs-test-interface` is published only as
+   `scalajs-test-interface_2.13` (JVM-side), and in a Scala.js project **any** cross-version (`%%`
+   or `.cross(for3Use2_13)`) injects the unwanted `_sjs1`. Name that fixed artifact directly with a
+   single `%`: `"org.scala-js" % "scalajs-test-interface_2.13" % scalaJSVersion`. (Genuine JS
+   platform libs like `scalajs-java-securerandom`/`-time`/`-logging` keep `%% … .cross(for3Use2_13)`
+   → `_sjs1_2.13`.)
+
+3. **`Test / jsEnv` must be `Def.uncached(...)`.** sbt 2.x caches setting values and a `JSEnv` is
+   not serializable, so both the `NodeJSEnv` and the `PlaywrightJSEnv` are wrapped in `Def.uncached`.
+
+4. **Opt into the `Project => ProjectReference` conversion.** `core.jvm` / `.js` / `.native`
+   (a `Project`) used in the `Seq[ProjectReference]` aggregation lists needs
+   `import scala.language.implicitConversions` at the top of `build.sbt` on Scala 3.
+
+5. **Deprecations now warn.** `xs: _*` → `xs*`, and infix `classifier "x"` → `.classifier("x")`.
+
+CI needs no change: the repo's `./sbt` runner reads `build.properties`, so it picks up 2.0.1, and
+`code_format` runs `scalafmtCheckAll` against the (kept) `sbt-scalafmt`.
+
+## Validation
+
+All three platforms compile and test on sbt 2.0.1: JVM (1655 passed + netty/book 39), JS via
+NodeJSEnv (~1491) and `domTest` via Playwright/Chromium (374), Native (1417 + 71). `uni-core`
+reports 0 tests on every platform (it has no `src/test`) — not a regression.

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,9 @@
 import sbtide.Keys.ideSkipProject
 
+// `core.jvm` / `.js` / `.native` (Project) are used where a ProjectReference is expected (e.g. the
+// jvmProjects/jsProjects/nativeProjects lists); sbt 2.x requires opting into that implicit conversion.
+import scala.language.implicitConversions
+
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 ThisBuild / organization := "org.wvlet.uni"
@@ -65,8 +69,9 @@ val buildSettings = Seq[Setting[?]](
 )
 
 val jsBuildSettings = Seq[Setting[?]](
-  // Use Node.js environment for tests (required for FileSystem tests)
-  Test / jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
+  // Use Node.js environment for tests (required for FileSystem tests).
+  // sbt 2.x caches setting values and a JSEnv is not serializable, so wrap it in Def.uncached.
+  Test / jsEnv := Def.uncached(new org.scalajs.jsenv.nodejs.NodeJSEnv()),
   // Enable ES modules for Node.js module imports
   scalaJSLinkerConfig ~= {
     _.withModuleKind(ModuleKind.ESModule)
@@ -76,13 +81,13 @@ val jsBuildSettings = Seq[Setting[?]](
       // For java.security.SecureRandom in Scala.js (used by ULID, reached through the Weaver
       // derivation chain). Must be a compile dependency so downstream JS apps (e.g. Electron)
       // can link uni's main code, not just uni's own tests.
-      ("org.scala-js" %%% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13),
+      ("org.scala-js" %% "scalajs-java-securerandom" % "1.0.0").cross(CrossVersion.for3Use2_13),
       // For using java.time.Instant in Scala.js
-      ("org.scala-js" %%% "scalajs-java-time" % "1.0.0").cross(CrossVersion.for3Use2_13),
+      ("org.scala-js" %% "scalajs-java-time" % "1.0.0").cross(CrossVersion.for3Use2_13),
       // For scheduling with timer
-      "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1",
+      "org.scala-js" %% "scala-js-macrotask-executor" % "1.1.1",
       // For Fetch API and DOM access
-      "org.scala-js" %%% "scalajs-dom" % "2.8.1"
+      "org.scala-js" %% "scalajs-dom" % "2.8.1"
     )
 )
 
@@ -91,7 +96,7 @@ val nativeBuildSettings = Seq[Setting[?]](
   libraryDependencies ++=
     Seq(
       // For using java.time libraries
-      "org.ekrich" %%% "sjavatime" % "1.5.0"
+      "org.ekrich" %% "sjavatime" % "1.5.0"
     ),
   // Link against libcurl for HTTP client support, and zlib for gzip compression
   nativeConfig ~= {
@@ -121,8 +126,10 @@ Global / excludeLintKeys ++= Set(ideSkipProject)
 // Root project aggregating others
 lazy val root = project
   .in(file("."))
-  .settings(buildSettings, name := "uni", publish / skip := true)
-  .aggregate((jvmProjects ++ jsProjects ++ nativeProjects): _*)
+  // sbt 2.x derives each project's output dir from its name, so the root must not reuse the
+  // `uni` library project's name (they would collide on target/out/jvm/.../uni).
+  .settings(buildSettings, name := "uni-root", publish / skip := true)
+  .aggregate((jvmProjects ++ jsProjects ++ nativeProjects) *)
 
 lazy val jvmProjects: Seq[ProjectReference] = Seq(core.jvm, uni.jvm, netty, bookExamples, test.jvm)
 
@@ -135,11 +142,11 @@ lazy val projectJVM = project
     // Use a stable coverage directory name without containing scala version
     // coverageDataDir := target.value
   )
-  .aggregate(jvmProjects: _*)
+  .aggregate(jvmProjects *)
 
-lazy val projectJS = project.settings(noPublish).aggregate(jsProjects: _*)
+lazy val projectJS = project.settings(noPublish).aggregate(jsProjects *)
 
-lazy val projectNative = project.settings(noPublish).aggregate(nativeProjects: _*)
+lazy val projectNative = project.settings(noPublish).aggregate(nativeProjects *)
 
 // Core library with logging and reactive streams
 lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -154,7 +161,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     jsBuildSettings,
     libraryDependencies ++=
       Seq(
-        ("org.scala-js" %%% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(
+        ("org.scala-js" %% "scalajs-java-logging" % JS_JAVA_LOGGING_VERSION).cross(
           CrossVersion.for3Use2_13
         )
       )
@@ -196,10 +203,11 @@ lazy val test = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     jsBuildSettings,
     libraryDependencies ++=
       Seq(
-        // Scala.js uses scalajs-test-interface for proper test discovery
-        ("org.scala-js" %% "scalajs-test-interface" % scalaJSVersion).cross(
-          CrossVersion.for3Use2_13
-        )
+        // Scala.js uses scalajs-test-interface for proper test discovery. This is the JVM-side
+        // test interface, published only as scalajs-test-interface_2.13. In a Scala.js project on
+        // sbt 2.x any cross-version (`%%` or `.cross(for3Use2_13)`) injects the _sjs1 platform
+        // suffix, so name the fixed _2.13 artifact directly with a single `%`.
+        "org.scala-js" % "scalajs-test-interface_2.13" % scalaJSVersion
       )
   )
   .nativeSettings(
@@ -207,7 +215,7 @@ lazy val test = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies ++=
       Seq(
         // Scala Native uses native test-interface
-        "org.scala-native" %%% "test-interface" % SCALA_NATIVE_TEST_INTERFACE_VERSION
+        "org.scala-native" %% "test-interface" % SCALA_NATIVE_TEST_INTERFACE_VERSION
       )
   )
   .dependsOn(core)
@@ -222,10 +230,10 @@ lazy val netty = project
     description := "Netty-based HTTP server for uni",
     libraryDependencies ++=
       Seq(
-        "io.netty" % "netty-handler"                % NETTY_VERSION,
-        "io.netty" % "netty-codec-http"             % NETTY_VERSION,
-        "io.netty" % "netty-transport-native-epoll" % NETTY_VERSION classifier "linux-x86_64",
-        "io.netty" % "netty-transport-native-epoll" % NETTY_VERSION classifier "linux-aarch_64"
+        "io.netty"  % "netty-handler"                % NETTY_VERSION,
+        "io.netty"  % "netty-codec-http"             % NETTY_VERSION,
+        ("io.netty" % "netty-transport-native-epoll" % NETTY_VERSION).classifier("linux-x86_64"),
+        ("io.netty" % "netty-transport-native-epoll" % NETTY_VERSION).classifier("linux-aarch_64")
       )
   )
   .dependsOn(uni.jvm, test.jvm % Test)
@@ -256,12 +264,10 @@ lazy val domTest = project
     // browser DOM AND supports ES modules (jsBuildSettings sets ModuleKind.ESModule),
     // unlike the outdated jsdom which only supports plain scripts. Chromium also matches
     // the Electron renderer, so these tests exercise web and Electron app code alike.
-    // Playwright's logs are quiet by default; set PLAYWRIGHT_SHOW_LOGS=true to debug locally.
+    // sbt 2.x caches setting values and a JSEnv is not serializable, so wrap it in Def.uncached.
     Test / jsEnv :=
-      new jsenv.playwright.PWEnv(
-        browserName = "chromium",
-        headless = true,
-        showLogs = sys.env.get("PLAYWRIGHT_SHOW_LOGS").exists(_.equalsIgnoreCase("true"))
+      Def.uncached(
+        new wvlet.uni.jsenv.playwright.PlaywrightJSEnv(browserName = "chromium", headless = true)
       )
   )
   .dependsOn(uni.js, test.js % Test)

--- a/docs/book/ch01-01-installation.md
+++ b/docs/book/ch01-01-installation.md
@@ -99,27 +99,25 @@ dependencies. Subsequent runs are fast.
 ## Cross-platform projects
 
 Most Uni code works unchanged on **JVM**, **Scala.js**, and **Scala
-Native**. For a cross-build project, use
-[sbt-crossproject](https://github.com/portable-scala/sbt-crossproject)
-and reference Uni with `%%%` instead of `%%`:
+Native**. On **sbt 2.x**, cross-build with Uni's own
+[sbt-uni-crossproject](/build/sbt-uni-crossproject) plugin (the
+portable-scala plugins are not published for sbt 2.x):
 
 ```scala
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"       % "1.3.2")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"                    % "1.16.0")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"               % "0.5.7")
+// project/plugins.sbt
+addSbtPlugin("org.scala-js"     % "sbt-scalajs"          % "1.22.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native"     % "0.5.12")
+addSbtPlugin("org.wvlet.uni"    % "sbt-uni-crossproject" % "__UNI_VERSION__")
 ```
 
 ```scala
 // build.sbt
-import sbtcrossproject.CrossPlugin.autoImport.CrossType
-
 lazy val hello = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("."))
   .settings(
     scalaVersion := "3.3.4",
-    libraryDependencies += "org.wvlet.uni" %%% "uni" % "2026.1.0"
+    libraryDependencies += "org.wvlet.uni" %% "uni" % "__UNI_VERSION__"
   )
 ```
 
@@ -161,12 +159,14 @@ everyone shares lives at the module root under `src/main/scala` and
 > browser DOM API, a native syscall. You will see examples of that in
 > Chapter 11.
 
-The `%%%` operator tells sbt: *pick the version of `uni` that was built
-for whichever platform I am compiling for right now*. Your Scala source
-does not change between platforms; only the build setting does.
+On sbt 2.x the `%%` operator tells sbt: *pick the version of `uni` that
+was built for whichever platform I am compiling for right now* (it
+encodes the platform suffix, so the older `%%%` is no longer needed).
+Your Scala source does not change between platforms; only the build
+setting does.
 
 We will build a real cross-platform codebase in Chapter 11. For now
-know that it is one cross-plugin, one `CrossType.Pure`, and a `%%%`
+know that it is one cross-plugin, one `CrossType.Pure`, and a `%%`
 away — and that everything you write goes in `src/main/scala`.
 
 ## IDE setup

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.12.13
+sbt.version=2.0.1
 

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,23 +1,20 @@
-// Ignore binary incompatible errors for libraries using scala-xml.
-// sbt-scoverage upgraded to scala-xml 2.1.0, but other sbt-plugins and Scala compilier 2.12 uses scala-xml 1.x.x
-ThisBuild / libraryDependencySchemes ++=
-  Seq(
-    "org.scala-lang.modules" %% "scala-xml"                % "always",
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "always"
-  )
-
-val AIRFRAME_VERSION = "2026.1.7"
+// uni-owned sbt 2.x plugins (published from this repo) that replace third-party plugins which have
+// not been ported to sbt 2.x: sbt-uni-crossproject replaces sbt-scalajs-crossproject +
+// sbt-scala-native-crossproject; uni-jsenv-playwright replaces io.github.gmkumar2005's env; sbt-uni
+// (uniRestart/uniStop/uniStatus) replaces sbt-revolver.
+val UNI_PLUGIN_VERSION = "2026.1.14"
 
 // For GPG signing published artifacts
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 
-addSbtPlugin("org.scalameta"       % "sbt-scalafmt"             % "2.6.1")
-addSbtPlugin("org.portable-scala"  % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("com.eed3si9n"        % "sbt-buildinfo"            % "0.13.1")
-addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings"         % "1.1.4")
+addSbtPlugin("org.scalameta"       % "sbt-scalafmt"     % "2.6.1")
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.4")
 
-// For developing server applications
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
+// Cross-building for JVM / Scala.js / Scala Native (CrossType.Pure)
+addSbtPlugin("org.wvlet.uni" % "sbt-uni-crossproject" % UNI_PLUGIN_VERSION)
+
+// uniRestart/uniStop/uniStatus for developing server applications
+addSbtPlugin("org.wvlet.uni" % "sbt-uni" % UNI_PLUGIN_VERSION)
 
 // For Scala.js
 val SCALAJS_VERSION = sys.env.getOrElse("SCALAJS_VERSION", "1.22.0")
@@ -26,20 +23,17 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % SCALAJS_VERSION)
 // For running Scala.js tests in Node.js
 libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.6.0"
 
-// For running Scala.js DOM tests in a real headless browser (Chromium via Playwright).
-// Unlike jsdom, this supports ES modules and a faithful DOM, and Chromium matches the
-// Electron renderer. The Java Playwright runtime bundles its own driver and downloads
-// browsers on demand, so no Node.js or npm packages are required to run these tests.
-libraryDependencies += "io.github.gmkumar2005" %% "scala-js-env-playwright" % "0.1.18"
+// For running Scala.js DOM tests in a real headless browser (Chromium via Playwright). Unlike
+// jsdom, this supports ES modules and a faithful DOM, and Chromium matches the Electron renderer.
+// The Java Playwright runtime bundles its own driver and downloads browsers on demand, so no
+// Node.js or npm packages are required to run these tests.
+libraryDependencies += "org.wvlet.uni" %% "uni-jsenv-playwright" % UNI_PLUGIN_VERSION
 
 // For Scala native
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.12")
-
-addDependencyTreePlugin
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
 
 // For setting explicit versions for each commit
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-pack"   % "0.23")
+addSbtPlugin("org.xerial.sbt" % "sbt-pack"   % "1.0.0")
 
 scalacOptions ++= Seq("-deprecation", "-feature")


### PR DESCRIPTION
## Why

The main build ran on **sbt 1.x**. The blockers are now gone:
- `sbt-scalajs-crossproject` + `sbt-scala-native-crossproject` → **`sbt-uni-crossproject`** (#623)
- third-party `scala-js-env-playwright` → **`uni-jsenv-playwright`** (#613)
- `sbt-revolver` (unused in the build, no sbt 2.x release) → **`sbt-uni`**'s `uniRestart`/`uniStop`/`uniStatus`

## What

- `project/build.properties` → **sbt 2.0.1**; metabuild plugins swapped (see table in the ADR). Dropped unused `sbt-buildinfo` and the now-built-in `addDependencyTreePlugin`; bumped `sbt-pack` 0.23 → 1.0.0.
- Because `sbt-uni-crossproject` reproduces the `crossProject` / `CrossType.Pure` API, the project definitions are **unchanged**. Only sbt-2.x source adjustments:
  - **root → `uni-root`** — sbt 2.x derives output dirs from the project *name*, which collided with the `uni` library project (*"Overlapping output directories"*).
  - **`%%%` → `%%`** everywhere; the platform-less `scalajs-test-interface_2.13` named directly with a single `%` (in a JS project, any cross-version injects the unwanted `_sjs1`).
  - **`Test / jsEnv` wrapped in `Def.uncached(...)`** (JSEnv isn't serializable; sbt 2.x caches settings).
  - `import scala.language.implicitConversions` for `core.jvm` used as `ProjectReference`; `xs: _*` → `xs*`; infix `classifier` → `.classifier(...)`.
- Docs: CLAUDE.md + the book's cross-build install snippet updated to the sbt 2.x / `sbt-uni-crossproject` approach. New ADR `adr/2026-06-30-sbt2-main-build-migration.md`.
- **CI needs no change** — the repo's `./sbt` runner reads `build.properties` (→ 2.0.1) and `code_format` uses the kept `sbt-scalafmt`.

## Validation (all on sbt 2.0.1, run locally)

| Platform | Result |
|---|---|
| JVM (`projectJVM/test`) | 1655 passed, 4 pending · +39 netty/book |
| JS / NodeJSEnv | uniJS ~1420 · testJS 71 passed |
| JS / Playwright Chromium (`domTest`) | 374 passed |
| Native (`projectNative/test`) | uniNative 1417 (+9 pending) · testNative 71 passed |

`scalafmtCheckAll` and `pnpm docs:build` pass. (`uni-core` reports 0 tests on every platform — it has no `src/test`, not a regression.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)