### PR TITLE
fix: Check sbt plugin sub-build formatting in the required Code format job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '23'
+          cache: sbt
       - name: scalafmt
         run: ./sbt scalafmtCheckAll
+      # The sbt plugin sub-builds have their own .scalafmt.conf, which the root scalafmtCheckAll
+      # never sees. Their scripted-test jobs also check formatting, but those are not required
+      # status checks, so a scalafmt bump could auto-merge with unformatted plugin code and leave
+      # main red (#654, #655). Check them here, inside the required Code format check.
+      - name: scalafmt (sbt plugin sub-builds)
+        run: |
+          for dir in sbt-uni sbt-uni-playwright sbt-uni-crossproject; do
+            (cd "$dir" && ../sbt scalafmtCheckAll)
+          done
   test_scala_3:
     name: Scala 3
     needs: changes

--- a/sbt-uni-crossproject/src/main/scala/wvlet/uni/sbt/crossproject/CrossProjectMacro.scala
+++ b/sbt-uni-crossproject/src/main/scala/wvlet/uni/sbt/crossproject/CrossProjectMacro.scala
@@ -20,44 +20,21 @@ private[crossproject] object CrossProjectMacro:
       "crossProject must be directly assigned to a val, " +
         "such as `val x = crossProject(JVMPlatform, JSPlatform)`."
     )
-    '{
-      CrossProject(
-        ${
-          name
-        },
-        new java.io.File(
-          ${
-            name
-          }
-        )
-      )(
-        ${
-          platforms
-        }*
-      )
-    }
+    '{ CrossProject(${ name }, new java.io.File(${ name }))(${ platforms }*) }
 
   private def definingValName(errorMsg: String)(using Quotes): Expr[String] =
     import quotes.reflect.*
     val term = enclosingTerm
-    if term.isValDef then
-      Expr(term.name)
-    else
-      report.errorAndAbort(errorMsg)
+    if term.isValDef then Expr(term.name) else report.errorAndAbort(errorMsg)
 
   private def enclosingTerm(using qctx: Quotes): qctx.reflect.Symbol =
     import qctx.reflect.*
     @tailrec
-    def enclosingTerm0(sym: Symbol): Symbol =
-      sym match
-        case sym if sym.flags.is(Flags.Macro) =>
-          enclosingTerm0(sym.owner)
-        case sym if sym.flags.is(Flags.Synthetic) =>
-          enclosingTerm0(sym.owner)
-        case sym if !sym.isTerm =>
-          enclosingTerm0(sym.owner)
-        case _ =>
-          sym
+    def enclosingTerm0(sym: Symbol): Symbol = sym match
+      case sym if sym.flags.is(Flags.Macro)     => enclosingTerm0(sym.owner)
+      case sym if sym.flags.is(Flags.Synthetic) => enclosingTerm0(sym.owner)
+      case sym if !sym.isTerm                   => enclosingTerm0(sym.owner)
+      case _                                    => sym
     enclosingTerm0(Symbol.spliceOwner)
 
 end CrossProjectMacro


### PR DESCRIPTION
## Why

The scalafmt 3.11.4 / sbt-scalafmt 2.6.2 bumps (#654, #655) auto-merged and left main red: the `sbt-uni-crossproject scripted test` job failed because `CrossProjectMacro.scala` was no longer formatted per the new scalafmt version.

Root cause: the plugin sub-builds (`sbt-uni`, `sbt-uni-playwright`, `sbt-uni-crossproject`) have their own `.scalafmt.conf` that the root `./sbt scalafmtCheckAll` never sees. Their formatting is only checked inside the scripted-test jobs, which are **not** required status checks — so a failing format check there can't block auto-merge.

## What

- Run `scalafmtCheckAll` for each plugin sub-build inside the `Code format` job, which **is** a required status check, so format drift in the sub-builds now blocks merge.
- Reformat `CrossProjectMacro.scala` for scalafmt 3.11.4 to turn main green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XinmPeK4Mmcwzvu5ViJoHY