### PR TITLE
feature: Build the electron-app renderer with Rx HTML

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,11 @@ jobs:
           for dir in sbt-uni sbt-uni-playwright sbt-uni-crossproject; do
             (cd "$dir" && ../sbt scalafmtCheckAll)
           done
+      # The electron-app example is a standalone sbt build too, with its own .scalafmt.conf
+      # symlink; the root scalafmtCheckAll never sees it. Check it here so the required Code
+      # format check covers the example as well.
+      - name: scalafmt (electron-app example)
+        run: (cd examples/electron-app && ../../sbt scalafmtCheckAll)
   test_scala_3:
     name: Scala 3
     needs: changes

--- a/docs/http/electron-tutorial.md
+++ b/docs/http/electron-tutorial.md
@@ -162,32 +162,49 @@ contextBridge.exposeInMainWorld('uniRPC', {
 ## Step 5: the renderer
 
 Call `ElectronRenderer.install()` once at startup; afterward every async client (including generated
-RPC stubs) rides over IPC. Here we build the client directly from the shared trait:
+RPC stubs) rides over IPC. Here we build the client directly from the shared trait and render the
+UI with uni's reactive DOM toolkit (`wvlet.uni.dom`):
 
 ```scala
 // renderer/src/main/scala/example/renderer/RendererApp.scala
 package example.renderer
 
 import example.api.{CounterApi, CounterState}
-import org.scalajs.dom
+import wvlet.uni.dom.all.*
+import wvlet.uni.dom.all.given
 import wvlet.uni.electron.ElectronRenderer
 import wvlet.uni.http.Http
 import wvlet.uni.http.rpc.RPCClient
+import wvlet.uni.rx.{Rx, RxVar}
 import wvlet.uni.surface.Surface
+import scala.language.implicitConversions
 import scala.scalajs.js.annotation.JSExportTopLevel
 
 object RendererApp:
-  private val rpc         = RPCClient.build(Surface.of[CounterApi], Surface.methodsOf[CounterApi])
-  private lazy val client = Http.client.newAsyncClient
-
   @JSExportTopLevel("main")
   def main(): Unit =
     ElectronRenderer.install() // wire window.uniRPC as the HTTP channel factory
-    val display = dom.document.getElementById("counter-value")
-    def show(s: CounterState): Unit = display.textContent = s.value.toString
+    CounterUI().renderTo("app")
 
+class CounterUI extends RxElement:
+  private val rpc         = RPCClient.build(Surface.of[CounterApi], Surface.methodsOf[CounterApi])
+  private lazy val client = Http.client.newAsyncClient
+
+  private val count = Rx.variable(0)
+
+  override def render: RxElement = div(
+    h1("Uni Counter"),
+    p(count.map(_.toString)), // re-renders when count changes
+    button(
+      onclick -> { () => rpc.callAsync[CounterState](client, "increment", Seq(1)).run(show) },
+      "+1"
+    )
+  )
+
+  private def show(s: CounterState): Unit = count := s.value
+
+  override def onMount(node: Any): Unit =
     rpc.callAsync[CounterState](client, "get", Seq.empty).run(show)
-    // wire buttons → rpc.callAsync[CounterState](client, "increment", Seq(1)).run(show), etc.
 ```
 
 The renderer HTML loads the Scala.js module and provides the mount point:
@@ -201,7 +218,7 @@ The renderer HTML loads the Scala.js module and provides the mount point:
     <title>Uni Electron Counter</title>
   </head>
   <body>
-    <p id="counter-value">…</p>
+    <div id="app"></div>
     <script type="module" src="./index.js"></script>
   </body>
 </html>
@@ -215,7 +232,7 @@ main()
 
 ::: tip Styling
 The example styles the renderer with [Tailwind CSS](https://tailwindcss.com/) v4 via
-`@tailwindcss/vite`, pointing `@source` at the Scala sources so Tailwind finds the `className`
+`@tailwindcss/vite`, pointing `@source` at the Scala sources so Tailwind finds the `cls` class
 strings used in `RendererApp.scala`. It's optional — plain CSS works too.
 :::
 

--- a/examples/electron-app/.scalafmt.conf
+++ b/examples/electron-app/.scalafmt.conf
@@ -1,0 +1,1 @@
+../../.scalafmt.conf

--- a/examples/electron-app/README.md
+++ b/examples/electron-app/README.md
@@ -26,7 +26,7 @@ transport (`wvlet.uni.electron`) carries the JSON envelope across the process bo
 | --------------------- | ---------------------------------------------------------------------- |
 | `api/`                | Scala.js: shared RPC service trait + models (`CounterApi`)              |
 | `main/`               | Scala.js: service impl + `ElectronRPCServer.serve(ipcMain, ...)`        |
-| `renderer/`           | Scala.js: UI + RPC client (`ElectronRenderer.install()`)               |
+| `renderer/`           | Scala.js: Rx HTML UI (`wvlet.uni.dom`) + RPC client (`ElectronRenderer.install()`) |
 | `src/main/index.js`   | Electron main entry — creates the window, hands `ipcMain` to Scala      |
 | `src/preload/index.js`| `contextBridge` bridge: `window.uniRPC.request → ipcRenderer.invoke`    |
 | `src/renderer/`       | `index.html` + the JS entry that imports the Scala.js renderer module   |

--- a/examples/electron-app/project/plugins.sbt
+++ b/examples/electron-app/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")

--- a/examples/electron-app/renderer/src/main/scala/example/renderer/RendererApp.scala
+++ b/examples/electron-app/renderer/src/main/scala/example/renderer/RendererApp.scala
@@ -2,13 +2,15 @@ package example.renderer
 
 import example.api.{CounterApi, CounterState}
 import org.scalajs.dom
-import org.scalajs.dom.html
+import wvlet.uni.dom.all.*
+import wvlet.uni.dom.all.given
 import wvlet.uni.electron.ElectronRenderer
 import wvlet.uni.http.Http
 import wvlet.uni.http.rpc.RPCClient
-import wvlet.uni.rx.Rx
+import wvlet.uni.rx.{Rx, RxVar}
 import wvlet.uni.surface.Surface
 
+import scala.language.implicitConversions
 import scala.scalajs.js.annotation.JSExportTopLevel
 
 /**
@@ -17,6 +19,20 @@ import scala.scalajs.js.annotation.JSExportTopLevel
   * whose buttons drive the [[CounterApi]].
   */
 object RendererApp:
+
+  @JSExportTopLevel("main")
+  def main(): Unit =
+    // Point Uni's HTTP client at the Electron IPC bridge exposed by the preload script.
+    ElectronRenderer.install()
+    CounterUI().renderTo("app")
+
+end RendererApp
+
+/**
+  * The counter UI, built with Rx HTML (`wvlet.uni.dom`). The count is held in an [[RxVar]] and
+  * embedded in the markup, so the display re-renders in place whenever an RPC result updates it.
+  */
+class CounterUI extends RxElement:
 
   // A reusable RPC engine for CounterApi. The generated/manual stub below adds typed methods.
   private val rpc: RPCClient = RPCClient.build(
@@ -36,88 +52,56 @@ object RendererApp:
 
   private def reset(): Rx[CounterState] = rpc.callAsync[CounterState](client, "reset", Seq.empty)
 
-  @JSExportTopLevel("main")
-  def main(): Unit =
-    // Point Uni's HTTP client at the Electron IPC bridge exposed by the preload script.
-    ElectronRenderer.install()
-    renderUI()
+  // The counter value shown in the display. Updating it re-renders the number in place.
+  private val count = Rx.variable(0)
 
-  // Small helper to create an element of a known HTML type with Tailwind classes + text.
-  private def el[E <: html.Element](tag: String, classes: String, text: String = ""): E =
-    val e = dom.document.createElement(tag).asInstanceOf[E]
-    e.className = classes
-    if text.nonEmpty then
-      e.textContent = text
-    e
+  // Handle to the display element, used to briefly scale it up on each change.
+  private val displayRef = DomRef[dom.html.Paragraph]()
 
-  private def renderUI(): Unit =
-    val app = dom.document.getElementById("app")
-
-    // Card container
-    val card = el[html.Div](
-      "div",
-      "w-80 rounded-2xl bg-slate-800 p-8 text-center shadow-2xl ring-1 ring-white/10"
-    )
-
-    val title    = el[html.Heading]("h1", "text-xl font-semibold text-slate-100", "Uni Counter")
-    val subtitle = el[html.Paragraph](
-      "p",
-      "mt-1 mb-7 text-xs uppercase tracking-widest text-slate-400",
-      "RPC over Electron IPC"
-    )
-
-    val display = el[html.Paragraph](
-      "p",
-      "mb-8 text-7xl font-bold tabular-nums text-indigo-400 transition-transform",
-      "…"
-    )
-    display.id = "counter-value"
-
-    def button(label: String, classes: String)(onClick: => Unit): html.Button =
-      val b = el[html.Button](
-        "button",
-        s"cursor-pointer rounded-lg px-4 py-2 font-medium text-white shadow transition-colors ${classes}",
+  override def render: RxElement =
+    def actionButton(label: String, colorClasses: String)(action: Rx[CounterState]): RxElement =
+      button(
+        cls ->
+          s"cursor-pointer rounded-lg px-4 py-2 font-medium text-white shadow transition-colors ${colorClasses}",
+        onclick -> { () =>
+          action.run(show)
+        },
         label
       )
-      b.onclick = _ => onClick
-      b
 
-    // Reflect a state snapshot into the UI (with a tiny pop animation).
-    def show(state: CounterState): Unit =
-      display.textContent = state.value.toString
-      display.className =
-        "mb-8 text-7xl font-bold tabular-nums text-indigo-400 transition-transform scale-110"
-      dom
-        .window
-        .setTimeout(
-          () =>
-            display.className =
-              "mb-8 text-7xl font-bold tabular-nums text-indigo-400 transition-transform",
-          120
-        )
-
-    val row = el[html.Div]("div", "flex items-center justify-center gap-3")
-    row.appendChild(
-      button("+1", "bg-indigo-600 hover:bg-indigo-500 active:bg-indigo-700")(increment(1).run(show))
-    )
-    row.appendChild(
-      button("+10", "bg-indigo-700 hover:bg-indigo-600 active:bg-indigo-800")(
-        increment(10).run(show)
+    div(
+      cls -> "w-80 rounded-2xl bg-slate-800 p-8 text-center shadow-2xl ring-1 ring-white/10",
+      h1(cls -> "text-xl font-semibold text-slate-100", "Uni Counter"),
+      p(
+        cls -> "mt-1 mb-7 text-xs uppercase tracking-widest text-slate-400",
+        "RPC over Electron IPC"
+      ),
+      p(
+        ref -> displayRef,
+        cls -> "mb-8 text-7xl font-bold tabular-nums text-indigo-400 transition-transform",
+        count.map(c => c.toString)
+      ),
+      div(
+        cls -> "flex items-center justify-center gap-3",
+        actionButton("+1", "bg-indigo-600 hover:bg-indigo-500 active:bg-indigo-700")(increment(1)),
+        actionButton("+10", "bg-indigo-700 hover:bg-indigo-600 active:bg-indigo-800")(
+          increment(10)
+        ),
+        actionButton("Reset", "bg-slate-600 hover:bg-slate-500 active:bg-slate-700")(reset())
       )
     )
-    row.appendChild(
-      button("Reset", "bg-slate-600 hover:bg-slate-500 active:bg-slate-700")(reset().run(show))
-    )
 
-    card.appendChild(title)
-    card.appendChild(subtitle)
-    card.appendChild(display)
-    card.appendChild(row)
-    app.appendChild(card)
+  end render
 
-    // Load the initial value from the main process.
-    get().run(show)
+  // Reflect a state snapshot into the reactive count (with a tiny pop animation).
+  private def show(state: CounterState): Unit =
+    count := state.value
+    displayRef.foreach { display =>
+      display.classList.add("scale-110")
+      dom.window.setTimeout(() => display.classList.remove("scale-110"), 120)
+    }
 
-  end renderUI
+  // Load the initial value from the main process once the UI is mounted.
+  override def onMount(node: Any): Unit = get().run(show)
 
-end RendererApp
+end CounterUI

--- a/plans/2026-08-12-electron-app-rx-html.md
+++ b/plans/2026-08-12-electron-app-rx-html.md
@@ -1,0 +1,84 @@
+# Update electron-app example to use Rx HTML (wvlet.uni.dom)
+
+Date: 2026-08-12
+
+## Goal
+
+The `examples/electron-app` renderer currently builds its UI with hand-written
+`org.scalajs.dom` calls: a `el(tag, classes, text)` helper, manual
+`createElement`/`appendChild`, direct `textContent`/`className` mutation, and a
+`setTimeout`-driven pop animation. Update it to use uni's reactive DOM toolkit,
+`wvlet.uni.dom` (Rx HTML), so the example showcases the recommended way to build
+Scala.js UIs.
+
+## Current state
+
+`renderer/src/main/scala/example/renderer/RendererApp.scala`:
+- imports `org.scalajs.dom`, `org.scalajs.dom.html`
+- `el[E <: html.Element](tag, classes, text)` creates elements imperatively
+- `renderUI()` builds card / title / subtitle / display / buttons with
+  `createElement`, `appendChild`, `className =`, `textContent =`
+- `show(state)` mutates `display.textContent` + toggles `scale-110` via
+  `window.setTimeout`
+- `get().run(show)` loads the initial value
+
+## Proposed design
+
+Rewrite `RendererApp.scala` to declare the UI with Rx HTML and let reactivity
+drive the display:
+
+- `import wvlet.uni.dom.all.*` (+ the `given` conversions, per the docs setup
+  block) instead of raw scalajs-dom.
+- Replace `el(...)` with the DSL: `div(cls -> "...", h1(...), p(...), button(...))`.
+- Replace imperative `display.textContent = ...` with an `RxVar` for the count
+  embedded in the markup:
+  ```scala
+  val count = Rx.variable(0)
+  ...
+  p(cls -> "mb-8 text-7xl ...", count.map(_.toString))
+  ```
+- Buttons use `onclick -> { () => ... }`:
+  ```scala
+  button(cls -> "...", onclick -> { () => increment(1).run(show) }, "+1")
+  ```
+  where `show(s: CounterState)` just does `count := s.value`.
+- Keep the pop animation: `DomRef` to the display element, add/remove
+  `scale-110` with `window.setTimeout` (only remaining imperative bit, and a
+  good showcase of `DomRef`). Alternatively drop the animation for simplicity —
+  decide during implementation.
+- Mount with `CounterUI().renderTo("app")` (returns `RxDomNode`).
+
+Design the renderer as an `RxElement` subclass (`CounterUI extends RxElement`,
+`override def render: RxElement`) so the example demonstrates the recommended
+component shape rather than an ad-hoc builder.
+
+The Electron IPC / RPC plumbing (`ElectronRenderer.install()`, the `rpc` /
+`client` calls) stays unchanged — only the DOM-building half of the renderer
+changes.
+
+## Files to change
+
+- `examples/electron-app/renderer/src/main/scala/example/renderer/RendererApp.scala`
+  — rewrite UI construction with `wvlet.uni.dom`. Rendered as an `RxElement`
+  subclass (`CounterUI`) with the count held in an `RxVar` and embedded in the
+  markup; the pop animation uses a `DomRef` (the only imperative bit).
+- `examples/electron-app/.scalafmt.conf` — symlink to the root config, so the
+  example build is formatted with the same rules.
+- `examples/electron-app/project/plugins.sbt` — add `sbt-scalafmt` 2.6.2 (same
+  version as the root and sbt plugin sub-builds).
+- `.github/workflows/test.yml` — check the example's `scalafmtCheckAll` in the
+  required `code_format` job (it's a standalone sbt build the root check never
+  sees, same rationale as the plugin sub-builds).
+- `examples/electron-app/README.md` — mention Rx HTML in the renderer row.
+- `docs/http/electron-tutorial.md` — update the Step 5 renderer snippet (was raw
+  DOM) and the HTML mount point (`#app` instead of `#counter-value`) to match.
+
+## Verification
+
+- `./sbt projectJS/publishLocal` then `./sbt renderer/compile` with
+  `-Duni.version=<snapshot>`: compiles clean (7 deprecation warnings come from
+  the uni library's internal `EmbeddableNode`/`EmbeddableAttribute` givens —
+  Scala 3.10 forward-compat, not from this example).
+- `./sbt scalafmtCheckAll` in the example passes.
+- `pnpm docs:build` passes.
+- Example is not built by root CI, so full `pnpm`/electron run is out of scope.


### PR DESCRIPTION
## What

Rewrite the `electron-app` example renderer to use uni's reactive DOM toolkit, `wvlet.uni.dom` (Rx HTML), replacing the hand-written `org.scalajs.dom` construction.

## Changes

- **`RendererApp.scala`** — the UI is now an `RxElement` (`CounterUI`). The count is an `RxVar` embedded in the markup (`count.map(_.toString)`), so each RPC result re-renders the number in place. Buttons use `onclick -> { () => ... }`; the pop animation is the only imperative bit, driven by a `DomRef` (`ref -> displayRef`).
- **Example build is now scalafmt-checked** — added `sbt-scalafmt` to `examples/electron-app/project/plugins.sbt`, a symlink to the root `.scalafmt.conf`, and a `scalafmt (electron-app example)` step in the required CI `code_format` job (it's a standalone sbt build the root check never sees, same rationale as the plugin sub-builds).
- **Docs** — `docs/http/electron-tutorial.md` Step 5 renderer snippet updated to Rx HTML and the mount point changed to `#app`; README renderer row mentions `wvlet.uni.dom`.

## Verification

- `sbt renderer/compile` passes against a locally published uni snapshot (7 deprecation warnings come from uni's internal `EmbeddableNode`/`EmbeddableAttribute` givens — Scala 3.10 forward-compat, not this example).
- `sbt scalafmtCheckAll` in the example passes.
- `pnpm docs:build` passes.

Closes nothing; example-only change.