### PR TITLE
docs: Fix MCP client registration instructions

### DIFF
--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -127,18 +127,34 @@ Run the emitted script (path printed by sbt) with `node`.
 
 ## 5. Register with an MCP client
 
-For Claude Code, add the server to `.mcp.json` in your project (or register it
-with `claude mcp add`):
+Any MCP client can launch the server; each has its own registration flow.
+
+**Claude Code** — register the command with the `claude mcp add` CLI:
+
+```
+claude mcp add weather -- /path/to/weather-server
+```
+
+To share the server with everyone working on a repository, use the project
+scope (`claude mcp add --scope project ...`), which records it in a `.mcp.json`
+file at the project root:
 
 ```json
 {
   "mcpServers": {
     "weather": {
+      "type": "stdio",
       "command": "/path/to/weather-server"
     }
   }
 }
 ```
+
+**Claude Desktop** — add the same `mcpServers` entry to
+`claude_desktop_config.json` (Settings → Developer → Edit Config).
+
+Other clients (VS Code, Cursor, ...) have equivalent settings; consult their
+documentation for the file location and exact schema.
 
 ## 6. Try it out
 
@@ -179,12 +195,21 @@ NodeServer.withPort(8080).withRxHandler(mcp.httpHandler).start()
 NativeServer.withPort(8080).withRxHandler(mcp.httpHandler).start()
 ```
 
-Register an HTTP server in `.mcp.json` with `"url"` instead of `"command"`:
+Register an HTTP server by its URL instead of a command — in Claude Code:
+
+```
+claude mcp add --transport http weather http://localhost:8080/mcp
+```
+
+or in a project-scope `.mcp.json`:
 
 ```json
 {
   "mcpServers": {
-    "weather": { "url": "http://localhost:8080/mcp" }
+    "weather": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
   }
 }
 ```


### PR DESCRIPTION
The "Register with an MCP client" section (https://wvlet.org/uni/mcp/#_5-register-with-an-mcp-client) read like a generic/VS-Code-style config recipe. Rewritten to:

- Lead with Claude Code's actual flow: `claude mcp add weather -- /path/to/weather-server`, and `claude mcp add --transport http` for HTTP servers
- Label the `.mcp.json` example as **project scope** (created by `--scope project`) and add the `type` field (`stdio` / `http`)
- Mention Claude Desktop's `claude_desktop_config.json` explicitly and defer other clients (VS Code, Cursor) to their own docs

`pnpm docs:build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X28nzmwNHfxNC8c1GnHqBM