### PR TITLE
docs: Show Uni at the C boundary in Book ch14/ch15

### DIFF
--- a/docs/book/ch14-00-calling-c.md
+++ b/docs/book/ch14-00-calling-c.md
@@ -30,6 +30,15 @@ object curl:
 
   @name("curl_easy_perform")
   def easyPerform(handle: Ptr[Byte]): CInt = extern
+
+  @name("curl_easy_strerror")
+  def easyStrError(code: CInt): CString = extern
+
+  @name("curl_easy_cleanup")
+  def easyCleanup(handle: Ptr[Byte]): Unit = extern
+
+// Option codes come from curl.h; 10002 is CURLOPT_URL
+val CURLOPT_URL: CInt = 10002
 ```
 
 Four pieces, mirroring the JavaScript facade from Chapter 12:
@@ -45,6 +54,8 @@ Four pieces, mirroring the JavaScript facade from Chapter 12:
 
 You declare only the handful of functions you call, exactly as with a JS
 facade. `libcurl` exports hundreds; a working HTTP client needs a dozen.
+C constants (like `CURLOPT_URL`) don't cross the boundary at all — you
+copy their values out of the header file into ordinary Scala `val`s.
 
 ## C types in Scala
 
@@ -96,6 +107,87 @@ can't be used after they're freed. (You'll see the one case where `Zone`
 is *wrong* — a value handed back to C that must outlive the call — in
 [Chapter 15](./ch15-00-exposing-native).)
 
+## A Uni service over the binding
+
+The binding compiles, but nothing about it feels like the code you've
+written in the rest of this book: it traffics in pointers and integer
+return codes, and a failure is a `CInt` you have to remember to check.
+Don't spread that through your application. Wrap the binding in one
+ordinary Scala class, and let Uni take over from there.
+
+```scala
+import scala.scalanative.unsafe.*
+import wvlet.uni.log.LogSupport
+
+class CurlError(code: Int, message: String)
+    extends Exception(s"curl error ${code}: ${message}")
+
+class Downloader extends LogSupport with AutoCloseable:
+  private val handle = curl.easyInit()
+
+  def fetch(url: String): Unit = Zone.acquire { implicit z =>
+    curl.easySetOpt(handle, CURLOPT_URL, toCString(url))
+    val code = curl.easyPerform(handle)
+    if code != 0 then
+      val message = fromCString(curl.easyStrError(code))
+      error(s"GET ${url} failed: ${message}")
+      throw CurlError(code, message)
+    debug(s"GET ${url} succeeded")
+  }
+
+  override def close(): Unit = curl.easyCleanup(handle)
+```
+
+This one class is the whole unsafe surface. Everything C-shaped is
+translated at the edge:
+
+- **Error codes become exceptions.** C reports failure by returning a
+  nonzero `CInt`; the compiler doesn't force anyone to look at it. The
+  wrapper checks once, converts the code to a message with
+  `easyStrError`, and throws — callers can't silently ignore a failed
+  download.
+- **`LogSupport` works here like everywhere else.** The logging you
+  learned in [Chapter 5](./ch05-00-logging) is pure Scala, so it
+  cross-compiles to Native unchanged — `error` and `debug` at the C
+  boundary behave exactly as they did on the JVM. When a native binary
+  misbehaves in production, the log line with curl's own error message
+  is what you'll want.
+- **Callers see `fetch(url: String)`.** No `Ptr`, no `CString`, no
+  `Zone`. The rest of the application cannot tell — and should not care —
+  that a C library sits underneath.
+
+## Give the C handle a lifecycle
+
+There is one problem left: `handle` is C memory. Scala's garbage
+collector doesn't know about it, so nothing frees it unless `close()`
+runs. That is precisely what `Design`'s lifecycle hooks from
+[Chapter 3](./ch03-00-design) are for:
+
+```scala
+import wvlet.uni.design.Design
+
+val design = Design
+  .newDesign
+  .bindSingleton[Downloader]
+  .onShutdown(_.close())
+
+design.build[Downloader] { downloader =>
+  downloader.fetch("https://example.com")
+}   // session ends here: close() runs, curl_easy_cleanup frees the handle
+```
+
+The session guarantees `close()` runs exactly once, when the session
+ends — the same deterministic teardown you'd want for a database
+connection, applied to a C resource. And because `Downloader` is now
+just a binding in a design, tests can substitute it the way
+[Chapter 3](./ch03-00-design) substituted a database: put a trait in
+front of it, `bindImpl` the C-backed class in the production design, and
+bind a stub in the test design — no test ever opens a real curl handle.
+
+This layering — raw `@extern` facade at the bottom, one safe wrapper
+class, Uni services on top — is how Uni's own Native HTTP client is
+built, and it is the shape to copy for any C library you bind.
+
 ## Why bind C directly?
 
 On the JVM, reaching a C library means JNI: a separate C shim, a build
@@ -113,7 +205,8 @@ wrap any C library the same way.
 
 ## What you have, what comes next
 
-You can now call C libraries from Scala Native:
+You can now call C libraries from Scala Native — and make them feel
+like Uni code:
 
 - An **`@extern` object** with **`@link`** and **`@name`** declares the C
   functions you use — a facade, like Chapter 12's, but for C.
@@ -121,6 +214,11 @@ You can now call C libraries from Scala Native:
   a `CString` is not a Scala `String`.
 - **`Zone.acquire`** + **`toCString`** allocate temporary arguments with a
   scoped lifetime; **`fromCString`** reads results back.
+- **One wrapper class** turns error codes into exceptions and logs
+  through `LogSupport`; the rest of the app never sees a `Ptr`.
+- **`Design` + `onShutdown`** give the C handle a deterministic
+  lifecycle, and a trait in front of the wrapper keeps it swappable in
+  tests.
 
 Next, [Chapter 15](./ch15-00-exposing-native) turns the arrow around:
 instead of Scala calling C, you'll expose your Scala Native code *as* a C

--- a/docs/book/ch14-00-calling-c.md
+++ b/docs/book/ch14-00-calling-c.md
@@ -138,8 +138,11 @@ class Downloader extends LogSupport with AutoCloseable:
   override def close(): Unit = curl.easyCleanup(handle)
 ```
 
