### PR TITLE
docs: Introduce the sbt 2.x plugins in README to make them discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,46 @@
 
 Cross-platform: JVM, Scala.js, and Scala Native.
 
+## sbt 2.x Plugins
+
+Uni also ships sbt plugins for **sbt 2.x**, usable in any sbt 2.x project
+(with or without the uni library):
+
+| Plugin | Description |
+|--------|-------------|
+| [`sbt-uni`](https://wvlet.org/uni/build/sbt-uni) | Type-safe HTTP/RPC client generation from service traits, plus `~uniRestart` — background fork-run on every code change (an sbt 2.x port of sbt-revolver's `reStart`) |
+| [`sbt-uni-crossproject`](https://wvlet.org/uni/build/sbt-uni-crossproject) | `crossProject(...)` for building one source tree for JVM, Scala.js, and Scala Native — a single-plugin replacement for portable-scala's `sbt-crossproject`, which is not available for sbt 2.x |
+| [`sbt-uni-playwright`](https://wvlet.org/uni/build/sbt-uni-playwright) | Run Scala.js tests in a real headless browser (Chromium, Firefox, or WebKit) via Playwright — ES module support and a faithful DOM, with no Node.js installation required |
+
+Add the ones you need to `project/plugins.sbt`:
+
+```scala
+// HTTP/RPC client generation + background fork-run (~uniRestart)
+addSbtPlugin("org.wvlet.uni" % "sbt-uni" % "<version>")
+
+// Cross-build one source tree for JVM, Scala.js, and Scala Native
+addSbtPlugin("org.scala-js"     % "sbt-scalajs"          % "1.22.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native"     % "0.5.12")
+addSbtPlugin("org.wvlet.uni"    % "sbt-uni-crossproject" % "<version>")
+
+// Run Scala.js tests in a real browser
+addSbtPlugin("org.wvlet.uni" % "sbt-uni-playwright" % "<version>")
+```
+
+For example, `sbt-uni-crossproject` defines cross-platform projects with
+shared sources in `src/` and platform-specific code in `.jvm/`, `.js/`,
+and `.native/` folders:
+
+```scala
+lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+  .crossType(CrossType.Pure)
+  .in(file("core"))
+  .settings(/* shared settings */)
+```
+
+See the [build plugin docs](https://wvlet.org/uni/build/sbt-uni) for
+details.
+
 ## Using `uni`
 
 Add the dependency to your `build.sbt` (replace `<version>` with the


### PR DESCRIPTION
## Why

The sbt 2.x plugins (`sbt-uni`, `sbt-uni-crossproject`, `sbt-uni-playwright`) fill real gaps for **any** sbt 2.x project — portable-scala's crossproject and a maintained Playwright JSEnv are not otherwise available on sbt 2.x — but the top-level README never mentioned them, so external users had no way to discover them.

## What

Adds an **sbt 2.x Plugins** section to README.md with:
- a table describing each plugin, linked to its reference docs page
- `project/plugins.sbt` snippets for adding each plugin
- a minimal `crossProject` example showing the Pure layout

All snippets follow the verified usage from `docs/build/*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X28nzmwNHfxNC8c1GnHqBM