### PR TITLE
fix: Resolve Any to AnyWeaver in Weaver.fromSurface instead of the lossy empty-object fallback

### DIFF
--- a/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
@@ -387,6 +387,14 @@ object Weaver:
       CaseClassWeaver(s, fieldWeavers)
   }
 
+  // Any has a well-defined generic codec: AnyWeaver packs values by their runtime type and
+  // unpacks to generic values (Long, Double, String, Seq, Map, ...). Resolve it ahead of the
+  // lossy empty-object fallback so fields like Map[String, Any] round-trip out of the box.
+  private val anyFactory: WeaverFactory = {
+    case s if s.fullName == "scala.Any" =>
+      AnyWeaver.default
+  }
+
   // Fallback for surfaces with no objectFactory (open abstract types). Lossy by design:
   // a custom `given Weaver[A]` is required to preserve subtype data on round-trip.
   private val emptyObjectWeaver: Weaver[Any] =
@@ -415,6 +423,7 @@ object Weaver:
     collectionFactory,
     javaCollectionFactory,
     complexTypeFactory,
+    anyFactory,
     emptyObjectFallbackFactory
   )
 

--- a/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
+++ b/uni/src/main/scala/wvlet/uni/weaver/Weaver.scala
@@ -387,11 +387,14 @@ object Weaver:
       CaseClassWeaver(s, fieldWeavers)
   }
 
-  // Any has a well-defined generic codec: AnyWeaver packs values by their runtime type and
-  // unpacks to generic values (Long, Double, String, Seq, Map, ...). Resolve it ahead of the
-  // lossy empty-object fallback so fields like Map[String, Any] round-trip out of the box.
+  // Any/AnyRef have a well-defined generic codec: AnyWeaver packs values by their runtime type
+  // and unpacks to generic values (Long, Double, String, Seq, Map, ...). Resolve them ahead of
+  // the lossy empty-object fallback so fields like Map[String, Any] round-trip out of the box.
+  // The rawType check covers the `scala.Any` alias, `AnyRef`/`java.lang.Object`, and the
+  // AnyRefSurface placeholders Surface uses for erased type parameters; case classes never
+  // reach here because complexTypeFactory matches first.
   private val anyFactory: WeaverFactory = {
-    case s if s.fullName == "scala.Any" =>
+    case s if s.rawType == classOf[AnyRef] =>
       AnyWeaver.default
   }
 

--- a/uni/src/test/scala/wvlet/uni/weaver/WeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/WeaverTest.scala
@@ -647,6 +647,14 @@ class WeaverTest extends UniTest:
     w.unweave(w.weave(3)) shouldBe 3L
   }
 
+  test("fromSurface resolves AnyRef and java.lang.Object to AnyWeaver") {
+    import wvlet.uni.surface.Surface
+    for surface <- Seq(Surface.of[AnyRef], Surface.of[Object]) do
+      val w = Weaver.fromSurface(surface).asInstanceOf[Weaver[Any]]
+      w.unweave(w.weave("hello")) shouldBe "hello"
+      w.unweave(w.weave(3)) shouldBe 3L
+  }
+
   test("case class with Map[String, Any] field decodes values from JSON") {
     val decoded = Weaver
       .of[WeaverTest.ConfigWithAnyMap]

--- a/uni/src/test/scala/wvlet/uni/weaver/WeaverTest.scala
+++ b/uni/src/test/scala/wvlet/uni/weaver/WeaverTest.scala
@@ -636,6 +636,39 @@ class WeaverTest extends UniTest:
     Weaver.fromSurfaceOpt(Surface.of[Map[String, WeaverTest.Greeting]]).isDefined shouldBe true
   }
 