-This one class is the whole unsafe surface. Everything C-shaped is
-translated at the edge:
+Notice what this class is: the *only* place where both vocabularies
+appear. Above it, pure Scala (`fetch(url: String)`, exceptions,
+`LogSupport`); below it, pure C (`Ptr`, `CString`, return codes). The
+mixing of the two worlds is the wrapper's entire job, and it happens
+here and nowhere else — everything C-shaped is translated at this edge:
 
 - **Error codes become exceptions.** C reports failure by returning a
   nonzero `CInt`; the compiler doesn't force anyone to look at it. The

--- a/docs/book/ch15-00-exposing-native.md
+++ b/docs/book/ch15-00-exposing-native.md
@@ -71,39 +71,65 @@ case classes, collections — and the C ABI only speaks integers and
 pointers. How do you get a `PriceRequest` across?
 
 You don't define C structs for it. You pass **JSON strings** and let
-[Weaver](./ch06-00-data) do the translating. The exported function
-becomes a thin shell: decode the argument, run ordinary Uni code, encode
-the result.
+[Weaver](./ch06-00-data) do the translating — and you keep the two
+worlds in two separate files, meeting at a plain Scala `String`.
+
+The first file is your actual library. It is pure Uni code: no
+`CString`, no `Ptr`, no `unsafe` import. Following
+[Chapter 11](./ch11-00-cross-platform)'s layout it lives in the shared
+`src/` folder, because nothing in it is native-specific:
 
 ```scala
-import scala.scalanative.unsafe.*
-import scala.scalanative.libc.stdlib
+// src/ — shared code. Compiles on JVM, JS, and Native alike.
 import wvlet.uni.log.LogSupport
 import wvlet.uni.weaver.Weaver
 
 case class PriceRequest(product: String, quantity: Int) derives Weaver
 case class PriceQuote(product: String, quantity: Int, total: Double) derives Weaver
 
-object PricingLib extends LogSupport:
-  @exported("pricing_quote")
-  def quote(requestJson: CString): CString =
-    val request = Weaver.fromJson[PriceRequest](fromCString(requestJson))
+object PricingService extends LogSupport:
+  def quote(requestJson: String): String =
+    val request = Weaver.fromJson[PriceRequest](requestJson)
     debug(s"Quoting ${request.quantity} x ${request.product}")
     val response = PriceQuote(request.product, request.quantity, request.quantity * 9.99)
-    toCStringHeap(Weaver.toJson(response))
+    Weaver.toJson(response)
+```
+
+The second file is the C bridge, and it is *only* the bridge. Each
+exported function is one line: convert, delegate, convert back. It goes
+in the `.native` folder, because it can compile nowhere else:
+
+```scala
+// .native/ — the C bridge. Conversions only; no logic lives here.
+import scala.scalanative.unsafe.*
+import scala.scalanative.libc.stdlib
+
+object PricingLib:
+  @exported("pricing_quote")
+  def quote(requestJson: CString): CString =
+    toCStringHeap(PricingService.quote(fromCString(requestJson)))
 
   @exported("pricing_free")
   def free(str: CString): Unit = stdlib.free(str)
 ```
 
