### PR TITLE
chore: Enable Dependabot for the electron-app example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,14 +14,16 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "npm"
-    directory: "/docs"
+    directory: "/examples/electron-app"
     schedule:
       interval: "weekly"
     groups:
-      # Grouping Docusaurus module updates into a single PR
-      docusaurus:
+      # Electron desktop app example: major-version updates (electron, vite,
+      # electron-builder, ...) can pull in breaking changes, so keep them as
+      # separate reviewable PRs and only group small transitive fixes.
+      minor-and-patch:
         patterns:
-          - "@docusaurus/*"
-      react:
-        patterns:
-          - "@react/react(-dom)?"
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds a Dependabot npm update job for `examples/electron-app`, so its
dependency updates arrive as PRs instead of accumulating as security
alerts (the previous 14 were all from this example's `pnpm-lock.yaml`).

- `minor`/`patch` bumps are grouped into a single PR via a `minor-and-patch`
  group
- `major` updates (`electron`, `vite`, `electron-builder`, ...) stay as
  separate PRs — they can pull breaking changes into the example

Also removes the stale `/docs` npm entry, which referenced a
`docs/package.json` that no longer exists (docs are built from the root
vitepress project, already covered by the `directory: "/"` npm job).