### PR TITLE
fix: Await each WebSocket client send in tests to fix flaky fragmented-message test

### DIFF
--- a/uni-netty/src/test/scala/wvlet/uni/http/netty/WebSocketTest.scala
+++ b/uni-netty/src/test/scala/wvlet/uni/http/netty/WebSocketTest.scala
@@ -137,9 +137,9 @@ class WebSocketTest extends UniTest:
         val listener = CollectingListener()
         val ws       = connect(server.localPort, "/ws/echo", listener)
         try
-          ws.sendText("hello", true)
+          ws.sendText("hello", true).get(10, TimeUnit.SECONDS)
           listener.nextText shouldBe "echo:hello"
-          ws.sendText("world", true)
+          ws.sendText("world", true).get(10, TimeUnit.SECONDS)
           listener.nextText shouldBe "echo:world"
         finally
           ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye")
@@ -213,9 +213,11 @@ class WebSocketTest extends UniTest:
         val listener = CollectingListener()
         val ws       = connect(server.localPort, "/ws/frag", listener)
         try
-          // Send across two fragments; the server should see one coalesced message.
-          ws.sendText("first-", false)
-          ws.sendText("second", true)
+          // Send across two fragments; the server should see one coalesced message. Each send must
+          // complete before the next: the JDK client rejects a send while one is pending, which
+          // would silently drop the final fragment and leave the aggregator waiting forever.
+          ws.sendText("first-", false).get(10, TimeUnit.SECONDS)
+          ws.sendText("second", true).get(10, TimeUnit.SECONDS)
           listener.nextText shouldBe s"len:${"first-second".length}"
         finally
           ws.sendClose(WebSocket.NORMAL_CLOSURE, "bye")


### PR DESCRIPTION
## Why

The `Scala 3` CI job failed on PR #650 with a flaky `WebSocketTest` failure:

```
- fragmented text messages are aggregated: Expected <len:12> but got <null> (WebSocketTest.scala:219) (12.01s)
```

The JDK `java.net.http.WebSocket` client rejects a new send while a previous send is still pending. The test called `sendText("first-", false)` and `sendText("second", true)` back-to-back without awaiting the returned futures, so under scheduling pressure the final fragment is dropped, the server-side aggregator never sees a complete message, and `nextText` times out returning `null`.

## What

Await each `sendText` future (`.get(10, TimeUnit.SECONDS)`) before the next send in the fragmented-message and echo tests. Verified locally: all 12 `WebSocketTest` tests pass, `scalafmtCheckAll` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)