-Three things to notice:
+The split is the point:
 
-- **Everything between decode and encode is ordinary Uni code.** The
-  logging from [Chapter 5](./ch05-00-logging), the `derives Weaver`
-  codecs from [Chapter 6](./ch06-00-data), `Design`-built services if
-  the logic needs them — all of it cross-compiles to Native, so all of
-  it is available inside an exported function. The C boundary is two
-  lines; Uni is everything in between.
+- **The two worlds meet in exactly one file.** `PricingService` speaks
+  Scala (`String` in, `String` out); `PricingLib` speaks C (`CString`
+  in, `CString` out); `fromCString` / `toCStringHeap` are the only
+  words they exchange. When something goes wrong at the boundary, there
+  is one short file to look in — the same one-place rule Chapter 14
+  applied to the `Downloader` wrapper, pointing the other way.
+- **The service never left the ordinary Uni world.** The logging from
+  [Chapter 5](./ch05-00-logging), the `derives Weaver` codecs from
+  [Chapter 6](./ch06-00-data), `Design`-built services if the logic
+  needs them — all available, because `PricingService` is just Scala.
+  And because it lives in shared `src/`, you can unit-test it with
+  UniTest on the JVM ([Chapter 4](./ch04-00-testing)) — no native
+  toolchain, no C caller — or serve the same logic over RPC
+  ([Chapter 10](./ch10-00-rpc)). The C ABI is one more front door, not
+  a fork of your code.
 - **JSON is the boundary contract.** Every language that can call C can
   also build a JSON string, so callers get rich structured input and
   output without you maintaining a C struct layout for each type. Add a
@@ -254,9 +280,12 @@ You can now ship Uni-powered Scala to the systems world:
 - Return values go on the **heap** (`malloc`), never a `Zone` — and the
   library exports the matching **free function**, because whoever
   `malloc`s must `free`.
-- **JSON strings are the boundary contract**: `Weaver.fromJson` on the
-  way in, ordinary Uni code (logging, codecs, `Design`) in the middle,
-  `Weaver.toJson` on the way out.
+- **Two files, one meeting point**: a pure-Scala service (`String` in,
+  `String` out, Uni everywhere) in shared `src/`, and a
+  conversions-only C bridge in `.native/` — `fromCString` /
+  `toCStringHeap` are the only words the two worlds exchange.
+- **JSON strings are the boundary contract**: `Weaver.fromJson` inside
+  the service on the way in, `Weaver.toJson` on the way out.
 - **`BuildTarget.libraryDynamic` / `libraryStatic`** + `nativeLink`
   produce a `.so` / `.dylib` / `.a` and a C header; static libraries
   need one **`ScalaNativeInit()`** call before use.