+  // Regression coverage for issue #632: Any-typed values (e.g. Map[String, Any] fields) must
+  // decode via AnyWeaver instead of the lossy empty-object fallback that silently yields null.
+  test("fromSurface resolves Any to AnyWeaver") {
+    import wvlet.uni.surface.Surface
+    val w       = Weaver.fromSurface(Surface.of[Any]).asInstanceOf[Weaver[Any]]
+    val decoded = w.unweave(w.weave("hello"))
+    decoded shouldBe "hello"
+    w.unweave(w.weave(true)) shouldBe true
+    w.unweave(w.weave(3)) shouldBe 3L
+  }
+
+  test("case class with Map[String, Any] field decodes values from JSON") {
+    val decoded = Weaver
+      .of[WeaverTest.ConfigWithAnyMap]
+      .fromJson("""{"name": "c", "properties": {"useSSL": false, "retries": 3}}""")
+    decoded.name shouldBe "c"
+    decoded.properties shouldBe Map("useSSL" -> false, "retries" -> 3L)
+  }
+
+  test("nested case class with Map[String, Any] decodes without per-level givens") {
+    val decoded = Weaver
+      .of[WeaverTest.OuterConfig]
+      .fromJson("""{"configs": [{"name": "c", "properties": {"useSSL": false}}]}""")
+    decoded shouldBe
+      WeaverTest.OuterConfig(List(WeaverTest.ConfigWithAnyMap("c", Map("useSSL" -> false))))
+  }
+
+  test("fromSurfaceOpt returns Some for Any-containing types") {
+    import wvlet.uni.surface.Surface
+    Weaver.fromSurfaceOpt(Surface.of[Map[String, Any]]).isDefined shouldBe true
+    Weaver.fromSurfaceOpt(Surface.of[WeaverTest.ConfigWithAnyMap]).isDefined shouldBe true
+  }
+
   test("fromSurfaceOpt returns None when fromSurface itself throws") {
     // java.math.BigInteger is marked primitive in Surface but has no primitiveFactory branch,
     // so fromSurface throws IllegalArgumentException. fromSurfaceOpt must convert that to None
@@ -651,3 +684,5 @@ end WeaverTest
 object WeaverTest:
   case class HasEither(e: Either[String, Int])
   case class Greeting(message: String)
+  case class ConfigWithAnyMap(name: String, properties: Map[String, Any] = Map.empty)
+  case class OuterConfig(configs: List[ConfigWithAnyMap])


### PR DESCRIPTION
## Summary

Fixes #632.

`Weaver.fromSurface` mapped the `Any` surface to the private `emptyObjectWeaver`, so any `Any`-typed value reached via the Surface-driven derivation path silently decoded to `null`. The visible symptom: a case class field like `properties: Map[String, Any]` inside a nested structure round-tripped every value in the map to `null` with no error, unless the caller hand-built a given chain down to `Weaver[Map[String, Any]]`.

## Fix

Add an `anyFactory` to `Weaver.fromSurface`'s factory list, ahead of `emptyObjectFallbackFactory`, that resolves surfaces with `rawType == classOf[AnyRef]` to `AnyWeaver.default` — the generic codec already exposed as `given anyWeaver: Weaver[Any]` in `PrimitiveWeaver`. This covers the `scala.Any` alias, `AnyRef`/`java.lang.Object`, and the `AnyRefSurface` placeholders Surface uses for erased type parameters (per review feedback). Case classes and other concrete types are unaffected because `complexTypeFactory` matches first, and the empty-object fallback remains in place for genuinely open abstract types.

As a consequence, `Weaver.fromSurfaceOpt` now returns `Some` for `Any`-containing types (e.g. `Map[String, Any]`), so `RouterHandler` routes returning such types use the weaver path (structural JSON) instead of the toString fallback.

## Tests

- `fromSurface(Surface.of[Any])` round-trips primitives via `AnyWeaver` (was: decodes to `null`)
- Same for `AnyRef` and `java.lang.Object`
- The exact issue repro: `Map[String, Any]` field decoding from JSON
- The nested variant (`List[ConfigWithAnyMap]`) that exercises the Surface-driven fallback path in the derivation macro, with no per-level givens (was: `Map("useSSL" -> null)`)
- `fromSurfaceOpt` returns `Some` for `Any`-containing types

All `uniJVM` and `netty` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)