### PR TITLE
fix: Reformat CrossProjectMacro for scalafmt 3.11.3 to unblock CI

### DIFF
--- a/sbt-uni-crossproject/src/main/scala/wvlet/uni/sbt/crossproject/CrossProjectMacro.scala
+++ b/sbt-uni-crossproject/src/main/scala/wvlet/uni/sbt/crossproject/CrossProjectMacro.scala
@@ -20,44 +20,21 @@ private[crossproject] object CrossProjectMacro:
       "crossProject must be directly assigned to a val, " +
         "such as `val x = crossProject(JVMPlatform, JSPlatform)`."
     )
-    '{
-      CrossProject(
-        ${
-          name
-        },
-        new java.io.File(
-          ${
-            name
-          }
-        )
-      )(
-        ${
-          platforms
-        }*
-      )
-    }
+    '{ CrossProject(${ name }, new java.io.File(${ name }))(${ platforms }*) }
 
   private def definingValName(errorMsg: String)(using Quotes): Expr[String] =
     import quotes.reflect.*
     val term = enclosingTerm
-    if term.isValDef then
-      Expr(term.name)
-    else
-      report.errorAndAbort(errorMsg)
+    if term.isValDef then Expr(term.name) else report.errorAndAbort(errorMsg)
 
   private def enclosingTerm(using qctx: Quotes): qctx.reflect.Symbol =
     import qctx.reflect.*
     @tailrec
-    def enclosingTerm0(sym: Symbol): Symbol =
-      sym match
-        case sym if sym.flags.is(Flags.Macro) =>
-          enclosingTerm0(sym.owner)
-        case sym if sym.flags.is(Flags.Synthetic) =>
-          enclosingTerm0(sym.owner)
-        case sym if !sym.isTerm =>
-          enclosingTerm0(sym.owner)
-        case _ =>
-          sym
+    def enclosingTerm0(sym: Symbol): Symbol = sym match
+      case sym if sym.flags.is(Flags.Macro)     => enclosingTerm0(sym.owner)
+      case sym if sym.flags.is(Flags.Synthetic) => enclosingTerm0(sym.owner)
+      case sym if !sym.isTerm                   => enclosingTerm0(sym.owner)
+      case _                                    => sym
     enclosingTerm0(Symbol.spliceOwner)
 
 end CrossProjectMacro


### PR DESCRIPTION
## Why

The scalafmt 3.11.3 update (#646) changed how `newlines.source = fold` formats `CrossProjectMacro.scala`, but the `sbt-uni-crossproject` sub-build was not reformatted at that time. As a result, `scalafmtCheckAll` in the **sbt-uni-crossproject scripted test** CI job fails on every PR — first surfaced by #648.

## What

Ran `scalafmtAll` in the sub-build. Verified locally with the same command CI runs: `scalafmtCheckAll; publishLocal; scripted` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)