--- a/docs/book/ch15-00-exposing-native.md
+++ b/docs/book/ch15-00-exposing-native.md
@@ -39,19 +39,84 @@ with `malloc` and hand ownership across the boundary:
 
 ```scala
 import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
 import scala.scalanative.libc.stdlib
 
-private def toCStringHeap(str: String): CString =
+def toCStringHeap(str: String): CString =
   val bytes  = str.getBytes("UTF-8")
-  val buffer = stdlib.malloc(bytes.length + 1).asInstanceOf[CString]
-  // copy bytes into buffer and null-terminate...
-  buffer
+  val buffer = stdlib.malloc((bytes.length + 1).toCSize)
+  var i      = 0
+  while i < bytes.length do
+    buffer(i) = bytes(i)
+    i += 1
+  buffer(bytes.length) = 0.toByte
+  buffer.asInstanceOf[CString]
 ```
 
 This is the one genuinely subtle rule of exporting: **arguments use a
 `Zone`, return values use the heap.** Wvlet's real C library uses exactly
 this split — `fromCString` on the way in, a `malloc`-backed `toCString` on
 the way out.
+
+Heap memory raises the question a `Zone` answered for you: who frees it?
+The answer at a C boundary is a convention — the library that `malloc`s
+must be the one that `free`s — so a well-behaved library also exports a
+matching free function. You'll see one in the next section.
+
+## Ship Uni logic, not toy strings
+
+`greet` shows the mechanics, but nobody builds a library to concatenate
+strings. The real question is: your Scala logic works on *rich* values —
+case classes, collections — and the C ABI only speaks integers and
+pointers. How do you get a `PriceRequest` across?
+
+You don't define C structs for it. You pass **JSON strings** and let
+[Weaver](./ch06-00-data) do the translating. The exported function
+becomes a thin shell: decode the argument, run ordinary Uni code, encode
+the result.
+
+```scala
+import scala.scalanative.unsafe.*
+import scala.scalanative.libc.stdlib
+import wvlet.uni.log.LogSupport
+import wvlet.uni.weaver.Weaver
+
+case class PriceRequest(product: String, quantity: Int) derives Weaver
+case class PriceQuote(product: String, quantity: Int, total: Double) derives Weaver
+
+object PricingLib extends LogSupport:
+  @exported("pricing_quote")
+  def quote(requestJson: CString): CString =
+    val request = Weaver.fromJson[PriceRequest](fromCString(requestJson))
+    debug(s"Quoting ${request.quantity} x ${request.product}")
+    val response = PriceQuote(request.product, request.quantity, request.quantity * 9.99)
+    toCStringHeap(Weaver.toJson(response))
+
+  @exported("pricing_free")
+  def free(str: CString): Unit = stdlib.free(str)
+```
+
+Three things to notice:
+
+- **Everything between decode and encode is ordinary Uni code.** The
+  logging from [Chapter 5](./ch05-00-logging), the `derives Weaver`
+  codecs from [Chapter 6](./ch06-00-data), `Design`-built services if
+  the logic needs them — all of it cross-compiles to Native, so all of
+  it is available inside an exported function. The C boundary is two
+  lines; Uni is everything in between.
+- **JSON is the boundary contract.** Every language that can call C can
+  also build a JSON string, so callers get rich structured input and
+  output without you maintaining a C struct layout for each type. Add a
+  field to `PriceQuote` and existing callers keep working.
+- **`pricing_free` completes the ownership story.** The returned string
+  was `malloc`ed inside the Scala library, so the Scala library exports
+  the function that frees it. Callers treat the pair as
+  open/close: call `pricing_quote`, read the result, call
+  `pricing_free`.
+
+Only static object methods can be exported, and their parameter and
+return types must be C-representable (primitives and pointers) — which
+is exactly why the JSON-string shape works so well.
 
 ## Build it as a library
 
@@ -66,67 +131,89 @@ import scala.scalanative.build.BuildTarget
 lazy val mylib = project
   .enablePlugins(ScalaNativePlugin)
   .settings(
-    nativeConfig ~= { _.withBuildTarget(BuildTarget.libraryDynamic) }
-  )
-
-// Static library: libmylib.a (and .withBaseName to set the lib name)
-lazy val mylibStatic = project
-  .enablePlugins(ScalaNativePlugin)
-  .settings(
+    libraryDependencies += "org.wvlet.uni" %%% "uni" % "__UNI_VERSION__",
     nativeConfig ~= {
-      _.withBuildTarget(BuildTarget.libraryStatic).withBaseName("mylib")
+      _.withBuildTarget(BuildTarget.libraryDynamic).withBaseName("mylib")
     }
   )
 ```
+
+The `uni` dependency is the same line as any Native project from
+[Chapter 11](./ch11-00-cross-platform) — Weaver and logging compile into
+the library like any other Scala code. Swap `libraryDynamic` for
+`BuildTarget.libraryStatic` to get a static `libmylib.a` instead.
 
 `sbt mylib/nativeLink` then emits the shared library, and Scala Native
 also generates a C header declaring your exported functions.
 
+One initialization rule: the Scala Native runtime must start before the
+first exported call. A *dynamic* library does this itself — Scala Native
+generates a constructor that runs when the library loads. A *static*
+library can't, so C callers linking `libmylib.a` must call the generated
+`ScalaNativeInit()` once (it returns `0` on success) before anything
+else.
+
 ## Call it from Rust
 
-Rust links the library and declares the function in an `extern "C"`
-block:
+Rust links the library and declares the exported functions in an
+`extern "C"` block — its native equivalent of Chapter 14's `@extern`
+object, pointing the other way:
 
 ```rust
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
 extern "C" {
-    fn greet(name: *const c_char) -> *const c_char;
+    fn pricing_quote(request_json: *const c_char) -> *mut c_char;
+    fn pricing_free(response_json: *mut c_char);
 }
 
 fn main() {
-    let name = CString::new("Rust").unwrap();
+    let request = CString::new(r#"{"product":"keyboard","quantity":3}"#).unwrap();
     unsafe {
-        let reply = greet(name.as_ptr());
-        // ... read the returned C string ...
+        let response = pricing_quote(request.as_ptr());
+        println!("{}", CStr::from_ptr(response).to_str().unwrap());
+        pricing_free(response);
     }
 }
 ```
 
+The Rust side mirrors the memory rules from the Scala side exactly:
+`CString::new` plays the role of `toCString` for the argument (freed by
+Rust when `request` drops), and the response — `malloc`ed inside the
+Scala library — goes back through `pricing_free`.
+
 Compile it against the library by pointing the linker at the output
-directory and naming the lib:
+directory and naming the lib, then run it with the shared library on
+the loader's path:
 
 ```bash
 $ sbt mylib/nativeLink
 $ rustc -L target/scala-3.x -lmylib test.rs -o test
+$ LD_LIBRARY_PATH=target/scala-3.x ./test    # DYLD_LIBRARY_PATH on macOS
+{"product":"keyboard","quantity":3,"total":29.97}
 ```
 
 `-L` is the search path (where `libmylib.so` lives) and `-lmylib` is the
-library — the same two flags whatever the consuming language is.
+library — the same two flags whatever the consuming language is. At run
+time the dynamic loader needs the same directory, hence
+`LD_LIBRARY_PATH`.
 
 ## Call it from C and C++
 
-C and C++ are the same story: declare the function, link the library.
+C and C++ are the same story: declare the functions, link the library.
 
 ```c
 // test.c
 #include <stdio.h>
 
-const char* greet(const char* name);   // declare the exported function
+char* pricing_quote(const char* request_json);
+void  pricing_free(char* response_json);
 
 int main() {
-    printf("%s\n", greet("C"));
+    char* response = pricing_quote("{\"product\":\"keyboard\",\"quantity\":3}");
+    printf("%s\n", response);
+    pricing_free(response);
     return 0;
 }
 ```
@@ -135,8 +222,11 @@ int main() {
 $ gcc -L target/scala-3.x -lmylib test.c -o test   # g++ for C++
 ```
 
-Wvlet ships its query compiler this way: one Scala Native module exports
-`wvlet_compile_query`, builds to `libwvlet`, and its
+Wvlet ships its query compiler this way, in exactly the JSON-in/JSON-out
+shape you just built: one Scala Native module exports
+`wvlet_compile_query_json`, which takes a JSON string of arguments and
+returns a `char*` of JSON (`{"success":true,"sql":...}`), builds to
+`libwvlet`, and its
 [test suite](https://github.com/wvlet/wvlet/tree/main/wvc-lib) links the
 same `.so` from Rust, C, *and* C++ — three languages, one implementation,
 no ports.
@@ -157,14 +247,19 @@ you prefer, and hand it to everyone else as a `.so`.
 
 ## What you have, what comes next
 
-You can now ship Scala Native code to the systems world:
+You can now ship Uni-powered Scala to the systems world:
 
 - **`@exported("name")`** gives a method a C ABI; **`fromCString`** reads
   arguments.
-- Return values go on the **heap** (`malloc`), never a `Zone` — the one
-  subtle rule.
+- Return values go on the **heap** (`malloc`), never a `Zone` — and the
+  library exports the matching **free function**, because whoever
+  `malloc`s must `free`.
+- **JSON strings are the boundary contract**: `Weaver.fromJson` on the
+  way in, ordinary Uni code (logging, codecs, `Design`) in the middle,
+  `Weaver.toJson` on the way out.
 - **`BuildTarget.libraryDynamic` / `libraryStatic`** + `nativeLink`
-  produce a `.so` / `.dylib` / `.a` and a C header.
+  produce a `.so` / `.dylib` / `.a` and a C header; static libraries
+  need one **`ScalaNativeInit()`** call before use.
 - **`-L<dir> -l<name>`** links it from Rust, C, or C++ alike.
 
 That closes Part VIII — and, with it, Uni's reach into both neighboring


### PR DESCRIPTION
## Why

Ch14 (Calling C) and ch15 (Exposing Scala Native) taught generic Scala Native FFI, but Uni itself never appeared in the example code — a reader finished the chapters without seeing how to actually use Uni with C or Rust.

## What changed

**Ch14 — Calling C from Scala Native**
- Extended the `@extern` binding with `curl_easy_strerror` / `curl_easy_cleanup` (the chapter already called `easyStrError` without declaring it) and the `CURLOPT_URL` constant, so the snippets are self-contained.
- New section **"A Uni service over the binding"**: wraps the raw binding in one `Downloader` class that converts error codes to exceptions and logs through `LogSupport` — and states the one-place rule: this wrapper is the only file where the C and Scala vocabularies mix.
- New section **"Give the C handle a lifecycle"**: `Design` + `onShutdown` for deterministic cleanup of C memory, with the ch3 test-substitution story.

**Ch15 — Exposing Scala Native to C and Rust**
- Completed the previously elided `toCStringHeap` (real copy loop, `.toCSize`).
- New section **"Ship Uni logic, not toy strings"**, structured as an explicit two-world split: a pure-Scala `PricingService` in shared `src/` (`String` in/out, `derives Weaver` + `LogSupport`, unit-testable on the JVM), and a conversions-only `PricingLib` C bridge in `.native/` whose exported functions are one line each. An exported `pricing_free` completes the malloc/free ownership story. This mirrors wvlet's real `wvlet_compile_query_json` API, and the wvlet reference paragraph now says so.
- Rust and C callers updated to the JSON API, including expected output and the `LD_LIBRARY_PATH` runtime detail.
- Documented the `ScalaNativeInit()` rule: dynamic libraries self-initialize via a generated constructor; static libraries must call it first (verified against Scala Native interop docs).
- Added the `uni` dependency line (`%%%` + `__UNI_VERSION__`, consistent with ch11) to the library build snippet.

## Verification

- All Scala snippets (including the cross-file service/bridge split) compile-checked against `uniNative` (Scala Native 0.5) via a temporary test file (not committed, per book-examples policy that ch14/15 are verified against reference sources).
- C ABI claims verified against Scala Native interop docs and wvlet's `wvc-lib` Makefile/tests.
- `pnpm docs:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)